### PR TITLE
- Implement instead using logical nonhydrostatic

### DIFF
--- a/source/src/quadtree.F90
+++ b/source/src/quadtree.F90
@@ -402,9 +402,9 @@ contains
       ! Check if a nonh_mask is provided, if not, we keep nonh_mask=1 everywhere
       ! 
       status = NF90_INQ_VARID(net_file_qtr%ncid, "nonh_mask", net_file_qtr%nonh_mask_varid)
-	  !
-	  ! Check the status
-	  if (status /= NF90_NOERR) then  
+      !
+      ! Check the status
+      if (status /= NF90_NOERR) then  
          !
          call write_log('Warning: variable nonh_mask does not exist in the quadtree file, values set to 1 everywhere !', 1)
          !

--- a/source/src/quadtree.F90
+++ b/source/src/quadtree.F90
@@ -59,14 +59,14 @@ module quadtree
    !
 contains
    !
-   subroutine quadtree_read_file(qtrfile, snapwave)
+   subroutine quadtree_read_file(qtrfile, snapwave, nonhydrostatic)
    !
    ! Reads quadtree file
    !
    implicit none
    !
    character*256, intent(in)                       :: qtrfile
-   logical, intent(in)                             :: snapwave   
+   logical, intent(in)                             :: snapwave, nonhydrostatic   
    !
    real*4,             dimension(:),   allocatable :: dxr
    real*4,             dimension(:),   allocatable :: dyr
@@ -86,7 +86,7 @@ contains
    endif
    !
    if (quadtree_netcdf) then
-      call quadtree_read_file_netcdf(qtrfile, snapwave)
+      call quadtree_read_file_netcdf(qtrfile, snapwave, nonhydrostatic)
    else
       call quadtree_read_file_binary(qtrfile)
    endif
@@ -287,14 +287,14 @@ contains
    end subroutine
 
 
-   subroutine quadtree_read_file_netcdf(qtrfile, snapwave)
+   subroutine quadtree_read_file_netcdf(qtrfile, snapwave, nonhydrostatic)
    !
    ! Reads quadtree file from netcdf file
    !
    implicit none
    !
    character*256, intent(in) :: qtrfile
-   logical, intent(in)       :: snapwave
+   logical, intent(in)       :: snapwave, nonhydrostatic
    !
    integer*1 :: iversion
    integer   :: np, ip, iepsg, status
@@ -390,23 +390,32 @@ contains
       NF90(nf90_get_var(net_file_qtr%ncid, net_file_qtr%snapwave_mask_varid,  quadtree_snapwave_mask(:)))
    endif
    !
-   ! Try to read nonh mask
-   !
+   ! Nonhydrostatic mask
    allocate(quadtree_nonh_mask(np))
    !
-   NF90(nf90_inq_varid(net_file_qtr%ncid, 'nonh_mask',  net_file_qtr%nonh_mask_varid))
+   ! First set all mask points to 1 
+   quadtree_nonh_mask = 1
+   ! Note, irregular points will be set to 0 in sfincs_domain.f90
    !
-   if (net_file_qtr%nonh_mask_varid /= 0) then
+   if (nonhydrostatic) then
       !
-      ! Read from file
-      !
-      NF90(nf90_get_var(net_file_qtr%ncid, net_file_qtr%nonh_mask_varid,  quadtree_nonh_mask(:)))
-      !
-   else
-      !
-      ! Set all mask point to 1 (irregular points will be set to 0 in sfincs_domain.f90)
-      !
-      quadtree_nonh_mask = 1
+      ! Check if a nonh_mask is provided, if not, we keep nonh_mask=1 everywhere
+      ! 
+      status = NF90_INQ_VARID(net_file_qtr%ncid, "nonh_mask", net_file_qtr%nonh_mask_varid)
+	  !
+	  ! Check the status
+	  if (status /= NF90_NOERR) then  
+         !
+         call write_log('Warning: variable nonh_mask does not exist in the quadtree file, values set to 1 everywhere !', 1)
+         !
+      else
+         !
+         NF90(nf90_inq_varid(net_file_qtr%ncid, 'nonh_mask',  net_file_qtr%nonh_mask_varid))
+         !
+         ! Read from file and overwrite
+         NF90(nf90_get_var(net_file_qtr%ncid, net_file_qtr%nonh_mask_varid,  quadtree_nonh_mask(:)))         
+         !
+      endif      
       !
    endif
    !

--- a/source/src/sfincs_domain.f90
+++ b/source/src/sfincs_domain.f90
@@ -172,7 +172,7 @@ contains
       ! 
       ! Read quadtree file
       !
-      call quadtree_read_file(qtrfile, snapwave)
+      call quadtree_read_file(qtrfile, snapwave, nonhydrostatic)
       !
    else
       !

--- a/source/src/sfincs_lib.f90
+++ b/source/src/sfincs_lib.f90
@@ -90,8 +90,8 @@ module sfincs_lib
    !
    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
    !
-   build_revision = '$Rev: v2.1.4:beta-nonhydrostatic_bicgstab'
-   build_date     = '$Date: 2025-04-14'
+   build_revision = "$Rev: v2.2.0 col d'Eze"
+   build_date     = "$Date: 2025-04-15"
    !
    call write_log('', 1)
    call write_log('------------ Welcome to SFINCS ------------', 1)


### PR DESCRIPTION
- Reason: we want to be able to get an warning, in case it is attempted to run nonhydrostatic mode, but nonh_mask not prescribed in quadtree input grid
- Now a warning message will be given if nonh=1, but no nonh_mask variable is provided