### PR TITLE
Removed cumprcpt

### DIFF
--- a/source/sfincs_lib/sfincs_lib.vfproj
+++ b/source/sfincs_lib/sfincs_lib.vfproj
@@ -31,10 +31,8 @@
 		<Filter Name="Source Files" Filter="f90;for;f;fpp;ftn;def;odl;idl">
 			<Filter Name="snapwave">
 				<File RelativePath="..\src\snapwave\interp.F90"/>
-				<File RelativePath="..\src\snapwave\snapwave_boundaries.f90">
-				</File>
-				<File RelativePath="..\src\snapwave\snapwave_data.f90">
-				</File>
+				<File RelativePath="..\src\snapwave\snapwave_boundaries.f90"/>
+				<File RelativePath="..\src\snapwave\snapwave_data.f90"/>
 				<File RelativePath="..\src\snapwave\snapwave_date.f90"/>
 				<File RelativePath="..\src\snapwave\snapwave_domain.f90"/>
 				<File RelativePath="..\src\snapwave\snapwave_infragravity.f90"/>
@@ -46,8 +44,7 @@
 						<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/>
 					</FileConfiguration>
 				</File>
-				<File RelativePath="..\src\snapwave\snapwave_solver.f90">
-				</File>
+				<File RelativePath="..\src\snapwave\snapwave_solver.f90"/>
 				<File RelativePath="..\src\snapwave\snapwave_windsource.f90"/>
 			</Filter>
 			<File RelativePath="..\src\deg2utm.f90"/>
@@ -60,7 +57,8 @@
 					<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/>
 				</FileConfiguration>
 			</File>
-			<File RelativePath="..\src\sfincs_boundaries.f90"/>
+			<File RelativePath="..\src\sfincs_boundaries.f90">
+			</File>
 			<File RelativePath="..\src\sfincs_continuity.f90"/>
 			<File RelativePath="..\src\sfincs_crosssections.f90"/>
 			<File RelativePath="..\src\sfincs_data.f90"/>
@@ -71,8 +69,8 @@
 			<File RelativePath="..\src\sfincs_infiltration.f90"/>
 			<File RelativePath="..\src\sfincs_initial_conditions.F90"/>
 			<File RelativePath="..\src\sfincs_input.f90"/>
-			<File RelativePath="..\src\sfincs_lib.f90">
-			</File>
+			<File RelativePath="..\src\sfincs_lib.f90"/>
+			<File RelativePath="..\src\sfincs_log.f90"/>
 			<File RelativePath="..\src\sfincs_meteo.f90"/>
 			<File RelativePath="..\src\sfincs_momentum.f90"/>
 			<File RelativePath="..\src\sfincs_ncinput.F90">
@@ -93,8 +91,7 @@
 			</File>
 			<File RelativePath="..\src\sfincs_obspoints.f90"/>
 			<File RelativePath="..\src\sfincs_output.f90"/>
-			<File RelativePath="..\src\sfincs_snapwave.f90">
-			</File>
+			<File RelativePath="..\src\sfincs_snapwave.f90"/>
 			<File RelativePath="..\src\sfincs_spiderweb.f90"/>
 			<File RelativePath="..\src\sfincs_structures.f90"/>
 			<File RelativePath="..\src\sfincs_subgrid.F90">

--- a/source/src/quadtree.F90
+++ b/source/src/quadtree.F90
@@ -1,7 +1,8 @@
 #define NF90(nf90call) call handle_err(nf90call,__FILE__,__LINE__)
 module quadtree
    !
-   use netcdf       
+   use sfincs_log
+   use netcdf
    !
    integer*4                                       :: quadtree_nr_points
    integer*1                                       :: quadtree_nr_levels
@@ -113,10 +114,12 @@ contains
       m    = quadtree_m(nm)
       iref = quadtree_level(nm)
       !
-      ! Determine quadtree_nmax and quadtree_mmax (these are needed for binary search of nm indices)
+      ! Determine quadtree_nmax and quadtree_mmax of the lowest level (these are needed for binary search of nm indices)
       !
-      quadtree_nmax = max(quadtree_nmax, int( (1.0*(n - 1) + 0.01) / (2**(iref - 1))) + 2)
-      quadtree_mmax = max(quadtree_mmax, int( (1.0*(m - 1) + 0.01) / (2**(iref - 1))) + 2)
+      ! quadtree_nmax = max(quadtree_nmax, int( (1.0*(n - 1) + 0.01) / (2**(iref - 1))) + 2)
+      ! quadtree_mmax = max(quadtree_mmax, int( (1.0*(m - 1) + 0.01) / (2**(iref - 1))) + 2)
+      quadtree_nmax = max(quadtree_nmax, int( (1.0*(n - 1) + 0.01) / (2**(iref - 1))) + 1)
+      quadtree_mmax = max(quadtree_mmax, int( (1.0*(m - 1) + 0.01) / (2**(iref - 1))) + 1)
       !
       ! Coordinates of cell centres
       ! 
@@ -177,14 +180,22 @@ contains
    !
    ! Some write statements of interpreted quadtree grid to output for user:
    !
-   write(*,*)'Quadtree grid info - nr_levels :', quadtree_nr_levels
-   write(*,*)'Quadtree grid info -        x0 :', quadtree_x0
-   write(*,*)'Quadtree grid info -        y0 :', quadtree_y0
-   write(*,*)'Quadtree grid info -        dx :', quadtree_dx
-   write(*,*)'Quadtree grid info -        dy :', quadtree_dy
-   write(*,*)'Quadtree grid info -      mmax :', quadtree_mmax
-   write(*,*)'Quadtree grid info -      nmax :', quadtree_nmax
-   write(*,*)'Quadtree grid info -  rotation :', quadtree_rotation / pi * 180
+   write(logstr,'(a,i10)')'Quadtree grid info - nr_levels : ', quadtree_nr_levels
+   call write_log(logstr, 0)
+   write(logstr,'(a,f10.2)')'Quadtree grid info -        x0 : ', quadtree_x0
+   call write_log(logstr, 0)
+   write(logstr,'(a,f10.2)')'Quadtree grid info -        y0 : ', quadtree_y0
+   call write_log(logstr, 0)
+   write(logstr,'(a,f10.2)')'Quadtree grid info -        dx : ', quadtree_dx
+   call write_log(logstr, 0)
+   write(logstr,'(a,f10.2)')'Quadtree grid info -        dy : ', quadtree_dy
+   call write_log(logstr, 0)
+   write(logstr,'(a,i10)')'Quadtree grid info -      mmax : ', quadtree_mmax
+   call write_log(logstr, 0)
+   write(logstr,'(a,i10)')'Quadtree grid info -      nmax : ', quadtree_nmax
+   call write_log(logstr, 0)
+   write(logstr,'(a,f10.2)')'Quadtree grid info -  rotation : ', quadtree_rotation / pi * 180
+   call write_log(logstr, 0)
    !
    end subroutine
 
@@ -202,8 +213,9 @@ contains
    !
    ! Read quadtree file (first time, only read number of active points)
    !
-   write(*,*)'Reading QuadTree binary file ...'
-   write(*,*)'Warning : quadtree mesh file has the "old" binary format, the simulation will continue, but we do recommended switching to the new Netcdf quadtree input format!'            !   
+   write(logstr,'(a,a)')'Info    : reading QuadTree binary file ', trim(qtrfile)
+   call write_log(logstr, 0)
+   call write_log('Warning : quadtree mesh file has the "old" binary format, the simulation will continue, but we do recommended switching to the new Netcdf quadtree input format!', 0)
    !
    open(unit = 500, file = trim(qtrfile), form = 'unformatted', access = 'stream')
    read(500)iversion
@@ -284,7 +296,8 @@ contains
    integer*1 :: iversion
    integer   :: np, ip, iepsg
    !
-   write(*,*)'Reading QuadTree netCDF file ...'
+   write(logstr,'(a,a)')'Info    : reading QuadTree netCDF file ', trim(qtrfile)
+   call write_log(logstr, 0)
    !
    NF90(nf90_open(trim(qtrfile), NF90_CLOBBER, net_file_qtr%ncid))
    !          

--- a/source/src/sfincs.f90
+++ b/source/src/sfincs.f90
@@ -1,22 +1,33 @@
 program sfincs
    !
+   use sfincs_data 
    use sfincs_lib
    !
    implicit none
    !
    integer :: ierr
-   character(len=1024) :: config_file
    double precision    :: deltat
    !
-   deltat = -1.0
+   deltat = -999.9
    ierr = 0
    !
    if (ierr == 0) then
-      ierr = sfincs_initialize(config_file)
+      !
+      ! Set BMI flags to false 
+      ! 
+      bmi = .false. 
+      use_qext = .false.
+      ! 
+      ierr = sfincs_initialize()
+      ! 
    endif
    !
    if (ierr == 0) then
+      ! 
+      ! if deltat < 999.0 update until end
+      !
       ierr = sfincs_update(deltat)
+      ! 
    endif
    !
    ! Always finalize, especially in case of error

--- a/source/src/sfincs_continuity.f90
+++ b/source/src/sfincs_continuity.f90
@@ -29,6 +29,7 @@ contains
    endif  
    !
    ! Put non-default store options in a separate subroutine (all but zsmax) to save computation time when not used (both regular and subgrid):
+   !
    if ((store_maximum_velocity .eqv. .true.) .or. (store_maximum_flux .eqv. .true.) .or. (store_twet .eqv. .true.)) then    
       ! 
       call compute_store_variables(dt)       
@@ -75,23 +76,34 @@ contains
    ! First discharges (don't do this parallel, as it's probably not worth it)
    ! Should try to do this in a smart way for openacc
    !
-   if (nsrcdrn>0) then
+   if (nsrcdrn > 0) then
+      ! 
       !$acc serial, present( zs,nmindsrc,qtsrc,zb,cell_area,z_flags_iref ), async(1)
+      ! 
       do isrc = 1, nsrcdrn
+         ! 
          nm = nmindsrc(isrc)
+         ! 
          if (crsgeo) then
+            ! 
             zs(nmindsrc(isrc))   = max(zs(nm) + qtsrc(isrc)*dt / cell_area_m2(nm), zb(nm))
+            ! 
          else
+            ! 
             zs(nmindsrc(isrc))   = max(zs(nm) + qtsrc(isrc)*dt / cell_area(z_flags_iref(nm)), zb(nm))
+            ! 
          endif
+         ! 
       enddo
+      ! 
       !$acc end serial
+      ! 
    endif   
    !
    !$omp parallel &
    !$omp private ( nm,dvol,nmd,nmu,ndm,num,qnmd,qnmu,qndm,qnum,iwm)
    !$omp do schedule ( dynamic, 256 )
