### PR TITLE
21 issue in running spiderwebs with very different reference times than sfincs tref 10s of years

### DIFF
--- a/source/src/sfincs_date.f90
+++ b/source/src/sfincs_date.f90
@@ -202,6 +202,30 @@ CONTAINS
        dtsec = (ijul2 - ijul1)*86400 + sec2 - sec1
        !
    end subroutine
+   ! 
+   subroutine time_difference_in_days(datespw,datesim,dtsec)
+       !
+       integer ijul1, ijul2     
+       integer yyyy1,mm1,dd1,hh1,mn1,ss1,yyyy2,mm2,dd2,hh2,mn2,ss2
+       integer sec1,sec2
+       real dtsec
+       !
+       character*15  :: datespw
+       character*15  :: datesim
+       !
+       read(datespw,'(I4,2I2,1X,3I2)')yyyy1,mm1,dd1,hh1,mn1,ss1
+       read(datesim,'(I4,2I2,1X,3I2)')yyyy2,mm2,dd2,hh2,mn2,ss2
+       !
+       ! Compute Julian days
+       !
+       ijul1 = julian_date (yyyy1,mm1,dd1)
+       ijul2 = julian_date (yyyy2,mm2,dd2)
+       !
+       sec1  = hh1/3600 + mn1*60 + ss1
+       sec2  = hh2/3600 + mn2*60 + ss2
+       dtsec = (ijul2 - ijul1) + (sec2 - sec1) / 86400
+       !
+   end subroutine   
    !
    FUNCTION julian_date (yyyy, mm, dd) RESULT (julian)
        ! converts calendar date to Julian date

--- a/source/src/sfincs_date.f90
+++ b/source/src/sfincs_date.f90
@@ -203,12 +203,12 @@ CONTAINS
        !
    end subroutine
    ! 
-   subroutine time_difference_in_days(datespw,datesim,dtsec)
+   subroutine time_difference_in_days(datespw,datesim,dtdays)
        !
        integer ijul1, ijul2     
        integer yyyy1,mm1,dd1,hh1,mn1,ss1,yyyy2,mm2,dd2,hh2,mn2,ss2
        integer sec1,sec2
-       real dtsec
+       real dtdays
        !
        character*15  :: datespw
        character*15  :: datesim
@@ -223,7 +223,7 @@ CONTAINS
        !
        sec1  = hh1/3600 + mn1*60 + ss1
        sec2  = hh2/3600 + mn2*60 + ss2
-       dtsec = (ijul2 - ijul1) + (sec2 - sec1) / 86400
+       dtdays = (ijul2 - ijul1) + (sec2 - sec1) / 86400
        !
    end subroutine   
    !

--- a/source/src/sfincs_spiderweb.f90
+++ b/source/src/sfincs_spiderweb.f90
@@ -81,21 +81,10 @@ contains
       !
       read(888,'(a)')line
       !
+      ! Compute difference in seconds between spiderweb reference time and simulation start time     
+      !
       call compute_time_in_seconds(line,trefstr,dtsec)
-!      j=index(line,'=')      
-!      j2=index(line,'m')      
-!      keystr = trim(line(1:j-1))
-!      valstr = trim(line(j+1:j2-1))
-!      timstr = trim(line(j2+14:j2+24))
-!      read(valstr,*)time(it)
-!      !
-!      ! Compute difference in seconds between spiderweb reference time and simulation start time
-!      !
-!      read(timstr,'(A,1X,A,1X,A)')cyspw,cmspw,cdspw
-!      datespw = cyspw // cmspw // cdspw // ' 000000'
-!      call time_difference(datespw,trefstr,dtsec)
-!      !
-!      time(it) = time(it)*60 - dtsec*1.0 ! Convert to seconds w.r.t. reference time
+      !
       time(it) = dtsec*1.0 ! Convert to seconds w.r.t. reference time
       !
       ! Xe
@@ -206,23 +195,10 @@ contains
       !
       read(888,'(a)')line
       !
+      ! Compute difference in seconds between spiderweb reference time and simulation start time
+      !
       call compute_time_in_seconds(line,trefstr,dtsec)
       !
-!      write(*,*)line
-!      j=index(line,'=')      
-!      j2=index(line,'m')      
-!      keystr = trim(line(1:j-1))
-!      valstr = trim(line(j+1:j2-1))
-!      timstr = trim(line(j2+14:j2+24))
-!      read(valstr,*)time(it)
-!      !
-!      ! Compute difference in seconds between spiderweb reference time and simulation start time
-!      !
-!      read(timstr,'(A,1X,A,1X,A)')cyspw,cmspw,cdspw
-!      datespw = cyspw // cmspw // cdspw // ' 000000'
-!      call time_difference(datespw,trefstr,dtsec)
-!      !
-!      time(it) = time(it)*60 - dtsec*1.0 ! Convert to seconds w.r.t. reference time
       time(it) = dtsec*1.0
       !
       do n = 1, nrows 
@@ -513,12 +489,12 @@ contains
    !
    read(valstr,*)tim
    !
-   ! Compute difference in seconds between spiderweb reference time and simulation start time
+   ! Compute difference in days between spiderweb reference time and simulation start time
    !
    read(timstr,'(A,1X,A,1X,A)')cyspw,cmspw,cdspw
+   !
    datespw = cyspw // cmspw // cdspw // ' 000000'
-   !call time_difference(datespw,trefstr,dtsec)
-   
+   !   
    call time_difference_in_days(datespw,trefstr,dtdays)   
    !
    if (iopt==1) then
@@ -528,9 +504,10 @@ contains
    endif
    !
    ! Only now convert to seconds w.r.t. reference time
+   ! TL: added this to overcome problem with rounding error when dates are very far (10-100s of years) apart and calculating differences directly in seconds lead to problems. Calculating in days is only done for spws.
    !
    dtsec = dtdays * 24 * 3600
    !
    end subroutine
-   
+   !
 end module        

--- a/source/src/sfincs_spiderweb.f90
+++ b/source/src/sfincs_spiderweb.f90
@@ -486,6 +486,7 @@ contains
    character*15  :: datespw
    character*256 :: timstr
    real          :: tim   
+   real          :: dtdays   
    !
    j=index(line,'=')      
    j2=index(line,'minutes')    
@@ -516,13 +517,19 @@ contains
    !
    read(timstr,'(A,1X,A,1X,A)')cyspw,cmspw,cdspw
    datespw = cyspw // cmspw // cdspw // ' 000000'
-   call time_difference(datespw,trefstr,dtsec)
+   !call time_difference(datespw,trefstr,dtsec)
+   
+   call time_difference_in_days(datespw,trefstr,dtdays)   
    !
    if (iopt==1) then
-      dtsec = tim*60 - dtsec ! Convert to seconds w.r.t. reference time
+      dtdays = tim/60/24 - dtdays ! Convert from minutes to days w.r.t. reference time
    else
-      dtsec = tim*3600 - dtsec ! Convert to seconds w.r.t. reference time
+      dtdays = tim/24 - dtdays ! Convert from hours to days w.r.t. reference time
    endif
+   !
+   ! Only now convert to seconds w.r.t. reference time
+   !
+   dtsec = dtdays * 24 * 3600
    !
    end subroutine
    


### PR DESCRIPTION
Please review my solution to overcome dtsec calculation when reference times of spw and SFINCS' internal tref are very far apart