### PR TITLE
workaround missing restart file

### DIFF
--- a/source/src/sfincs_lib.f90
+++ b/source/src/sfincs_lib.f90
@@ -497,11 +497,12 @@ module sfincs_lib
    !
    ! Write restart-file of water levels at last time-step if wanted
    !
-   if (restartfile(1:4) /= 'none') then
-      !
-      call write_restartfile()
-      !
-   endif
+   ! TODO: this code was added, but the restartfile variable and the write_restartfile function are not yet available
+   ! if (restartfile(1:4) /= 'none') then
+   !    !
+   !    call write_restartfile()
+   !    !
+   ! endif
    !
    if (store_tsunami_arrival_time) then
       !


### PR DESCRIPTION
- Restart seems to be missing function `write_restartfile` and variable `restartfile`. I suggest that we disable this part of the code until these parts are included. 