-   !$acc kernels present( kcs, zs, zb, netprcp, cumprcpt, prcp, q, zsmax, zsm, maxzsm, &
+   !$acc kernels present( kcs, zs, zb, netprcp, cumprcpt, prcp, q, qext, zsmax, zsm, maxzsm, &
    !$acc                  z_flags_iref, uv_flags_iref, &
    !$acc                  z_index_uv_md, z_index_uv_nd, z_index_uv_mu, z_index_uv_nu, &
    !$acc                  dxm, dxrm, dyrm, dxminv, dxrinv, dyrinv, cell_area_m2, cell_area,  &
@@ -99,20 +111,31 @@ contains
    !$acc loop independent, private( nm )
    do nm = 1, np
       ! 
-      if (kcs(nm)==1) then ! Regular point
+      if (kcs(nm) == 1) then ! Regular point
          !
          if (precip) then
             !
-            cumprcpt(nm) = cumprcpt(nm) + netprcp(nm)*dt
+            cumprcpt(nm) = cumprcpt(nm) + netprcp(nm) * dt
+            !
+         endif
+         !
+         if (use_qext) then
+            !
+            ! Add external source (e.g. from XMI coupling) 
+            ! 
+            cumprcpt(nm) = cumprcpt(nm) + qext(nm) * dt
+            !
+         endif
+         !
+         if (precip .or. use_qext) then
             !
             ! Add rain and/or infiltration only when cumulative effect over last interval exceeds 0.001 m
             ! Otherwise single precision may miss a lot of the rainfall/infiltration
             !
-            if (cumprcpt(nm)>0.001 .or. cumprcpt(nm)<-0.001) then
+            if (cumprcpt(nm) > 0.001 .or. cumprcpt(nm) < -0.001) then
                !
                zs(nm) = zs(nm) + cumprcpt(nm)
                cumprcpt(nm) = 0.0
-               ! zs(nm) = max(zs(nm), zb(nm)) ! don't allow negative water levels due to infiltration
                !
             endif
             !
@@ -137,14 +160,14 @@ contains
       !
       if (wavemaker) then
          !      
-         if (kcs(nm)==4) then
+         if (kcs(nm) == 4) then
             !
             ! Wave maker point (seaward of wave maker)
             ! Here we use the mean flux at the location of the wave maker 
             !
             iwm = z_index_wavemaker(nm)
             !
-            if (wavemaker_nmd(iwm)>0) then
+            if (wavemaker_nmd(iwm) > 0) then
                !
                ! Wave paddle on the left
                !
@@ -156,7 +179,7 @@ contains
                !
             endif   
             !
-            if (wavemaker_nmu(iwm)>0) then
+            if (wavemaker_nmu(iwm) > 0) then
                !
                ! Wave paddle on the right
                !
@@ -168,7 +191,7 @@ contains
                !
             endif   
             !
-            if (wavemaker_ndm(iwm)>0) then
+            if (wavemaker_ndm(iwm) > 0) then
                !
                ! Wave paddle below
                !
@@ -180,7 +203,7 @@ contains
                !
             endif   
             !
-            if (wavemaker_num(iwm)>0) then
+            if (wavemaker_num(iwm) > 0) then
                !
                ! Wave paddle above
                !
@@ -192,7 +215,7 @@ contains
                !
             endif   
             !
-            zs(nm)   = zs(nm) + (((qnmd - qnmu)*dxrinv(z_flags_iref(nm)) + (qndm - qnum)*dyrinv(z_flags_iref(nm))))*dt
+            zs(nm)   = zs(nm) + (((qnmd - qnmu) * dxrinv(z_flags_iref(nm)) + (qndm - qnum) * dyrinv(z_flags_iref(nm)))) * dt
             !
          endif   
          !
@@ -204,7 +227,7 @@ contains
          !
          ! Would double exponential filtering be better?
          !
-         zsm(nm) = factime*zs(nm) + (1.0 - factime)*zsm(nm)
+         zsm(nm) = factime * zs(nm) + (1.0 - factime) * zsm(nm)
          !
          if (store_maximum_waterlevel) then
              !
@@ -269,13 +292,13 @@ contains
    !
    if (wavemaker) then
       !
-      factime = min(dt/wmtfilter, 1.0)
+      factime = min(dt / wmtfilter, 1.0)
       !
    endif   
    !
    !$acc parallel present( kcs, zs, zs0, zb, z_volume, zsmax, zsm, nmindsrc, qtsrc, maxzsm, zsderv, &
    !$acc                   subgrid_z_zmin,  subgrid_z_zmax, subgrid_z_dep, subgrid_z_volmax, &
-   !$acc                   netprcp, cumprcpt, prcp, q, z_flags_iref, uv_flags_iref, &
+   !$acc                   netprcp, cumprcpt, prcp, q, qext, z_flags_iref, uv_flags_iref, &
    !$acc                   z_index_uv_md, z_index_uv_nd, z_index_uv_mu, z_index_uv_nu, &
    !$acc                   dxm, dxrm, dyrm, dxminv, dxrinv, dyrinv, cell_area_m2, cell_area, &
    !$acc                   z_index_wavemaker, wavemaker_uvmean, wavemaker_nmd, wavemaker_nmu, wavemaker_ndm, wavemaker_num, storage_volume), &
@@ -284,12 +307,18 @@ contains
    ! First discharges (don't do this parallel, as it's probably not worth it)
    ! Should try to do this in a smart way for openacc
    !
-   if (nsrcdrn>0) then
+   if (nsrcdrn > 0) then
+      ! 
       do isrc = 1, nsrcdrn
-         if (nmindsrc(isrc)>0) then ! should really let this happen
-            z_volume(nmindsrc(isrc)) = max(z_volume(nmindsrc(isrc)) + qtsrc(isrc)*dt, 0.0)         
+         ! 
+         if (nmindsrc(isrc) > 0) then ! Is this even possible?
+            ! 
+            z_volume(nmindsrc(isrc)) = max(z_volume(nmindsrc(isrc)) + qtsrc(isrc) * dt, 0.0)         
+            ! 
          endif   
+         ! 
       enddo
+      ! 
    endif   
    !
    !$omp parallel &
@@ -305,21 +334,39 @@ contains
       if (kcs(nm)==1) then
          !
          if (crsgeo) then
-             a = cell_area_m2(nm)
+            !
+            a = cell_area_m2(nm)
+            !
          else   
-             a = cell_area(z_flags_iref(nm))
+            !
+            a = cell_area(z_flags_iref(nm))
+            !
          endif
          !   
          if (precip) then
             !
-            cumprcpt(nm) = cumprcpt(nm) + netprcp(nm)*dt
+            ! Add nett rainfall 
+            ! 
+            cumprcpt(nm) = cumprcpt(nm) + netprcp(nm) * dt
+            !
+         endif
+         !
+         if (use_qext) then
+            !
+            ! Add external source (e.g. from XMI coupling) 
+            ! 
+            cumprcpt(nm) = cumprcpt(nm) + qext(nm) * dt
+            !
+         endif
+         !
+         if (precip .or. use_qext) then
             !
             ! Add rain and/or infiltration only when cumulative effect over last interval exceeds 0.001 m
             ! Otherwise single precision may miss a lot of the rainfall/infiltration
             !
-            if (cumprcpt(nm)>0.001 .or. cumprcpt(nm)<-0.001) then
+            if (cumprcpt(nm) > 0.001 .or. cumprcpt(nm) < -0.001) then
                !
-               dvol = dvol + cumprcpt(nm)*a
+               dvol = dvol + cumprcpt(nm) * a
                cumprcpt(nm) = 0.0
                !
             endif
@@ -333,27 +380,31 @@ contains
          !
          if (crsgeo) then
             !
-            dvol = dvol + ( (q(nmd) - q(nmu))*dyrm(uv_flags_iref(nm)) + (q(ndm) - q(num))*dxm(nm) ) * dt
+            dvol = dvol + ( (q(nmd) - q(nmu)) * dyrm(z_flags_iref(nm)) + (q(ndm) - q(num)) * dxm(nm) ) * dt
             !
          else
             !
             if (use_quadtree) then   
-               dvol = dvol + ( (q(nmd) - q(nmu))*dyrm(uv_flags_iref(nm)) + (q(ndm) - q(num))*dxrm(uv_flags_iref(nm)) ) * dt
+               ! 
+               dvol = dvol + ( (q(nmd) - q(nmu)) * dyrm(z_flags_iref(nm)) + (q(ndm) - q(num)) * dxrm(z_flags_iref(nm)) ) * dt
+               ! 
             else
-               dvol = dvol + ( (q(nmd) - q(nmu))*dy + (q(ndm) - q(num))*dx ) * dt
+               ! 
+               dvol = dvol + ( (q(nmd) - q(nmu)) * dy + (q(ndm) - q(num)) * dx ) * dt
+               ! 
             endif   
             !
          endif   
       endif ! kcs==1    
       !
-      if (wavemaker .and. kcs(nm)==4) then
+      if (wavemaker .and. kcs(nm) == 4) then
          !
          ! Wave maker point (seaward of wave maker)
          ! Here we use the mean flux at the location of the wave maker 
          !
          iwm = z_index_wavemaker(nm)
          !
-         if (wavemaker_nmd(iwm)>0) then
+         if (wavemaker_nmd(iwm) > 0) then
             !
             ! Wave paddle on the left
             !
@@ -365,7 +416,7 @@ contains
             !
          endif   
          !
-         if (wavemaker_nmu(iwm)>0) then
+         if (wavemaker_nmu(iwm) > 0) then
             !
             ! Wave paddle on the right
             !
@@ -377,7 +428,7 @@ contains
             !
          endif   
          !
-         if (wavemaker_ndm(iwm)>0) then
+         if (wavemaker_ndm(iwm) > 0) then
             !
             ! Wave paddle below
             !
@@ -389,7 +440,7 @@ contains
             !
          endif   
          !
-         if (wavemaker_num(iwm)>0) then
+         if (wavemaker_num(iwm) > 0) then
             !
             ! Wave paddle above
             !
@@ -401,10 +452,14 @@ contains
             !
          endif   
          !
-         if (use_quadtree) then   
-            dvol = dvol + ( (qnmd - qnmu)*dyrm(uv_flags_iref(nm)) + (qndm - qnum)*dxrm(uv_flags_iref(nm)) ) * dt
+         if (use_quadtree) then
+            ! 
+            dvol = dvol + ( (qnmd - qnmu) * dyrm(z_flags_iref(nm)) + (qndm - qnum) * dxrm(z_flags_iref(nm)) ) * dt
+            ! 
          else
-            dvol = dvol + ( (qnmd - qnmu)*dy + (qndm - qnum)*dx ) * dt
+            ! 
+            dvol = dvol + ( (qnmd - qnmu) * dy + (qndm - qnum) * dx ) * dt
+            !
          endif   
          !
       endif
@@ -428,7 +483,7 @@ contains
                !
                ! Update storage volume (it cannot become negative)) 
                ! 
-               storage_volume(nm) =  max(dv, 0.0)
+               storage_volume(nm) = max(dv, 0.0)
                !
                if (dv < 0.0) then
                   !
@@ -464,13 +519,13 @@ contains
          ! 
          ! Obtain new water level from subgrid tables 
          !
-         if (z_volume(nm)>=subgrid_z_volmax(nm) * 0.999) then
+         if (z_volume(nm) >= subgrid_z_volmax(nm) * 0.999) then
             !
             ! Entire cell is wet, no interpolation needed
             !
-            zs(nm) = max(subgrid_z_zmax(nm), -20.0) + (z_volume(nm) - subgrid_z_volmax(nm))/a
+            zs(nm) = max(subgrid_z_zmax(nm), -20.0) + (z_volume(nm) - subgrid_z_volmax(nm)) / a
             !
-         elseif (z_volume(nm)<=1.0e-6) then
+         elseif (z_volume(nm) <= 1.0e-6) then
             !
             ! No water in this cell. Set zs to z_zmin.
             !
@@ -483,16 +538,13 @@ contains
             dzvol    = subgrid_z_volmax(nm) / (subgrid_nlevels - 1)
             iuv      = int(z_volume(nm) / dzvol) + 1
             facint   = (z_volume(nm) - (iuv - 1) * dzvol ) / dzvol
-            ! if (iuv<1 .or. iuv>subgrid_nlevels-1) then
-            !  write(*,'(a,6i12,20e16.6)')'nm,iuv,nmd,nmu,ndm,num,z_volume(nm),dzvol,dvol,q(nmd),q(nmu),q(ndm),q(num)',nm,iuv,nmd,nmu,ndm,num,z_volume(nm),dzvol,dvol,q(nmd),q(nmu),q(ndm),q(num)
-            !endif
             zs(nm)   = subgrid_z_dep(iuv, nm) + (subgrid_z_dep(iuv + 1, nm) - subgrid_z_dep(iuv, nm)) * facint
             !
          endif
          !
          if (wiggle_suppression) then 
             ! 
-            zsderv(nm) = zs(nm) - 2*zs11 + zs00
+            zsderv(nm) = zs(nm) - 2 * zs11 + zs00
             ! 
          endif
          !
@@ -504,7 +556,7 @@ contains
          !
          ! Would double exponential filtering be better?
          !
-         zsm(nm) = factime*zs(nm) + (1.0 - factime)*zsm(nm)
+         zsm(nm) = factime * zs(nm) + (1.0 - factime) * zsm(nm)
          !
          if (store_maximum_waterlevel) then
              !
@@ -566,7 +618,7 @@ contains
       qz = 0.0
       uvz = 0.0    
       !
-      if (kcs(nm)==1 .or. kcs(nm)==4) then ! TL: kcs(nm)==4 also correct for regular?
+      if (kcs(nm) == 1 .or. kcs(nm) == 4) then ! TL: kcs(nm)==4 also correct for regular?
          !      
          ! Regular point with four surrounding cells of the same size
          !
@@ -613,7 +665,9 @@ contains
             else
               !
               if ( (zs(nm) - zb(nm)) > twet_threshold) then
+                 !
                  twet(nm) = twet(nm) + dt
+                 !
               endif
               !
             endif               

--- a/source/src/sfincs_crosssections.f90
+++ b/source/src/sfincs_crosssections.f90
@@ -34,7 +34,7 @@ contains
    !
    if (crsfile(1:4) /= 'none') then
       ! 
-      write(*,*)'Reading cross sections ...'
+      call write_log('Info    : reading cross sections', 0)
       !
       ! First count number of polylines
       !
@@ -154,7 +154,7 @@ contains
             ! V
             !
             if (crsgeo) then
-               dxycrs = dxm(indx) 
+               dxycrs = 1.0 / dxminv(indx) 
             else
                dxycrs = dxrm(iref) 
             endif   

--- a/source/src/sfincs_data.f90
+++ b/source/src/sfincs_data.f90
@@ -11,6 +11,11 @@ module sfincs_data
       integer :: error
       character*256 :: error_message
       !!!
+      !!! BMI
+      !!!
+      logical       :: bmi
+      logical       :: use_qext
+      !!!
       !!! Constants
       !!!
       real*4 g                                   ! gravitational constant g
@@ -232,6 +237,7 @@ module sfincs_data
       logical       :: advection_mask
       logical       :: wiggle_suppression
       logical       :: wmrandom      
+      logical       :: store_dynamic_bed_level
       !!!
       !!! sfincs_input.f90 switches
       integer storevelmax
@@ -264,8 +270,8 @@ module sfincs_data
       ! Indices
       !
       integer*4,          dimension(:),   allocatable :: nmindbnd
-      integer*4,          dimension(:),   allocatable :: z_index_z_n
-      integer*4,          dimension(:),   allocatable :: z_index_z_m
+      integer*4,          dimension(:),   allocatable, target :: z_index_z_n
+      integer*4,          dimension(:),   allocatable, target :: z_index_z_m
       integer*4,          dimension(:),   allocatable :: z_index_uv_md1
       integer*4,          dimension(:),   allocatable :: z_index_uv_md2
       integer*4,          dimension(:),   allocatable :: z_index_uv_mu1
@@ -336,14 +342,14 @@ module sfincs_data
       !
       ! Z-points
       !
-      real*4,             dimension(:),   allocatable :: z_xz
-      real*4,             dimension(:),   allocatable :: z_yz
+      real*4,             dimension(:),   allocatable, target :: z_xz
+      real*4,             dimension(:),   allocatable, target :: z_yz
       real*4,             dimension(:),   allocatable :: cell_area_m2
       real*4,             dimension(:),   allocatable :: nuvisc      
       !
       ! UV-points
       !
-      real*4, dimension(:),   allocatable :: zb
+      real*4, dimension(:),   allocatable, target :: zb
       real*4, dimension(:),   allocatable :: zbuv
       real*4, dimension(:),   allocatable :: zbuvmx
       real*4, dimension(:),   allocatable :: gn2uv
@@ -476,7 +482,7 @@ module sfincs_data
       !
       integer                             :: subgrid_nlevels
       !
-      real*4, dimension(:),   allocatable :: subgrid_z_zmin
+      real*4, dimension(:),   allocatable, target :: subgrid_z_zmin
       real*4, dimension(:),   allocatable :: subgrid_z_zmax
       real*4, dimension(:),   allocatable :: subgrid_z_volmax
       real*4, dimension(:,:), allocatable :: subgrid_z_dep
@@ -500,7 +506,7 @@ module sfincs_data
       real*4, dimension(:),   allocatable :: zsmax
       real*4, dimension(:),   allocatable :: vmax
       real*4, dimension(:),   allocatable :: qmax
-      real*8, dimension(:),   allocatable :: zs
+      real*8, dimension(:),   allocatable, target :: zs
       real*4, dimension(:),   allocatable :: zsm
       real*4, dimension(:),   allocatable :: maxzsm      
       real*4, dimension(:),   allocatable :: q
@@ -512,6 +518,7 @@ module sfincs_data
       real*4, dimension(:),   allocatable :: tsunami_arrival_time
       real*4, dimension(:),   allocatable :: zs0
       real*4, dimension(:),   allocatable :: zsderv
+      real*4, dimension(:),   allocatable, target :: qext
       !
       real*4, dimension(:),   allocatable :: tauwu
       real*4, dimension(:),   allocatable :: tauwv
@@ -917,6 +924,7 @@ module sfincs_data
     if(allocated(uv)) deallocate(uv)
     if(allocated(uv0)) deallocate(uv0)
     if(allocated(twet)) deallocate(twet)
+    if(allocated(qext)) deallocate(qext)
     !
 !    if(allocated(huu)) deallocate(huu)
 !    if(allocated(hvv)) deallocate(hvv)

--- a/source/src/sfincs_data.f90
+++ b/source/src/sfincs_data.f90
@@ -239,7 +239,7 @@ module sfincs_data
       logical       :: output_irregular_grid
       logical       :: use_spw_precip
       logical       :: friction2d
-      logical       :: advection_limiter
+      ! logical       :: advection_limiter
       logical       :: advection_mask
       logical       :: wiggle_suppression
       logical       :: wmrandom      

--- a/source/src/sfincs_data.f90
+++ b/source/src/sfincs_data.f90
@@ -92,6 +92,12 @@ module sfincs_data
       real*4 btrelax
       real*4 wiggle_factor
       real*4 wiggle_threshold
+      real*4 uvlim
+      real*4 uvmax
+      !real*4 normbnd
+      !real*4 dzdsbnd
+      !real*4 manningbnd
+      real*4 nuviscfac ! Factor on viscosity for 'difficult' points. Used in sfincs_momentum.f90.
       !
       real*4 freqminig
       real*4 freqmaxig

--- a/source/src/sfincs_data.f90
+++ b/source/src/sfincs_data.f90
@@ -238,7 +238,6 @@ module sfincs_data
       logical       :: output_irregular_grid
       logical       :: use_spw_precip
       logical       :: friction2d
-      ! logical       :: advection_limiter
       logical       :: advection_mask
       logical       :: wiggle_suppression
       logical       :: wmrandom      
@@ -518,7 +517,7 @@ module sfincs_data
       real*4, dimension(:),   allocatable :: q0
       real*4, dimension(:),   allocatable :: uv
       real*4, dimension(:),   allocatable :: uv0
-      real*4, dimension(:),   allocatable :: z_volume
+      real*8, dimension(:),   allocatable :: z_volume
       real*4, dimension(:),   allocatable :: twet
       real*4, dimension(:),   allocatable :: tsunami_arrival_time
       real*4, dimension(:),   allocatable :: zs0
@@ -531,7 +530,6 @@ module sfincs_data
       real*4, dimension(:),   allocatable :: prcp
       real*4, dimension(:),   allocatable :: cumprcp
       real*4, dimension(:),   allocatable :: netprcp
-      real*4, dimension(:),   allocatable :: cumprcpt
       real*4, dimension(:),   allocatable :: cuminf
       real*4, dimension(:),   allocatable :: tauwu0
       real*4, dimension(:),   allocatable :: tauwu1
@@ -842,7 +840,7 @@ module sfincs_data
    !
    implicit none
    !
-    ! memory cleanup
+   ! memory cleanup
 !    if(allocated(indices)) deallocate(indices)
     if(allocated(nmindbnd)) deallocate(nmindbnd)
 !    if(allocated(index_v_m)) deallocate(index_v_m)
@@ -941,7 +939,6 @@ module sfincs_data
     if(allocated(patm)) deallocate(patm)
     if(allocated(prcp)) deallocate(prcp)
     if(allocated(cumprcp)) deallocate(cumprcp)
-    if(allocated(cumprcpt)) deallocate(cumprcpt)
     if(allocated(tauwu0)) deallocate(tauwu0)
     if(allocated(tauwu1)) deallocate(tauwu1)
     if(allocated(tauwv0)) deallocate(tauwv0)

--- a/source/src/sfincs_data.f90
+++ b/source/src/sfincs_data.f90
@@ -217,7 +217,6 @@ module sfincs_data
       logical       :: debug
       logical       :: radstr
       logical       :: crsgeo
-      logical       :: use_coriolis
       logical       :: ampr_block
       logical       :: global
       logical       :: store_tsunami_arrival_time

--- a/source/src/sfincs_discharges.f90
+++ b/source/src/sfincs_discharges.f90
@@ -27,7 +27,8 @@ contains
    !
    if (srcfile(1:4) /= 'none') then
       !
-      write(*,*)'Reading discharges ...'
+      write(logstr,'(a)')'Info    : reading discharges'
+      call write_log(logstr, 0)
       !
       open(500, file=trim(srcfile))
       do while(.true.)
@@ -45,7 +46,8 @@ contains
    !
    if (drnfile(1:4) /= 'none') then
       !
-      write(*,*)'Reading drainage file ...'
+      write(logstr,'(a)')'Info    : reading drainage file'
+      call write_log(logstr, 0)
       !
       open(501, file=trim(drnfile))
       do while(.true.)
@@ -151,7 +153,8 @@ contains
    !
    if (ndrn>0) then
       !
-      write(*,'(a,a,a,i0,a)')' Reading ',trim(drnfile),' (', ndrn, ' drainage points found) ...'
+      write(logstr,'(a,a,a,i0,a)')' Reading ',trim(drnfile),' (', ndrn, ' drainage points found) ...'
+      call write_log(logstr, 0)
       !         
       allocate(xsrc(ndrn))
       allocate(ysrc(ndrn))
@@ -258,8 +261,10 @@ contains
       ! Check if all sink/source points have found an index
       if (any(nmindsrc == 0)) then
          !
-        write(*,*)'WARNING: for some sink/source drainage points no matching active grid cell was found!'
-        write(*,*)'These points will be skipped, please check your input!'
+         write(logstr,'(a)')'Warning ! For some sink/source drainage points no matching active grid cell was found!'
+         call write_log(logstr, 0)
+         write(logstr,'(a)')'Warning ! These points will be skipped, please check your input!'
+         call write_log(logstr, 0)
          !
       endif      
       !

--- a/source/src/sfincs_domain.f90
+++ b/source/src/sfincs_domain.f90
@@ -1371,7 +1371,7 @@ contains
       !
       ! Spatially varying Coriolis
       !
-      if (use_coriolis) then
+      if (coriolis) then
          do nm = 1, np            
             fcorio2d(nm) = 2 * 7.2921e-05 * sin(z_yz(nm) * pi / 180)
          enddo

--- a/source/src/sfincs_domain.f90
+++ b/source/src/sfincs_domain.f90
@@ -2546,15 +2546,6 @@ contains
       !
    endif    
    !
-   if (precip .or. use_qext) then
-      !
-      ! cumprcpt array for cumulative total influx 
-      ! 
-      allocate(cumprcpt(np))      
-      cumprcpt = 0.0
-      ! 
-   endif    
-   !
    if (subgrid) then
       !
       ! Compute initial volumes

--- a/source/src/sfincs_domain.f90
+++ b/source/src/sfincs_domain.f90
@@ -1,5 +1,7 @@
 module sfincs_domain
 
+   use sfincs_log
+
 contains
 
    subroutine initialize_domain()
@@ -25,7 +27,7 @@ contains
    !
    call initialize_hydro()
    !
-   if (quadtree_nr_levels==1 .and. .not. use_quadtree_output) then
+   if (quadtree_nr_levels == 1 .and. .not. use_quadtree_output) then
       !
       ! Only one refinement level found in quadtree file. 
       ! Reverting to use_quadtree is false (default), with use_quadtree_output = false (default).
@@ -49,11 +51,16 @@ contains
    ! Set some flags
    !
    use_quadtree = .false.
+   !
    if (qtrfile(1:4) /= 'none') then
+      !
       use_quadtree = .true.
-      write(*,*)'Info : Preparing SFINCS grid on quadtree mesh ...'   
+      call write_log('Info    : using quadtree mesh', 0)
+      !
    else
-      write(*,*)'Info : Preparing SFINCS grid on regular mesh ...'      
+      !
+      call write_log('Info    : using regular mesh', 0)
+      !
    endif
    !
    ! Always turn off waves at boundaries. Using wave makers for that sort of thing now.
@@ -69,36 +76,37 @@ contains
    if (spwfile(1:4) /= 'none' .or. wndfile(1:4) /= 'none' .or. amufile(1:4) /= 'none' .or. netamuamvfile(1:4) /= 'none' .or. netspwfile(1:4) /= 'none') then
       !
       wind = .true.
-      write(*,*)'Turning on process: Wind'
+      call write_log('Info    : turning on wind', 0)
       !
       if (spw_precip) then
-          precip = .true.
-          write(*,*)'Turning on process: Precipitation from spwfile'
+         precip = .true.
+         call write_log('Info    : turning on precipitation from spwfile', 0)
       endif
+      !
    endif
    !
    if ((ampfile(1:4) /= 'none' .or. netampfile(1:4) /= 'none' .or. spwfile(1:4) /= 'none' .or. netspwfile(1:4) /= 'none') .and. baro==1) then
-       patmos = .true.
-       write(*,*)'Turning on process: Atmospheric pressure'       
+      patmos = .true.
+      call write_log('Info    : turning on atmospheric pressure', 0)
    endif
    !
    if (prcpfile(1:4) /= 'none' .or. amprfile(1:4) /= 'none' .or. netamprfile(1:4) /= 'none' .or. spw_precip) then
        precip = .true.
-       write(*,*)'Turning on process: Precipitation'       
+      call write_log('Info    : turning on precipitation', 0)
    endif
    !
    ! Check for time-spatially varying meteo
    !
    if (prcpfile(1:4) /= 'none' .or. spwfile(1:4) /= 'none' .or. amufile(1:4) /= 'none' .or. amprfile(1:4) /= 'none' .or. ampfile(1:4) /= 'none' .or. netampfile(1:4) /= 'none' .or. netamprfile(1:4) /= 'none' .or. netamuamvfile(1:4) /= 'none' .or. netspwfile(1:4) /= 'none') then
       meteo3d = .true.
-      write(*,*)'Turning on flag: meteo3d'
+      call write_log('Info    : using gridded meteo data', 0)
    endif
    !
    wind_reduction = .false.
    if (spwfile(1:4) /= 'none' .or. netspwfile(1:4) /= 'none') then
       if (z0lfile(1:4) /= 'none') then
          wind_reduction = .true.
-         write(*,*)'Turning on process: wind reduction over land'
+         call write_log('Info    : turning on wind reduction over land', 0)
       endif
    endif            
    !
@@ -170,7 +178,7 @@ contains
          !
          ! Read ASCII input
          !
-         write(*,*)'Reading ASCII input ...'
+         call write_log('Info : reading ASCII input ...', 0)
          !
          allocate(kcsg(nmax,  mmax))       ! KCS
          !
@@ -213,7 +221,8 @@ contains
          !
          ! Read index file (first time, only read number of active points)
          !
-         write(*,*)'Reading index file : ', trim(indexfile), ' ...'
+         write(logstr,'(a,a)')'Info    : reading index file ', trim(indexfile)
+         call write_log(logstr, 0)
          open(unit = 500, file = trim(indexfile), form = 'unformatted', access = 'stream')
          read(500)np
          allocate(indices(np))
@@ -273,7 +282,8 @@ contains
          !
          ! Read mask file (must have same number of cells as quadtree file !)
          !
-         write(*,*)'Reading mask file : ', trim(mskfile), ' ...'
+         write(logstr,'(a,a)')'Info    : reading mask file : ', trim(mskfile)
+         call write_log(logstr, 0)
          !
          open(unit = 500, file = trim(mskfile), form = 'unformatted', access = 'stream')
          read(500)msk
@@ -549,7 +559,8 @@ contains
          !
       enddo 
       ! 
-      write(*,*)'Number of refinement transitions : ', ncuv
+      write(logstr,'(a,i0)')'Info    : number of quadtree refinement transitions : ', ncuv
+      call write_log(logstr, 0)
       !
    endif
    !
@@ -1220,12 +1231,18 @@ contains
    !
    ! Okay, got all the quadtree cells including indices, neighbors flags 
    !
-   write(*,*)'Number of active z points    : ', np
-   write(*,*)'Number of active u/v points  : ', npuv
+   call write_log('------------------------------------------', 1)
+   call write_log('Computational mesh', 1)
+   call write_log('------------------------------------------', 1)
+   write(logstr,'(a,i9)')'Number of active z points      : ', np
+   call write_log(logstr, 1)   
+   write(logstr,'(a,i9)')'Number of active u/v points    : ', npuv
+   call write_log(logstr, 1)
    !
    if (use_quadtree) then
       do iref = 1, nref
-         write(*,'(a,i3,a,i8)')' Number of cells in level ', iref, ' : ', quadtree_last_point_per_level(iref) - quadtree_first_point_per_level(iref) + 1
+         write(logstr,'(a,i3,a,i9)')'Number of cells in level ', iref, '   : ', quadtree_last_point_per_level(iref) - quadtree_first_point_per_level(iref) + 1
+         call write_log(logstr, 1)
       enddo
    endif
    !
@@ -1293,7 +1310,6 @@ contains
       ! dxr and dyr are now in degrees. Must convert to metres.
       ! For dxr, we need a value for every uv point. For dyr, just multiply by 111111.1
       !
-      allocate(dxm(npuv)) 
       allocate(dxminv(npuv))   
       allocate(dxm2inv(npuv))
       !
@@ -1303,7 +1319,7 @@ contains
       allocate(dyrinvc(nref))
       !      
       allocate(cell_area_m2(np))
-      !
+      allocate(dxm(np)) 
       allocate(fcorio2d(np))
       !
       dyrinvc = 0.0
@@ -1315,8 +1331,7 @@ contains
          iref = uv_flags_iref(ip)
          nm   = uv_index_z_nm(ip)
          !
-         dxm(ip)     = dxr(iref)*111111.1*cos(z_yz(nm)*pi/180)
-         dxminv(ip)  = 1.0/dxm(ip)
+         dxminv(ip)  = 1.0 / ( dxr(iref) * 111111.1 * cos(z_yz(nm) * pi / 180) )
          dxm2inv(ip) = dxminv(ip)**2
          !
          ! Minimum grid spacing to determine dtmax 
@@ -1349,7 +1364,8 @@ contains
          !
          iref = z_flags_iref(nm)
          !
-         cell_area_m2(nm) = dxr(iref)*111111.1*cos(z_yz(nm)*pi/180)*dyrm(iref) 
+         dxm(nm)          = dxr(iref) * 111111.1 * cos(z_yz(nm) * pi / 180)
+         cell_area_m2(nm) = dxm(nm) * dyrm(iref) 
          !         
       enddo   
       !
@@ -1357,7 +1373,7 @@ contains
       !
       if (use_coriolis) then
          do nm = 1, np            
-            fcorio2d(nm) = 2*7.2921e-05*sin(z_yz(nm)*pi/180)
+            fcorio2d(nm) = 2 * 7.2921e-05 * sin(z_yz(nm) * pi / 180)
          enddo
       endif   
       !
@@ -1408,8 +1424,24 @@ contains
       !
       ! Determine minimum and maximum time step
       !
-      dtmax = min(dtmax, alfa * dxymin / (sqrt(9.81 * hmin_cfl)))      
-      dtmin = alfa*dxymin/(sqrt(9.81*stopdepth)) ! If dt falls below this value, the simulation will stop
+      ! dtmax will ensure that time step does not become too large because all cells are dry
+      !
+      dtmax = min(dtmax, alfa * dxymin / (sqrt(9.81 * hmin_cfl)))
+      !
+      ! Compute dtmin (if dt falls below this value, the simulation will stop).
+      !
+      ! No longer use long wave celerity
+      !
+      ! dtmin = alfa * dxymin / (sqrt(9.81 * stopdepth))
+      !
+      ! Current velocity
+      !
+      ! dtmin = min(dtmin, alfa * dxymin / (1.25 * abs(uvmax)))
+      !
+      ! Would be better to stop the simulation if water level change exceeds a certain value
+      ! But use uvmax for now (which is typically set to a very high value)
+      !       
+      dtmin = alfa * dxymin / (1.25 * abs(uvmax))
       !
    endif   
    !
@@ -1447,9 +1479,11 @@ contains
         endif
         !
         if (use_quadtree) then
-            write(*,*)'Viscosity - nuvisc  = [', minval(nuvisc),'- ',maxval(nuvisc),']'           
+            write(logstr,'(a,e10.3,a,e10.3,a)')'Info    : viscosity - nuvisc  = [', minval(nuvisc),'- ',maxval(nuvisc),']'           
+            call write_log(logstr, 0)
         else
-            write(*,*)'Viscosity - nuvisc  = ', maxval(nuvisc)           
+            write(logstr,'(a,e10.3)')'Info    : viscosity - nuvisc  = ', maxval(nuvisc)           
+            call write_log(logstr, 0)
         endif            
         !
    endif   
@@ -1490,7 +1524,9 @@ contains
          !
          if (depfile(1:4) /= 'none') then
             !
-            write(*,*)'Reading dep file : ',trim(depfile)
+            write(logstr,'(a,a)')'Info    :reading dep file : ',trim(depfile)
+            call write_log(logstr, 0)
+            !
             open(unit = 500, file = trim(depfile), form = 'unformatted', access = 'stream')
             read(500)zb
             close(500)
@@ -1505,7 +1541,8 @@ contains
          !
       else
          !
-         write(*,*)'Reading dep file : ',trim(depfile)
+         write(logstr,'(a,a)')'Reading dep file : ',trim(depfile)
+         call write_log(logstr, 0)
          !
          if (inputtype=='asc') then
             !
@@ -1580,7 +1617,6 @@ contains
    if (allocated(kcsg)) deallocate(kcsg)
    !
    end subroutine
-
    
    subroutine compute_zbuvmx()
    !
@@ -1600,8 +1636,7 @@ contains
    enddo      
    !
    end subroutine
-   
-   
+
    subroutine initialize_boundaries()
    !
    use sfincs_data
@@ -1803,7 +1838,8 @@ contains
          ! Read spatially-varying friction
          !
          allocate(rghfield(np))
-         write(*,*)'Reading ',trim(manningfile), ' ...'
+         write(logstr,'(a,a)')'Info    : reading roughness file ',trim(manningfile)
+         call write_log(logstr, 0)
          open(unit = 500, file = trim(manningfile), form = 'unformatted', access = 'stream')
          read(500)rghfield
          close(500)
@@ -1881,7 +1917,7 @@ contains
    !   a) store_cumulative_precipitation == .true.
    ! or:  
    !   b) inftype == 'cna' or inftype == 'cnb'
