### PR TITLE
bug fix computing hu in regular mode

### DIFF
--- a/source/src/sfincs_momentum.f90
+++ b/source/src/sfincs_momentum.f90
@@ -338,7 +338,7 @@
                !
             else
                !
-               hu     = max(zsu - zbuv(ip), huthresh)
+               hu     = max(zsu - zbuvmx(ip), huthresh)
                gnavg2 = gn2uv(ip)
                !
             endif


### PR DESCRIPTION
Bug fix computing hu in regular mode (how did this not get caught by the test bank?)
There was a major mismatch between how water levels (max of surrounding points) are computed, and bed levels (mean of surrounding points). Now using max for both. Not sure when/where this was introduced.