-   !
+   !   
    ! First we determine precipitation type
    !
    if (precip) then
@@ -1931,17 +1967,13 @@ contains
          !
       endif
       !
-      if (precip) then
-         !
-         ! We need cumprcp and cuminf
-         !
-         allocate(cumprcp(np))
-         cumprcp = 0.0
-         !
-         allocate(cuminf(np))
-         cuminf = 0.0
-         ! 
-      endif
+      ! We need cumprcp and cuminf
+      !
+      allocate(cumprcp(np))
+      cumprcp = 0.0
+      !
+      allocate(cuminf(np))
+      cuminf = 0.0
       !
       ! Now allocate and read spatially-varying inputs 
       !
@@ -1956,7 +1988,8 @@ contains
          !
          ! Spatially-uniform constant infiltration (specified as +mm/hr)
          !
-         write(*,*)'Turning on process: Spatially-uniform constant infiltration'        
+         write(logstr,'(a)')'Info    : turning on spatially-uniform constant infiltration'        
+         call write_log(logstr, 0)
          !
          allocate(qinffield(np))
          do nm = 1, np
@@ -1979,11 +2012,13 @@ contains
          !
          ! Spatially-varying constant infiltration
          !
-         write(*,*)'Turning on process: Spatially-varying constant infiltration'      
+         write(logstr,'(a)')'Info    : turning on spatially-varying constant infiltration'      
+         call write_log(logstr, 0)
          !
          ! Read spatially-varying infiltration (only binary, specified in +mm/hr)
          !
-         write(*,*)'Reading ', trim(qinffile), ' ...'
+         write(logstr,'(a,a)')'Info    : reading infiltration file ', trim(qinffile)
+         call write_log(logstr, 0)
          allocate(qinffield(np))
          open(unit = 500, file = trim(qinffile), form = 'unformatted', access = 'stream')
          read(500)qinffield
@@ -1997,12 +2032,14 @@ contains
          !
          ! Spatially-varying infiltration with CN numbers (old)
          !
-         write(*,*)'Turning on process: Infiltration (via Curve Number method - A)'               
+         write(logstr,'(a)')'Info    : turning on infiltration (via Curve Number method - A)'               
+         call write_log(logstr, 0)
          !
          allocate(qinffield(np))
          qinffield = 0.0
          !
-         write(*,*)'Reading ',trim(scsfile)
+         write(logstr,'(a,a)')'Info    : reading scs file ',trim(scsfile)
+         call write_log(logstr, 0)
          open(unit = 500, file = trim(scsfile), form = 'unformatted', access = 'stream')
          read(500)qinffield
          close(500)
@@ -2016,12 +2053,14 @@ contains
          !
          ! Spatially-varying infiltration with CN numbers (new)
          !
-         write(*,*)'Turning on process: Infiltration (via Curve Number method - B)'            
+         write(logstr,'(a)')'Info    : turning on infiltration (via Curve Number method - B)' 
+         call write_log(logstr, 0)
          ! 
          ! Allocate Smax
          allocate(qinffield(np))
          qinffield = 0.0
-         write(*,*)'Reading ',trim(smaxfile)
+         write(logstr,'(a,a)')'Info    : reading smax file ',trim(smaxfile)
+         call write_log(logstr, 0)
          open(unit = 500, file = trim(smaxfile), form = 'unformatted', access = 'stream')
          read(500)qinffield
          close(500)
@@ -2029,7 +2068,8 @@ contains
          ! Allocate Se
          allocate(scs_Se(np))
          scs_Se = 0.0
-         write(*,*)'Reading ',trim(sefffile)
+         write(logstr,'(a,a)')'Info    : reading seff file ',trim(sefffile)
+         call write_log(logstr, 0)
          open(unit = 501, file = trim(sefffile), form = 'unformatted', access = 'stream')
          read(501)scs_Se
          close(501)
@@ -2038,7 +2078,8 @@ contains
          ! Allocate Ks
          allocate(ksfield(np))
          ksfield = 0.0
-         write(*,*)'Reading ',trim(ksfile)
+         write(logstr,'(a,a)')'Info    : reading ks file ',trim(ksfile)
+         call write_log(logstr, 0)
          open(unit = 502, file = trim(ksfile), form = 'unformatted', access = 'stream')
          read(502)ksfield
          close(502)
@@ -2064,12 +2105,13 @@ contains
          !
          ! Spatially-varying infiltration with the Green-Ampt (GA) model
          !
-         write(*,*)'Turning on process: Infiltration (via Green-Ampt)'            
+         call write_log('Info    : turning on process infiltration (via Green-Ampt)', 0)
          ! 
          ! Allocate suction head at the wetting front 
          allocate(GA_head(np))
          GA_head = 0.0
-         write(*,*)'Reading ',trim(psifile)
+         write(logstr,'(a,a)')'Info    : reading psi file ',trim(psifile)
+         call write_log(logstr, 0)
          open(unit = 500, file = trim(psifile), form = 'unformatted', access = 'stream')
          read(500)GA_head
          close(500)
@@ -2077,7 +2119,8 @@ contains
          ! Allocate maximum soil moisture deficit
          allocate(GA_sigma_max(np))
          GA_sigma_max = 0.0
-         write(*,*)'Reading ',trim(sigmafile)
+         write(logstr,'(a,a)')'Info    : reading sigma file ',trim(sigmafile)
+         call write_log(logstr, 0)
          open(unit = 501, file = trim(sigmafile), form = 'unformatted', access = 'stream')
          read(501)GA_sigma_max
          close(501)
@@ -2085,7 +2128,8 @@ contains
          ! Allocate saturated hydraulic conductivity
          allocate(ksfield(np))
          ksfield = 0.0
-         write(*,*)'Reading ',trim(ksfile)
+         write(logstr,'(a,a)')'Info    : reading ks file ',trim(ksfile)
+         call write_log(logstr, 0)
          open(unit = 502, file = trim(ksfile), form = 'unformatted', access = 'stream')
          read(502)ksfield
          close(502)
@@ -2118,13 +2162,14 @@ contains
          !
          ! Spatially-varying infiltration with the modified Horton Equation 
          !
-         write(*,*)'Turning on process: Infiltration (via modified Horton)'            
+         call write_log('Info    : turning on process infiltration (via modified Horton)', 0)
          ! 
          ! Horton: final infiltration capacity (fc)
          ! Note that qinffield = horton_fc
          allocate(horton_fc(np))
          horton_fc = 0.0
-         write(*,*)'Reading ',trim(fcfile)
+         write(logstr,'(a,a)')'Info    : reading fc file ',trim(fcfile)
+         call write_log(logstr, 0)
          open(unit = 500, file = trim(fcfile), form = 'unformatted', access = 'stream')
          read(500)horton_fc
          close(500)
@@ -2132,7 +2177,8 @@ contains
          ! Horton: initial infiltration capacity (f0)
          allocate(horton_f0(np))
          horton_f0 = 0.0
-         write(*,*)'Reading ',trim(f0file)
+         write(logstr,'(a,a)')'Info    : reading f0 file ',trim(f0file)
+         call write_log(logstr, 0)
          open(unit = 501, file = trim(f0file), form = 'unformatted', access = 'stream')
          read(501)horton_f0
          close(501)
@@ -2143,11 +2189,13 @@ contains
          ! Empirical constant (1/hr) k => note that this is different than ks used in Curve Number and Green-Ampt
          allocate(horton_kd(np))
          horton_kd = 0.0
-         write(*,*)'Reading ',trim(kdfile)
+         write(logstr,'(a,a)')'Info    : reading kd file ',trim(kdfile)
+         call write_log(logstr, 0)
          open(unit = 502, file = trim(kdfile), form = 'unformatted', access = 'stream')
          read(502)horton_kd
          close(502)
-         write(*,*)'Using constant recovery rate that is based on constant factor relative to ',trim(kdfile)
+         write(logstr,'(a,a)')'Using constant recovery rate that is based on constant factor relative to ',trim(kdfile)
+         call write_log(logstr, 0)         
          !
          ! Estimate of time
          allocate(rain_T1(np))
@@ -2176,11 +2224,13 @@ contains
       !
       ! Spatially-varying storage volume for green infra
       !
-      write(*,*)'Turning on process: Storage Green Infrastructure'      
+      write(logstr,'(a)')'Info    : turning on Storage Green Infrastructure'      
+      call write_log(logstr, 0)
       !
       ! Read spatially-varying storage per cell (m3)
       !
-      write(*,*)'Reading ', trim(volfile), ' ...'
+      write(logstr,'(a,a)')'Info    : reading vol file ',trim(volfile)
+      call write_log(logstr, 0)
       allocate(storage_volume(np))
       open(unit = 500, file = trim(volfile), form = 'unformatted', access = 'stream')
       read(500)storage_volume
@@ -2426,7 +2476,6 @@ contains
       allocate(tauwv0(np))
       allocate(tauwu1(np))
       allocate(tauwv1(np))
-      !
       tauwu  = 0.0
       tauwv  = 0.0
       tauwu0 = 0.0
@@ -2490,7 +2539,7 @@ contains
    !
    if (use_qext) then
       !
-      ! Allocating and initializing qext (used e.g. for XMI coupling with ground water model)
+      ! Allocating and initializing qext (used e.g. for BMI coupling with ground water model)
       !
       allocate(qext(np))
       qext = 0.0
@@ -2499,7 +2548,7 @@ contains
    !
    if (precip .or. use_qext) then
       !
-      ! temporary cumprcpt array for cumulative total influx (set back to 0.0 in continuity everytime it exceeds 0.001) 
+      ! cumprcpt array for cumulative total influx 
       ! 
       allocate(cumprcpt(np))      
       cumprcpt = 0.0

--- a/source/src/sfincs_domain.f90
+++ b/source/src/sfincs_domain.f90
@@ -1581,6 +1581,27 @@ contains
    !
    end subroutine
 
+   
+   subroutine compute_zbuvmx()
+   !
+   use sfincs_data
+   !
+   integer :: ip
+   integer :: nm
+   integer :: nmu
+   !
+   do ip = 1, npuv
+      !
+      nm  = uv_index_z_nm(ip)
+      nmu = uv_index_z_nmu(ip)
+      !
+      zbuvmx(ip) = max(zb(nm), zb(nmu)) + huthresh
+      !   
+   enddo      
+   !
+   end subroutine
+   
+   
    subroutine initialize_boundaries()
    !
    use sfincs_data
@@ -2405,6 +2426,7 @@ contains
       allocate(tauwv0(np))
       allocate(tauwu1(np))
       allocate(tauwv1(np))
+      !
       tauwu  = 0.0
       tauwv  = 0.0
       tauwu0 = 0.0
@@ -2427,6 +2449,7 @@ contains
          windv0 = 0.0
          windu1 = 0.0
          windv1 = 0.0
+         !
          if (store_wind_max) then
             allocate(windmax(np))
             windmax = 0.0
@@ -2460,12 +2483,28 @@ contains
       prcp0   = 0.0
       prcp1   = 0.0
       !
-      allocate(cumprcpt(np))      
-      cumprcpt = 0.0
       allocate(netprcp(np))      
       netprcp  = 0.0
       !
    endif
+   !
+   if (use_qext) then
+      !
+      ! Allocating and initializing qext (used e.g. for XMI coupling with ground water model)
+      !
+      allocate(qext(np))
+      qext = 0.0
+      !
+   endif    
+   !
+   if (precip .or. use_qext) then
+      !
+      ! temporary cumprcpt array for cumulative total influx (set back to 0.0 in continuity everytime it exceeds 0.001) 
+      ! 
+      allocate(cumprcpt(np))      
+      cumprcpt = 0.0
+      ! 
+   endif    
    !
    if (subgrid) then
       !

--- a/source/src/sfincs_initial_conditions.F90
+++ b/source/src/sfincs_initial_conditions.F90
@@ -2,6 +2,7 @@
 module sfincs_initial_conditions
    !
    use sfincs_data
+   use sfincs_log
    use netcdf       
    !
    type net_type_ini
@@ -45,7 +46,8 @@ contains
          !
          ! Binary restart file
          !
-         write(*,*)'Reading restart file ', trim(rstfile), ' ...'
+         write(logstr,'(a,a)')'Info    : reading restart file ', trim(rstfile)
+         call write_log(logstr, 0)
          !
          call read_binary_restart_file()
          !
@@ -53,7 +55,8 @@ contains
          !
          ! Binary initial water level file
          !
-         write(*,*)'Reading initial conditions file ', trim(zsinifile), ' ...'
+         write(logstr,'(a,a)')'Info    : reading initial conditions file ', trim(zsinifile)
+         call write_log(logstr, 0)
          !
          call read_zsini_file()
          !
@@ -61,7 +64,8 @@ contains
          !
          ! NetCDF file
          !
-         write(*,*)'Reading NetCDF initial conditions file ', trim(zsinifile), ' ...'
+         write(logstr,'(a,a)')'Info    : reading NetCDF initial conditions file ', trim(zsinifile)
+         call write_log(logstr, 0)
          !
          call read_nc_ini_file()
          !
@@ -183,13 +187,15 @@ contains
       read(500)rsttype
       read(500)rdummy
       !
-      write(*,*)'Info: found rsttype = ', rsttype 
+      write(logstr,'(a,i0)')'Info    : found rsttype = ', rsttype
+      call write_log(logstr, 0)
       !
       if (rsttype < 1 .or. rsttype > 6) then
          !
          ! Give warning, rstfile input rsttype not recognized
          !
-         write(*,*)'WARNING! rstfile not recognized, skipping restartfile input! rsttype should be 1-6, but found rsttype = ', rsttype 
+         write(logstr,'(a,i0)')'Warning! rstfile not recognized, skipping restart file input! rsttype should be 1-6, but found rsttype = ', rsttype 
+         call write_log(logstr, 1)
          !          
          close(500)      
          !          
@@ -216,7 +222,7 @@ contains
             !
             read(500)rdummy                 
             read(500)scs_Se
-            write(*,*)'Reading scs_Se from rstfile, overwrites input values of: ',trim(sefffile)
+            ! write(*,*)'Reading scs_Se from rstfile, overwrites input values of: ',trim(sefffile)
             !
          elseif (rsttype==5) then ! Infiltration method gai    
             !
@@ -224,13 +230,15 @@ contains
             read(500)GA_sigma
             read(500)rdummy
             read(500)GA_F
-            write(*,*)'Reading GA_sigma from rstfile, overwrites input values of: ',trim(sigmafile)        
+            write(logstr,'(a,a)')'Info    : reading GA_sigma from rstfile, overwrites input values of ', trim(sigmafile)
+            call write_log(logstr, 0)
             !
          elseif (rsttype==6) then ! Infiltration method horton
             !
             read(500)rdummy                               
             read(500)rain_T1
-            write(*,*)'Reading rain_T1 from rstfile, complements input values of: ',trim(fcfile)        
+            write(logstr,'(a,a)')'Info    : reading rain_T1 from rstfile, complements input values of ', trim(fcfile) 
+            call write_log(logstr, 0)
             !              
          endif          
          !
@@ -248,9 +256,10 @@ contains
       !
       implicit none
       !
-      write(*,*)'Reading ',trim(zsinifile)
+      write(logstr,'(a,a)')'Info    : reading zsini file ', trim(zsinifile)
+      call write_log(logstr, 0)
       !
-      write(*,*)'Warning : binary ini files from SFINCS v2.1.1 and older are not compatible with SFINCS v2.1.2+, remake your inifile containing zs as real*8 double precision'    
+      call write_log('Warning : binary ini files from SFINCS v2.1.1 and older are not compatible with SFINCS v2.1.2+, remake your inifile containing zs as real*8 double precision', 0)  
       !
       open(unit = 500, file = trim(zsinifile), form = 'unformatted', access = 'stream')
       read(500)inizs

--- a/source/src/sfincs_input.f90
+++ b/source/src/sfincs_input.f90
@@ -537,7 +537,7 @@ contains
       endif
    endif
    !
-   advection_limiter = .false.
+   ! advection_limiter = .false.
    !   
    if (advection) then
       !
@@ -558,11 +558,11 @@ contains
          call write_log(logstr, 1)
       endif
       !
-      if (advlim < 9999.0) then
-         !
-         advection_limiter = .true.
-         !
-      endif
+      ! if (advlim < 9999.0) then
+      !    !
+      !    advection_limiter = .true.
+      !    !
+      ! endif
       !
    endif
    !

--- a/source/src/sfincs_lib.f90
+++ b/source/src/sfincs_lib.f90
@@ -316,7 +316,7 @@ module sfincs_lib
    !$acc               tauwu, tauwv, tauwu0, tauwv0, tauwu1, tauwv1, &
    !$acc               windu, windv, windu0, windv0, windu1, windv1, windmax, & 
    !$acc               patm, patm0, patm1, patmb, nmindbnd, &
-   !$acc               prcp, prcp0, prcp1, cumprcp, cumprcpt, netprcp, prcp, qinfmap, cuminf, qext, & 
+   !$acc               prcp, prcp0, prcp1, cumprcp, netprcp, prcp, qinfmap, cuminf, qext, & 
    !$acc               dxminv, dxrinv, dyrinv, dxm2inv, dxr2inv, dyr2inv, dxrinvc, dxm, dxrm, dyrm, cell_area_m2, cell_area, &
    !$acc               gn2uv, fcorio2d, min_dt, storage_volume, nuvisc, &
    !$acc               cuv_index_uv, cuv_index_uv1, cuv_index_uv2 )

--- a/source/src/sfincs_lib.f90
+++ b/source/src/sfincs_lib.f90
@@ -21,6 +21,7 @@ module sfincs_lib
    use sfincs_continuity
    use sfincs_snapwave
    use sfincs_wavemaker
+   use sfincs_log
    !
    implicit none
    !
@@ -80,68 +81,78 @@ module sfincs_lib
    !
    integer :: ierr
    !
+   call open_log()   
+   !
    error = 0 ! Error code. This is now only set to 1 in case of instabilities. Could also use other error codes, e.g. for missing files.
    !
    ierr = 0 ! Always 0 or 1  ! Always 0 or 1 
    !
    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
    !
-   build_revision = '$Rev: v2.1.2-Dollerup'
-   build_date     = '$Date: 2024-12-20'
+   build_revision = '$Rev: v2.1.1-Dollerup - branch with log file added by MvO and quadtree index bug fix'
+   build_date     = '$Date: 2024-10-01'
    !
-   write(*,'(a)')''   
-   write(*,*)'----------- Welcome to SFINCS -----------'   
-   write(*,'(a)')''   
-   write(*,*)' @@@@@  @@@@@@@ @@ @@  @@   @@@@   @@@@@ '
-   write(*,*)'@@@ @@@ @@@@@@@ @@ @@@ @@ @@@@@@@ @@@ @@@'
-   write(*,*)'@@@     @@      @@ @@@ @@ @@   @@ @@@    '
-   write(*,*)' @@@@@  @@@@@@  @@ @@@@@@ @@       @@@@@ '
-   write(*,*)'    @@@ @@      @@ @@ @@@ @@   @@     @@@'
-   write(*,*)'@@@ @@@ @@      @@ @@  @@  @@@@@@ @@@ @@@'
-   write(*,*)' @@@@@  @@      @@ @@   @   @@@@   @@@@@ '   
-   write(*,'(a)')''      
-   write(*,*)'             ..............              ' 
-   write(*,*)'         ......:@@@@@@@@:......          '
-   write(*,*)'      ..::::..@@........@@.:::::..       '
-   write(*,*)'    ..:::::..@@..::..::..@@.::::::..     '
-   write(*,*)'   .::::::..@@............@@.:::::::.    '
-   write(*,*)'  .::::::..@@..............@@.:::::::.   '
-   write(*,*)' .::::::::..@@............@@..::::::::.  '
-   write(*,*)'.:::::::::...@@.@..@@..@.@@..::::::::::. '
-   write(*,*)'.:::::::::...:@@@..@@..@@@:..:::::::::.. '
-   write(*,*)'............@@.@@..@@..@@.@@............ '
-   write(*,*)'^^^~~^^~~^^@@..............@@^^^~^^^~~^^ '
-   write(*,*)'.::::::::::@@..............@@.:::::::::. '
-   write(*,*)' .......:.@@.....@.....@....@@.:.......  '
-   write(*,*)'  .::....@@......@.@@@.@....@@.....::.   '
-   write(*,*)'   .:::~@@.:...:.@@...@@.:.:.@@~::::.    '
-   write(*,*)'    .::~@@@@@@@@@@.....@@@@@@@@@~::.     '
-   write(*,*)'      ..:~~~~~~~:.......:~~~~~~~:..      '
-   write(*,*)'         ......................          '
-   write(*,*)'             ..............              '
-   write(*,'(a)')''
-   write(*,*)'-----------------------------------------'
-   write(*,'(a)')''
-   write(*,*)'Build-Revision: ',trim(build_revision)
-   write(*,*)'Build-Date:     ',trim(build_date)
-   write(*,'(a)')''
+   call write_log('', 1)
+   call write_log('------------ Welcome to SFINCS ------------', 1)
+   call write_log('', 1)
+   call write_log('  @@@@@  @@@@@@@ @@ @@  @@   @@@@   @@@@@ ', 1)
+   call write_log(' @@@ @@@ @@@@@@@ @@ @@@ @@ @@@@@@@ @@@ @@@', 1)
+   call write_log(' @@@     @@      @@ @@@ @@ @@   @@ @@@    ', 1)
+   call write_log('  @@@@@  @@@@@@  @@ @@@@@@ @@       @@@@@ ', 1)
+   call write_log('     @@@ @@      @@ @@ @@@ @@   @@     @@@', 1)
+   call write_log(' @@@ @@@ @@      @@ @@  @@  @@@@@@ @@@ @@@', 1)
+   call write_log('  @@@@@  @@      @@ @@   @   @@@@   @@@@@ ', 1)
+   call write_log('', 1)
+   call write_log('              ..............              ', 1)
+   call write_log('          ......:@@@@@@@@:......          ', 1)
+   call write_log('       ..::::..@@........@@.:::::..       ', 1)
+   call write_log('     ..:::::..@@..::..::..@@.::::::..     ', 1)
+   call write_log('    .::::::..@@............@@.:::::::.    ', 1)
+   call write_log('   .::::::..@@..............@@.:::::::.   ', 1)
+   call write_log('  .::::::::..@@............@@..::::::::.  ', 1)
+   call write_log(' .:::::::::...@@.@..@@..@.@@..::::::::::. ', 1)
+   call write_log(' .:::::::::...:@@@..@@..@@@:..:::::::::.. ', 1)
+   call write_log(' ............@@.@@..@@..@@.@@............ ', 1)
+   call write_log(' ^^^~~^^~~^^@@..............@@^^^~^^^~~^^ ', 1)
+   call write_log(' .::::::::::@@..............@@.:::::::::. ', 1)
+   call write_log('  .......:.@@.....@.....@....@@.:.......  ', 1)
+   call write_log('   .::....@@......@.@@@.@....@@.....::.   ', 1)
+   call write_log('    .:::~@@.:...:.@@...@@.:.:.@@~::::.    ', 1)
+   call write_log('     .::~@@@@@@@@@@.....@@@@@@@@@~::.     ', 1)
+   call write_log('       ..:~~~~~~~:.......:~~~~~~~:..      ', 1)
+   call write_log('          ......................          ', 1)
+   call write_log('              ..............              ', 1)
+   call write_log('', 1)
+   call write_log('------------------------------------------', 1)
+   call write_log('', 1)
+   call write_log('Build-Revision: '//trim(build_revision), 1)
+   call write_log('Build-Date: '//trim(build_date), 1)
+   call write_log('', 1)
    !
    call system_clock(count0, count_rate, count_max)
    !
+   call write_log('------ Preparing model simulation --------', 1)
+   call write_log('', 1)
+   !
+   call write_log('Reading input file ...', 0) 
    call read_sfincs_input()     ! Reads sfincs.inp
    !
+   call write_log('Reading meteo data ...', 0) 
    call read_meteo_data()       ! Reads meteo data (amu, amv, spw file etc.)
    !
+   call write_log('Preparing domain ...', 0) 
    call initialize_domain()     ! Reads dep, msk, index files, creates index, flag and depth arrays, initializes hydro quantities
    !
    call read_structures()       ! Reads thd files and sets kcuv to zero where necessary
    !
+   call write_log('Reading boundary data ...', 0) 
    call read_boundary_data()    ! Reads bnd, bzs, etc files
    !
    ! call read_coastline()        ! Reads cst file. Do we still do this ?
    !
    call find_boundary_indices()
    !
+   call write_log('Reading observation points ...', 0) 
    call read_obs_points()       ! Reads obs file
    !
    call read_crs_file()         ! Reads cross sections
@@ -150,8 +161,7 @@ module sfincs_lib
    !
    if (snapwave) then
       !
-      write(*,*)'Coupling with SnapWave ...'
-      !
+      call write_log('Coupling with SnapWave ...', 1)
       call couple_snapwave(crsgeo)
       !
    endif   
@@ -202,8 +212,7 @@ module sfincs_lib
    tloopsnapwave  = 0.0
    tloopwavemaker = 0.0
    !
-   write(*,'(a)')''   
-   write(*,*)'Initializing output ...'
+   call write_log('Initializing output ...', 0)
    !
    call initialize_output(tmapout, tmaxout, thisout, trstout)
    !
@@ -215,6 +224,67 @@ module sfincs_lib
    !
    ierr = error
    !
+   call write_log('------------------------------------------', 1)
+   call write_log('Processes', 1)
+   call write_log('------------------------------------------', 1)
+   if (subgrid) then
+      call write_log('Subgrid topography   : yes', 1)
+   else   
+      call write_log('Subgrid topography   : no', 1)
+   endif
+   if (use_quadtree) then
+      call write_log('Quadtree refinement  : yes', 1)
+   else   
+      call write_log('Quadtree refinement  : no', 1)
+   endif
+   if (advection) then 
+      call write_log('Advection            : yes', 1)
+   else   
+      call write_log('Advection            : no', 1)
+   endif
+   if (viscosity) then
+      call write_log('Viscosity            : yes', 1)
+   else   
+      call write_log('Viscosity            : no', 1)
+   endif
+   if (coriolis) then
+      call write_log('Coriolis             : yes', 1)
+   else   
+      call write_log('Coriolis             : no', 1)
+   endif
+   if (wind) then
+      call write_log('Wind                 : yes', 1)
+   else   
+      call write_log('Wind                 : no', 1)
+   endif
+   if (patmos) then
+      call write_log('Atmospheric pressure : yes', 1)
+   else   
+      call write_log('Atmospheric pressure : no', 1)
+   endif
+   if (precip) then
+      call write_log('Precipitation        : yes', 1)
+   else   
+      call write_log('Precipitation        : no', 1)
+   endif
+   if (snapwave) then
+      call write_log('SnapWave             : yes', 1)
+   else
+      call write_log('SnapWave             : no', 1)
+   endif
+   if (wavemaker) then
+      call write_log('Wave paddles         : yes', 1)
+   else   
+      call write_log('Wave paddles         : no', 1)
+   endif
+   call write_log('------------------------------------------', 1)   
+   !
+   call write_log('', 1)
+   call write_log('---------- Starting simulation -----------', 1)
+   write(logstr,'(a,i0,a,i0,a)')'---- Using ', omp_get_max_threads(), ' of ', omp_get_num_procs(), ' available threads ----'   
+   call write_log(logstr, 1)
+   call write_log('', 1)
+   !
    end function sfincs_initialize
    !
    !-----------------------------------------------------------------------------------------------------!
@@ -223,7 +293,7 @@ module sfincs_lib
    !
    double precision, intent(in)  :: dtrange
    integer                       :: ierr
-   real*8                        :: tend  !< end of update interval
+   real*8                        :: tend !< end of update interval
    real*4                        :: dtchk !< dt to check for instability
    logical                       :: single_time_step 
    !
@@ -250,6 +320,8 @@ module sfincs_lib
    !$acc               dxminv, dxrinv, dyrinv, dxm2inv, dxr2inv, dyr2inv, dxrinvc, dxm, dxrm, dyrm, cell_area_m2, cell_area, &
    !$acc               gn2uv, fcorio2d, min_dt, storage_volume, nuvisc, &
    !$acc               cuv_index_uv, cuv_index_uv1, cuv_index_uv2 )
+   !
+   ! Set target time: if dt range is negative, do not modify t1
    !
    single_time_step = .false.
    !   
@@ -281,14 +353,9 @@ module sfincs_lib
    !
    ! Start computational loop
    !
-   write(*,'(a)')''   
-   write(*,*)'---------- Starting simulation ----------'   
-   write(*,'(a,i0,a,i0,a)')' ---- Using ', omp_get_max_threads(), ' of ', omp_get_num_procs(), ' available threads -----'   
-   write(*,'(a)')''   
-   !
    call system_clock(count00, count_rate, count_max)
    !
-   do while (t<t1)
+   do while (t < tend)
       !
       call system_clock(countdt0, count_rate, count_max)
       !
@@ -301,7 +368,7 @@ module sfincs_lib
       !
       nt = nt + 1
       dt = min(alfa * min_dt, tend - t) ! min_dt was computed in sfincs_momentum.f90 without alfa
-      dtchk = alfa * min_dt ! Used to check for instabilities
+      dtchk = alfa * min_dt
       !
       ! A bit unclear why this happens, but large jumps in the time step lead to weird oscillations.
       ! In the 'original' sfincs v11 version, this behavior was supressed by the use of theta.
@@ -455,7 +522,8 @@ module sfincs_lib
          call update_wave_field(t, tloopsnapwave)
          !
          call timer(t4)                   
-         write(*,'(a,f10.1,a,f6.2,a)')'Computing SnapWave at t = ', t, ' s took ', t4 - t3, ' seconds'         
+         write(logstr,'(a,f10.1,a,f6.2,a)')'Computing SnapWave at t = ', t, ' s took ', t4 - t3, ' seconds'         
+         call write_log(logstr, 1)
          !
          ! Maybe we'll add moving wave makers back at some point
          !
@@ -501,10 +569,11 @@ module sfincs_lib
       !      
       ! Stop loop in case of instabilities (make sure water depth does not exceed stopdepth)
       !
-      if (dtchk < dtmin .and. nt > 1) then
+      if (dtchk<dtmin .and. nt>1) then
          !
          error = 1
-         write(error_message,'(a,f0.1,a)')'Error! Maximum depth of ', stopdepth, ' m reached!!! Simulation stopped.'
+         !
+         write(error_message,'(a,f0.4,a,f0.1,a)')'Error! Minimum time step of ', dtmin, ' s reached ! Current velocity exceeded uvmax ', uvmax, ' m/s. Simulation stopped.'
          !
          ! Write map output at last time step 
          !
@@ -516,18 +585,21 @@ module sfincs_lib
          !
       endif
       !
-      percdone = min(100*(t - t0)/(t1 - t0), 100.0)
+      percdone = min(100 * (t - t0) / (t1 - t0), 100.0)
       !
-      if (percdone>=percdonenext) then
+      if (percdone >= percdonenext) then
          !
-         percdonenext = 1.0*(int(percdone) + 5)
+         ! percdonenext = 1.0 * (int(percdone) + 5)
+         percdonenext = 1.0 * (int(percdone) + 1)
          call system_clock(count1, count_rate, count_max)
          trun  = 1.0*(count1 - count00)/count_rate
          trem = trun / max(0.01*percdone, 1.0e-6) - trun
-         if (int(percdone)>0) then         
-            write(*,'(i4,a,f7.1,a)')int(percdone),'% complete, ',trem,' s remaining ...'
+         if (int(percdone)>0) then
+            write(logstr,'(i4,a,f7.1,a)')int(percdone),'% complete, ',trem,' s remaining ...'
+            call write_log(logstr, 1)
          else
-            write(*,'(i4,a,f7.1,a)')int(percdone),'% complete,       - s remaining ...'
+            write(logstr,'(i4,a,f7.1,a)')int(percdone),'% complete,       - s remaining ...'
+            call write_log(logstr, 1)
          endif   
          !
       endif
@@ -543,6 +615,7 @@ module sfincs_lib
       !
    enddo
    !
+   !
    !$acc end data
    !
    end function sfincs_update
@@ -556,11 +629,13 @@ module sfincs_lib
    call system_clock(count1, count_rate, count_max)
    !
    tstart_all = 0.0
-   tfinish_all = 1.0*(count1- count00)/count_rate
+   tfinish_all = 1.0 * (count1 - count00) / count_rate
    !
    call finalize_output(t,ntmaxout,tloopoutput,tmaxout)
-   !
+   !   
    if (store_tsunami_arrival_time) then
+      !
+      ! Should this not be moved to ncoutput? 
       !
       call write_tsunami_arrival_file()   
       !
@@ -568,39 +643,53 @@ module sfincs_lib
    !
    dtavg = dtavg/nt
    !
-   write(*,'(a)')''
-   write(*,*)'---------- Simulation finished ----------'   
-   write(*,'(a)')''
-   write(*,'(a,f10.3)')          ' Total time             : ',tinput + tfinish_all - tstart_all
-   write(*,'(a,f10.3)')          ' Total simulation time  : ',tfinish_all - tstart_all
-   write(*,'(a,f10.3)')          ' Time in input          : ',tinput
+   call write_log('', 1)
+   call write_log('---------- Simulation finished -----------', 1)                  
+   call write_log('', 1)
+   write(logstr,'(a,f10.3)')          ' Total time             : ',tinput + tfinish_all - tstart_all
+   call write_log(logstr, 1)
+   write(logstr,'(a,f10.3)')          ' Total simulation time  : ',tfinish_all - tstart_all
+   call write_log(logstr, 1)
+   write(logstr,'(a,f10.3)')          ' Time in input          : ',tinput
+   call write_log(logstr, 1)
    if (include_boundaries) then
-      write(*,'(a,f10.3,a,f5.1,a)') ' Time in boundaries     : ',tloopbnd,' (',100*tloopbnd/(tfinish_all - tstart_all),'%)'
+      write(logstr,'(a,f10.3,a,f5.1,a)') ' Time in boundaries     : ',tloopbnd,' (',100*tloopbnd/(tfinish_all - tstart_all),'%)'
+      call write_log(logstr, 1)
    endif   
    if (nsrc>0 .or. ndrn>0) then
-      write(*,'(a,f10.3,a,f5.1,a)') ' Time in discharges     : ',tloopsrc,' (',100*tloopsrc/(tfinish_all - tstart_all),'%)'
+      write(logstr,'(a,f10.3,a,f5.1,a)') ' Time in discharges     : ',tloopsrc,' (',100*tloopsrc/(tfinish_all - tstart_all),'%)'
+      call write_log(logstr, 1)
    endif   
    if (meteo3d)  then
-      write(*,'(a,f10.3,a,f5.1,a)') ' Time in meteo fields   : ',tloopwnd1,' (',100*tloopwnd1/(tfinish_all - tstart_all),'%)'
+      write(logstr,'(a,f10.3,a,f5.1,a)') ' Time in meteo fields   : ',tloopwnd1,' (',100*tloopwnd1/(tfinish_all - tstart_all),'%)'
+      call write_log(logstr, 1)
    endif   
    if (wind .or. patmos .or. precip) then
-      write(*,'(a,f10.3,a,f5.1,a)') ' Time in meteo forcing  : ',tloopwnd2,' (',100*tloopwnd2/(tfinish_all - tstart_all),'%)'
+      write(logstr,'(a,f10.3,a,f5.1,a)') ' Time in meteo forcing  : ',tloopwnd2,' (',100*tloopwnd2/(tfinish_all - tstart_all),'%)'
+      call write_log(logstr, 1)
    endif   
-   write(*,'(a,f10.3,a,f5.1,a)') ' Time in momentum       : ',tloopflux,' (',100*tloopflux/(tfinish_all - tstart_all),'%)'
+   write(logstr,'(a,f10.3,a,f5.1,a)') ' Time in momentum       : ',tloopflux,' (',100*tloopflux/(tfinish_all - tstart_all),'%)'
+   call write_log(logstr, 1)
    if (nrstructures>0) then
-      write(*,'(a,f10.3,a,f5.1,a)') ' Time in structures     : ',tloopstruc,' (',100*tloopstruc/(tfinish_all - tstart_all),'%)'
+      write(logstr,'(a,f10.3,a,f5.1,a)') ' Time in structures     : ',tloopstruc,' (',100*tloopstruc/(tfinish_all - tstart_all),'%)'
+      call write_log(logstr, 1)
    endif   
-   write(*,'(a,f10.3,a,f5.1,a)') ' Time in continuity     : ',tloopcont,' (',100*tloopcont/(tfinish_all - tstart_all),'%)'
-   write(*,'(a,f10.3,a,f5.1,a)') ' Time in output         : ',tloopoutput,' (',100*tloopoutput/(tfinish_all - tstart_all),'%)'
+   write(logstr,'(a,f10.3,a,f5.1,a)') ' Time in continuity     : ',tloopcont,' (',100*tloopcont/(tfinish_all - tstart_all),'%)'
+   call write_log(logstr, 1)
+   write(logstr,'(a,f10.3,a,f5.1,a)') ' Time in output         : ',tloopoutput,' (',100*tloopoutput/(tfinish_all - tstart_all),'%)'
+   call write_log(logstr, 1)
    if (snapwave) then
-      write(*,'(a,f10.3,a,f5.1,a)') ' Time in SnapWave       : ',tloopsnapwave,' (',100*tloopsnapwave/(tfinish_all - tstart_all),'%)'
+      write(logstr,'(a,f10.3,a,f5.1,a)') ' Time in SnapWave       : ',tloopsnapwave,' (',100*tloopsnapwave/(tfinish_all - tstart_all),'%)'
+      call write_log(logstr, 1)
    endif
    if (wavemaker) then
-      write(*,'(a,f10.3,a,f5.1,a)') ' Time in wave maker     : ',tloopwavemaker,' (',100*tloopwavemaker/(tfinish_all - tstart_all),'%)'
+      write(logstr,'(a,f10.3,a,f5.1,a)') ' Time in wave maker     : ',tloopwavemaker,' (',100*tloopwavemaker/(tfinish_all - tstart_all),'%)'
+      call write_log(logstr, 1)
    endif
-   write(*,'(a)')''
-   write(*,'(a,20f10.3)')        ' Average time step (s)  : ',dtavg
-   write(*,'(a)')''
+   call write_log('', 1)
+   write(logstr,'(a,20f10.3)')        ' Average time step (s)  : ',dtavg
+   call write_log(logstr, 1)
+   call write_log('', 1)
    !
    if (write_time_output) then
       open(123,file='runtimes.txt')
@@ -617,7 +706,7 @@ module sfincs_lib
       close(123)
    endif
    !
-   write(*,*)'---------- Closing off SFINCS -----------'   
+   call write_log('---------- Closing off SFINCS -----------', 1)
    !
    ! call finalize_parameters()
    !
@@ -627,11 +716,13 @@ module sfincs_lib
       !
       ! Stop depth was exceeded, or e.g. input file missing
       !
-      write(*,*)''
-      write(*,*)trim(error_message)
+      call write_log('', 1)
+      call write_log(trim(error_message), 1)
       ierr = error
       !
    endif
+   !
+   call close_log()
    !
    end function sfincs_finalize
    !

--- a/source/src/sfincs_lib.f90
+++ b/source/src/sfincs_lib.f90
@@ -90,7 +90,7 @@ module sfincs_lib
    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
    !
    build_revision = '$Rev: v2.1.1-Dollerup - branch with log file added by MvO and quadtree index bug fix'
-   build_date     = '$Date: 2024-10-01'
+   build_date     = '$Date: 2025-02-08'
    !
    call write_log('', 1)
    call write_log('------------ Welcome to SFINCS ------------', 1)

--- a/source/src/sfincs_log.f90
+++ b/source/src/sfincs_log.f90
@@ -1,0 +1,40 @@
+module sfincs_log
+   !
+   integer        :: fid
+   character(256) :: logstr
+   !
+contains   
+
+   subroutine open_log()
+   !
+   implicit none
+   !
+   fid = 777
+   open(unit = fid, file = 'sfincs.log')
+   !
+   end subroutine
+
+   subroutine write_log(str, to_screen)
+   !
+   implicit none
+   !
+   character(*), intent(in) :: str
+   integer, intent(in)      :: to_screen
+   !
+   write(fid,'(a)')trim(str)
+   !
+   if (to_screen==1) then
+      write(*,'(a)')trim(str)
+   endif
+   !
+   end subroutine
+
+   subroutine close_log()
+   !
+   implicit none
+   !
+   close(fid)
+   !
+   end subroutine
+
+end module

--- a/source/src/sfincs_meteo.f90
+++ b/source/src/sfincs_meteo.f90
@@ -9,6 +9,7 @@ contains
    use sfincs_data
    use sfincs_spiderweb
    use sfincs_ncinput
+   use sfincs_log
    !
    implicit none
    !   
@@ -16,13 +17,12 @@ contains
    !
    real*4 dummy, wnd, xx, yy
    !
-   write(*,*)'Reading meteo data ...'
-   !
    spw_precip = .false.
    !
    if (spwfile(1:4) /= 'none') then
       !
-      write(*,*)'Reading spiderweb file ...'
+      write(logstr,'(a,a)')'Info    : reading spiderweb file ', trim(spwfile)
+      call write_log(logstr, 0)
       !  
       call read_spw_dimensions(spwfile,spw_nt,spw_nrows,spw_ncols,spw_radius,spw_nquant)
       !
@@ -70,7 +70,7 @@ contains
             ! 
          else
             ! 
-            write(*,*)'Info : Overruled to not use precipitation from spiderweb input ...'
+            call write_log('Info    : not using precipitation from spiderweb input', 0)
             ! 
             spw_precip = .false.
             ! 
@@ -81,10 +81,9 @@ contains
    !
    if (netspwfile(1:4) /= 'none') then
       ! 
-      ! Write statement to log
-      write(*,*)'Reading netcdf spiderweb file ...'
-      ! 
-      ! Read information
+      write(logstr,'(a,a)')'Info    : reading netcdf spiderweb file ', trim(netspwfile)
+      call write_log(logstr, 0)
+      !
       call read_netcdf_spw_data()
       !
    endif
@@ -95,7 +94,8 @@ contains
          !
          ! Convert spiderweb coordinates to utm zone
          ! 
-         write(*,*)'Converting spiderweb coordinates to utm zone ...'
+         write(logstr,'(a,a)')'Info    : converting spiderweb coordinates to UTM  zone ', utmzone
+         call write_log(logstr, 0)
          !       
          do it = 1, spw_nt
             call deg2utm(spw_ye(it),spw_xe(it),xx,yy,utmzone)
@@ -109,7 +109,7 @@ contains
    !
    if (amufile(1:4) /= 'none') then
       !
-      write(*,*)'Reading amu and amv file ...'
+      call write_log('Info    : reading amu and amv file', 0)
       !  
       call read_amuv_dimensions(amufile,amuv_nt,amuv_nrows,amuv_ncols,amuv_x_llcorner,amuv_y_llcorner,amuv_dx,amuv_dy,amuv_nquant)
       !
@@ -135,7 +135,7 @@ contains
    ! 
    if (amprfile(1:4) /= 'none') then
       !
-      write(*,*)'Reading ampr file ...'
+      call write_log('Info    : reading ampr file', 0)
       !  
       call read_amuv_dimensions(amprfile,ampr_nt,ampr_nrows,ampr_ncols,ampr_x_llcorner,ampr_y_llcorner,ampr_dx,ampr_dy,ampr_nquant)
       !
@@ -157,7 +157,7 @@ contains
    !
    if (ampfile(1:4) /= 'none') then
       !
-      write(*,*)'Reading amp file ...'
+      call write_log('Info    : reading amp file', 0)
       !  
       call read_amuv_dimensions(ampfile,amp_nt,amp_nrows,amp_ncols,amp_x_llcorner,amp_y_llcorner,amp_dx,amp_dy,amp_nquant)
       !
@@ -180,7 +180,8 @@ contains
    if (wndfile(1:4) /= 'none') then
       !
       ! Wind in time series file 
-      write(*,*)'Reading ', trim(wndfile)              
+      write(logstr,'(a,a)')'Info    : reading ', trim(wndfile)    
+      call write_log(logstr, 0)
       !
       ntwnd = 0
       itwndlast = 1
@@ -209,7 +210,8 @@ contains
    if (prcpfile(1:4) /= 'none') then
       !
       ! Rainfall in time series file 
-      write(*,*)'Reading ',trim(prcpfile)       
+      write(logstr,'(a,a)')'Info    : reading prcp file ', trim(prcpfile)    
+      call write_log(logstr, 0)
       !
       ntprcp = 0 
       itprcplast = 1
@@ -1283,10 +1285,12 @@ contains
    real*4  :: ptmp
    !
    do itp = itprcplast, ntprcp ! Loop in time
-      if (tprcpt(itp)>t) then
+      if (tprcpt(itp) > t) then          
          exit
       endif
    enddo
+   !
+   itp = max(min(itp, ntprcp), 1)
    !
    twfac  = (t - tprcpt(itp - 1))/(tprcpt(itp) - tprcpt(itp - 1))
    !

--- a/source/src/sfincs_momentum.f90
+++ b/source/src/sfincs_momentum.f90
@@ -154,13 +154,13 @@
             zmin = subgrid_uv_zmin(ip)
             zmax = subgrid_uv_zmax(ip)
             !
-            if (zsu>zmin + huthresh) then ! In the 'new' subgrid formulations, zmin is lowest pixel + huthresh. Huthresh was already applied when building the subgrid tables. In sfincs_domain, huthresh is set to 0.0 to acount for this.
+            if (zsu > zmin + huthresh) then ! In the 'new' subgrid formulations, zmin is lowest pixel + huthresh. Huthresh was already applied when building the subgrid tables. In sfincs_domain, huthresh is set to 0.0 to acount for this.
                iok = .true.
             endif   
             !
          else
             !            
-            if (zsu>zbuvmx(ip)) then ! zbuvmx = max(zb(nm), zb(nmu)) + huthresh
+            if (zsu > zbuvmx(ip)) then ! zbuvmx = max(zb(nm), zb(nmu)) + huthresh
                iok = .true.
             endif   
             !            

--- a/source/src/sfincs_momentum.f90
+++ b/source/src/sfincs_momentum.f90
@@ -662,9 +662,9 @@
                !
             endif
             !
-            ! Apply flux limiter
+            ! Apply flux limiter (default 10 m/s)
             !
-            q(ip) = min(max(q(ip), -hu * uvlim), hu * uvlim)
+            q(ip) = min(max(q(ip), - hu * uvlim), hu * uvlim)
             !
             ! Compute velocity
             !
@@ -675,7 +675,7 @@
             ! Determine minimum time step (alpha is added later on in sfincs_lib.f90) of all uv points
             ! Use maximum of sqrt(gh) and current velocity
             !
-            min_dt = min(min_dt, 1.0 / ( max(sqrt(g * hu), 1.25 * abs(uv(ip)) ) * dxuvinv))
+            min_dt = min(min_dt, 1.0 / ( max(sqrt(g * hu), abs(uv(ip)) ) * dxuvinv))
             !
          else
             !

--- a/source/src/sfincs_momentum.f90
+++ b/source/src/sfincs_momentum.f90
@@ -154,13 +154,13 @@
             zmin = subgrid_uv_zmin(ip)
             zmax = subgrid_uv_zmax(ip)
             !
-            if (zsu > zmin + huthresh) then ! In the 'new' subgrid formulations, zmin is lowest pixel + huthresh. Huthresh was already applied when building the subgrid tables. In sfincs_domain, huthresh is set to 0.0 to acount for this.
+            if (zsu>zmin + huthresh) then ! In the 'new' subgrid formulations, zmin is lowest pixel + huthresh. Huthresh was already applied when building the subgrid tables. In sfincs_domain, huthresh is set to 0.0 to acount for this.
                iok = .true.
             endif   
             !
          else
             !            
-            if (zsu > zbuvmx(ip)) then ! zbuvmx = max(zb(nm), zb(nmu)) + huthresh
+            if (zsu>zbuvmx(ip)) then ! zbuvmx = max(zb(nm), zb(nmu)) + huthresh
                iok = .true.
             endif   
             !            

--- a/source/src/sfincs_ncinput.F90
+++ b/source/src/sfincs_ncinput.F90
@@ -3,6 +3,7 @@ module sfincs_ncinput
    !
    use netcdf       
    use sfincs_spiderweb
+   use sfincs_log
    !
    implicit none
    !
@@ -88,7 +89,7 @@ module sfincs_ncinput
       y_varname    = 'y'  
 !   endif   
    !
-   write(*,*)'Reading FEWS compatible netcdf type water level boundaries (bnd, bzs, bzi)...'
+   call write_log('Info    : reading FEWS compatible netcdf type water level boundaries (bnd, bzs, bzi)...', 0)
    !
    ! Actual reading of data
    !
@@ -129,7 +130,7 @@ module sfincs_ncinput
    !   
    if (net_file_bndbzsbzi%zi_varid /= 0) then     ! Allocate and read if bzi data is present
       bziwaves = .true.   ! turn on flag
-      write(*,*)'   Incident waves are forced...'      
+      !write(*,*)'   Incident waves are forced...'      
       !      
       allocate(zsi_bnd(nbnd,ntbnd))
       allocate(zsit_bnd(nbnd))
@@ -173,7 +174,7 @@ module sfincs_ncinput
       y_varname    = 'y'  
 !   endif   
    !
-   write(*,*)'Reading FEWS compatible netcdf type discharges ...'
+   call write_log('Reading FEWS compatible netcdf type discharges', 0)
    !
    ! Actual reading of data
    !
@@ -257,7 +258,7 @@ module sfincs_ncinput
       y_varname    = 'y'  
 !   endif   
    !
-   write(*,*)'Reading FEWS compatible NetCDF type wind input ...'
+   call write_log('Info    : reading FEWS compatible NetCDF type wind input', 0)
    !
    ! Actual reading of data
    !
@@ -378,7 +379,7 @@ module sfincs_ncinput
       y_varname    = 'y'  
 !   endif   
    !
-   write(*,*)'Reading FEWS compatible NetCDF type barometric pressure input ...'
+   call write_log('Info    : reading FEWS compatible NetCDF type barometric pressure input', 0)
    !
    ! Actual reading of data
    !
@@ -492,7 +493,7 @@ module sfincs_ncinput
       y_varname    = 'y'  
 !   endif   
    !
-   write(*,*)'Reading FEWS compatible NetCDF type precipitation input ...'
+   call write_log('Info    : reading FEWS compatible NetCDF type precipitation input', 0)
    !
    ! Actual reading of data
    !
@@ -619,7 +620,7 @@ module sfincs_ncinput
        !
        ! Handle error: variable does not exist
        ! 
-       write(*,*) "Warning: variable 'precipitation' does not exist in the NetCDF file."
+       call write_log('Warning: variable precipitation does not exist in the NetCDF file !', 0)
        ! 
        spw_precip   = .false.
        precip       = .false.
@@ -629,7 +630,7 @@ module sfincs_ncinput
        NF90(nf90_inq_varid(net_file_spw%ncid, "precipitation",          net_file_spw%precip_varid) )
        spw_precip   = .true.
        precip       = .true.
-       write(*,*)'Turning on process: Precipitation from spwfile'
+       call write_log('Info    : turning on precipitation from spw file', 0)
        !
     endif
     !

--- a/source/src/sfincs_obspoints.f90
+++ b/source/src/sfincs_obspoints.f90
@@ -29,11 +29,14 @@ contains
    !
    if (obsfile(1:4) /= 'none') then
       ! 
-      write(*,*)'Reading observation points ...'
+      write(logstr,'(a)')'Info    : reading observation points'
+      call write_log(logstr, 0)
       !
-      ok = check_file_exists(obsfile, 'obs file')      
+      ok = check_file_exists(obsfile, 'obs file')
       !
-      if (.not. ok) return
+      if (.not. ok) then
+         return
+      endif   
       !
       open(500, file=trim(obsfile))       
       do while(.true.)
@@ -126,11 +129,13 @@ contains
                 iref = z_flags_iref(nm)
             endif         
             !
-            ! write(*,'(a,i0,a,a,a,i0,a,i0,a,i0,a,i0,a,f0.3)')' Observation point ',iobs,' : "',trim(nameobs(iobs)),'" nm=',nm,' n=',n,' m=',m,' iref=',iref,' z=',zbobs(iobs)
+            write(logstr,'(a,i0,a,a,a,i0,a,i0,a,i0,a,i0,a,f0.3)')'Info    : observation point ',iobs,' : "',trim(nameobs(iobs)),'" nm=',nm,' n=',n,' m=',m,' iref=',iref,' z=',zbobs(iobs)
+            call write_log(logstr, 0)
             !
          else
             !
-            write(*,'(a,a,a)')' Warning : observation point "', trim(nameobs(iobs)), '" falls outside model domain.'
+            write(logstr,'(a,a,a)')'Warning ! Observation point "', trim(nameobs(iobs)), '" falls outside model domain !'
+            call write_log(logstr, 0)
             !
          endif   
          !

--- a/source/src/sfincs_output.f90
+++ b/source/src/sfincs_output.f90
@@ -1,6 +1,7 @@
 module sfincs_output
 
    use sfincs_ncoutput
+   use sfincs_log
    
    contains
 
@@ -256,15 +257,15 @@ module sfincs_output
        !write dtmax output if 1) value for dtmaxout wasn't achieved yet, 
        !or 2) in the last timeinterval, the full 'dtmaxout' wasn't achieved yet, but we still want the max over this interval
       ! 
-      write(*,'(a)')''       
-      write(*,*)'Info : Write maximum values at final timestep since t=dtmaxout was not reached yet...'
+      call write_log('', 1)
+      call write_log('Info : Write maximum values at final timestep since t=dtmaxout was not reached yet...', 1)
       ntmaxout = 1
       call write_output(t,.false.,.false.,.true.,.false.,0,ntmaxout,0,tloopoutput)
       !
    elseif (dtmaxout>1.e-6 .and. ntmaxout>0 .and. t < tmaxout) then
       !
-      write(*,'(a)')''       
-      write(*,*)'Info : Write maximum values at final timestep since t=dtmaxout was not reached yet for final interval...'
+      call write_log('', 1)
+      call write_log('Info : Write maximum values at final timestep since t=dtmaxout was not reached yet for final interval...', 1)
       ntmaxout = ntmaxout + 1
       !
       ! Write 'tstop' as timemax instead of actual (unrounded) 't'

--- a/source/src/sfincs_structures.f90
+++ b/source/src/sfincs_structures.f90
@@ -93,7 +93,8 @@
    integer,   dimension(:), allocatable  :: vertices 
    integer*1, dimension(:), allocatable  :: istruc
    !
-   write(*,*)'Reading weir file ...'
+   write(logstr,'(a)')'Info    : reading weir file'
+   call write_log(logstr, 0)
    !
    ! Read structures file
    !
@@ -126,8 +127,6 @@
    rewind(500)
    !
    ! Loop through polylines
-   !
-!   open(600, file='structures.ldb')
    !
    do ithd = 1, nthd
       !
@@ -181,7 +180,7 @@
                dxs = dyrm(iref)
             else
                ! V point
-               dxs = dxm(indx)
+               dxs = 1.0 / dxminv(indx)
             endif   
          else   
             ! Projected coordinate system
@@ -333,7 +332,7 @@
                !
                ! V point
                !
-               dxs = dxm(ip)
+               dxs = 1.0 / dxminv(ip)
                !
             endif   
             !
@@ -371,7 +370,8 @@
    !
    nrstructures = nstruc
    !
-   write(*,*)nrstructures,' structure u/v points found'
+   write(logstr,'(a,i0,a)')'Info    : ', nrstructures, ' structure u/v points found'
+   call write_log(logstr, 0)
    !
    end subroutine
 
@@ -422,7 +422,8 @@
       !
       ! Loop through polylines
       !
-      write(*,'(a,a,a,i0,a)')' Reading ',trim(thdfile),' (', nthd, ' thin dams found) ...'
+      write(logstr,'(a,a,a,i0,a)')'Info    : reading ', trim(thdfile), ' (', nthd, ' thin dams found)'
+      call write_log(logstr, 0)
       !
       do ithd = 1, nthd
          !
@@ -454,7 +455,8 @@
       !
       close(500)
       !
-      write(*,*)nr_points,' structure points found'
+      write(logstr,'(a,i0,a)')'Info    : ', nr_points,' structure points found'
+      call write_log(logstr, 0)
       !
    endif   
    !

--- a/source/src/sfincs_subgrid.F90
+++ b/source/src/sfincs_subgrid.F90
@@ -357,12 +357,16 @@ contains
       nm = uv_index_z_nm(ip)
       nmu = uv_index_z_nmu(ip)
       if (subgrid_z_zmin(nm) > subgrid_uv_zmin(ip)) then
-         write(*,'(a,i0,a,i0,a)')'Error in subgrid uv point! subgrid_uv_zmin(',ip,') < subgrid_z_zmin(', nm, ')'
+         ! This should normally never happen
+         write(logstr,'(a,i0,a,i0,a)')'Error in subgrid uv point! subgrid_uv_zmin(',ip,') < subgrid_z_zmin(', nm, ')'
+         call write_log(logstr, 0)
          subgrid_uv_zmin(ip) = max(subgrid_uv_zmin(ip), subgrid_z_zmin(nm))
          subgrid_uv_zmax(ip) = max(subgrid_uv_zmax(ip), subgrid_uv_zmin(ip) + 0.001)
       endif   
       if (subgrid_z_zmin(nmu) > subgrid_uv_zmin(ip)) then
-         write(*,'(a,i0,a,i0,a)')'Error in subgrid uv point! subgrid_uv_zmin(',ip,') < subgrid_z_zmin(', nmu, ')'
+         ! This should normally never happen
+         write(logstr,'(a,i0,a,i0,a)')'Error in subgrid uv point! subgrid_uv_zmin(',ip,') < subgrid_z_zmin(', nmu, ')'
+         call write_log(logstr, 0)
          subgrid_uv_zmin(ip) = max(subgrid_uv_zmin(ip), subgrid_z_zmin(nmu))
          subgrid_uv_zmax(ip) = max(subgrid_uv_zmax(ip), subgrid_uv_zmin(ip) + 0.001)
       endif   
@@ -379,8 +383,10 @@ contains
    !
    do ip = 1, npuv
       if (subgrid_uv_zmax(ip) - subgrid_uv_zmin(ip) < 1.0e-7) then
-         write(*,'(a,i0,a)')'Error in subgrid uv point (ip=', ip, '), zmax <= zmin'
-         subgrid_uv_zmax(ip) = subgrid_uv_zmax(ip) + 0.001
+         ! This should normally never happen
+         write(logstr,'(a,i0,a)')'Error in subgrid uv point (ip=', ip, '), zmax <= zmin'
+         call write_log(logstr, 0)
+         subgrid_uv_zmax(ip) = subgrid_uv_zmax(ip) + 0.01
       endif   
    enddo
    !


### PR DESCRIPTION
This branch builds upon a few other branches.

There's a lot of changes here, I'm afraid.

In order of commits, it contains:

1) xmi updates

2) log file functionality (writing to screen and sfincs.log)

3) updated advection limiter and added flux limiter (using uvlim, default = 10 m/s)

4) a small rewrite of the coriolis and use_coriolis variables

5) removal of cumprcpt (no longer necessesary with double precision zs) and double precision z_volume


