### PR TITLE
added run-up gauges (tekal format but no more than 2 rows per gauge)

### DIFF
--- a/source/sfincs_lib/sfincs_lib.vfproj
+++ b/source/sfincs_lib/sfincs_lib.vfproj
@@ -47,8 +47,7 @@
 				<File RelativePath="..\src\snapwave\snapwave_solver.f90"/>
 				<File RelativePath="..\src\snapwave\snapwave_windsource.f90"/>
 			</Filter>
-			<File RelativePath="..\src\bicgstab_solver_ilu.f90">
-			</File>
+			<File RelativePath="..\src\bicgstab_solver_ilu.f90"/>
 			<File RelativePath="..\src\deg2utm.f90"/>
 			<File RelativePath="..\src\geometry.f90"/>
 			<File RelativePath="..\src\quadtree.F90">
@@ -59,13 +58,17 @@
 					<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/>
 				</FileConfiguration>
 			</File>
-			<File RelativePath="..\src\sfincs_boundaries.f90"/>
+			<File RelativePath="..\src\sfincs_boundaries.f90">
+			</File>
 			<File RelativePath="..\src\sfincs_continuity.f90"/>
-			<File RelativePath="..\src\sfincs_crosssections.f90"/>
-			<File RelativePath="..\src\sfincs_data.f90"/>
+			<File RelativePath="..\src\sfincs_crosssections.f90">
+			</File>
+			<File RelativePath="..\src\sfincs_data.f90">
+			</File>
 			<File RelativePath="..\src\sfincs_date.f90"/>
 			<File RelativePath="..\src\sfincs_discharges.f90"/>
-			<File RelativePath="..\src\sfincs_domain.f90"/>
+			<File RelativePath="..\src\sfincs_domain.f90">
+			</File>
 			<File RelativePath="..\src\sfincs_error.f90"/>
 			<File RelativePath="..\src\sfincs_infiltration.f90"/>
 			<File RelativePath="..\src\sfincs_initial_conditions.F90"/>
@@ -90,10 +93,12 @@
 					<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/>
 				</FileConfiguration>
 			</File>
-			<File RelativePath="..\src\sfincs_nonhydrostatic.f90">
+			<File RelativePath="..\src\sfincs_nonhydrostatic.f90"/>
+			<File RelativePath="..\src\sfincs_obspoints.f90">
 			</File>
-			<File RelativePath="..\src\sfincs_obspoints.f90"/>
 			<File RelativePath="..\src\sfincs_output.f90"/>
+			<File RelativePath="..\src\sfincs_runup_gauges.f90">
+			</File>
 			<File RelativePath="..\src\sfincs_snapwave.f90"/>
 			<File RelativePath="..\src\sfincs_spiderweb.f90"/>
 			<File RelativePath="..\src\sfincs_structures.f90"/>

--- a/source/src/Makefile.am
+++ b/source/src/Makefile.am
@@ -37,6 +37,7 @@ libsfincs_la_SOURCES = \
 	sfincs_boundaries.f90 \
 	sfincs_continuity.f90 \
 	sfincs_crosssections.f90 \
+	sfincs_runup_gauges.f90 \
 	sfincs_discharges.f90 \
 	sfincs_subgrid.F90 \
 	sfincs_domain.f90 \
@@ -45,7 +46,7 @@ libsfincs_la_SOURCES = \
 	sfincs_snapwave.f90 \
 	deg2utm.f90 \
 	sfincs_meteo.f90 \
-        bicgstab_solver_ilu.f90 \
+    bicgstab_solver_ilu.f90 \
 	sfincs_nonhydrostatic.f90 \
 	sfincs_ncoutput.F90 \
 	sfincs_output.f90 \

--- a/source/src/sfincs_data.f90
+++ b/source/src/sfincs_data.f90
@@ -2,8 +2,9 @@ module sfincs_data
 
       !!! Revision data
       character*256 :: build_revision, build_date
-      !!!!
+      !!!
       !!! Time variables
+      !!!
       real    :: tstart_all, tfinish_all
       real*4  :: dtavg
       !!!
@@ -100,6 +101,7 @@ module sfincs_data
       real*4 nh_tstop
       integer nh_itermax
       real*4 nh_tol
+      real*4 runup_gauge_depth
       !
       real*4 freqminig
       real*4 freqmaxig
@@ -128,6 +130,7 @@ module sfincs_data
       character*256 :: wstfile
       character*256 :: obsfile
       character*256 :: crsfile
+      character*256 :: rugfile
       character*256 :: srcfile
       character*256 :: disfile
       character*256 :: drnfile
@@ -250,6 +253,7 @@ module sfincs_data
       logical       :: h73table
       !!!
       !!! sfincs_input.f90 switches
+      !!!
       integer storevelmax
       integer storefluxmax
       integer storevel
@@ -767,6 +771,14 @@ module sfincs_data
       integer, dimension(:,:),   allocatable   :: crs_uv_index
       integer, dimension(:,:),   allocatable   :: crs_idir
       character*256, dimension(:), allocatable :: namecrs
+      !!!
+      !!! Run-up gauges
+      !!!
+      integer                                  :: nr_runup_gauges
+      integer, dimension(:,:),   allocatable   :: runup_gauge_nm
+      character*256, dimension(:), allocatable :: runup_gauge_name
+      integer, dimension(:),     allocatable   :: runup_gauge_nrp
+      !!!      
       !
       real*4 :: waveage
       !

--- a/source/src/sfincs_input.f90
+++ b/source/src/sfincs_input.f90
@@ -132,6 +132,7 @@ contains
    call read_real_input(500, 'nh_tol', nh_tol, 0.001)
    call read_int_input(500, 'nh_itermax', nh_itermax, 100)
    call read_logical_input(500, 'h73table', h73table, .false.)   
+   call read_real_input(500, 'rugdepth', runup_gauge_depth, 0.05)
    !
    ! Domain
    !
@@ -202,8 +203,10 @@ contains
    call read_char_input(500,'netspwfile',netspwfile,'none')      
    !
    ! Output
+   !
    call read_char_input(500,'obsfile',obsfile,'none')
    call read_char_input(500,'crsfile',crsfile,'none')
+   call read_char_input(500, 'rugfile', rugfile, 'none')
    call read_int_input(500,'storevelmax',storevelmax,0)
    call read_int_input(500,'storefluxmax',storefluxmax,0)
    call read_int_input(500,'storevel',storevel,0)

--- a/source/src/sfincs_lib.f90
+++ b/source/src/sfincs_lib.f90
@@ -9,6 +9,7 @@ module sfincs_lib
    use sfincs_boundaries
    use sfincs_obspoints
    use sfincs_crosssections
+   use sfincs_runup_gauges
    use sfincs_discharges
    use sfincs_meteo
    use sfincs_infiltration
@@ -146,15 +147,15 @@ module sfincs_lib
    !
    call read_structures()       ! Reads thd files and sets kcuv to zero where necessary
    !
-   call write_log('Reading boundary data ...', 0) 
    call read_boundary_data()    ! Reads bnd, bzs, etc files
    !
    call find_boundary_indices()
    !
-   call write_log('Reading observation points ...', 0) 
    call read_obs_points()       ! Reads obs file
    !
    call read_crs_file()         ! Reads cross sections
+   !
+   call read_rug_file()         ! Reads cross sections
    !
    call read_discharges()       ! Reads dis and src file
    !

--- a/source/src/sfincs_ncoutput.F90
+++ b/source/src/sfincs_ncoutput.F90
@@ -39,7 +39,7 @@ module sfincs_ncoutput
       integer :: ncid   
       integer :: time_dimid 
       integer :: points_dimid, pointnamelength_dimid
-      integer :: crosssections_dimid, structures_dimid, drain_dimid
+      integer :: crosssections_dimid, structures_dimid, drain_dimid, runup_gauges_dimid
       integer :: runtime_dimid
       integer :: point_x_varid, point_y_varid, station_x_varid, station_y_varid, crs_varid, qinf_varid, S_varid  
       integer :: station_id_varid, station_name_varid
@@ -53,6 +53,7 @@ module sfincs_ncoutput
       integer :: inp_varid, total_runtime_varid, average_dt_varid, status_varid  
       integer :: hm0_varid, hm0ig_varid, zsm_varid, tp_varid, tpig_varid, wavdir_varid, dirspr_varid
       integer :: dw_varid, df_varid, dwig_varid, dfig_varid, cg_varid, qb_varid, beta_varid, srcig_varid, alphaig_varid
+      integer :: runup_gauge_name_varid, runup_gauge_zs_varid
       !
    end type
    !
@@ -1403,6 +1404,7 @@ contains
    
    
    subroutine ncoutput_his_init()
+   !
    ! 1. Initialise dimensions/variables/attributes
    ! 2. write grid/msk/zb to file
    !
@@ -1419,8 +1421,8 @@ contains
    real*4, dimension(:), allocatable :: struc_y
    real*4, dimension(:), allocatable :: struc_height   
    !
-   if (nobs==0 .and. nrcrosssections==0 .and. nrstructures==0 .and. ndrn==0) then ! If no observation points, cross-sections, structures or drains; his file is not created        
-        return
+   if (nobs==0 .and. nrcrosssections==0 .and. nrstructures==0 .and. ndrn==0 .and. nr_runup_gauges==0) then ! If no observation points, cross-sections, structures or drains; his file is not created        
+      return
    endif
    !
    NF90(nf90_create('sfincs_his.nc', ior(NF90_CLOBBER,NF90_NETCDF4), his_file%ncid))
@@ -1447,10 +1449,13 @@ contains
       NF90(nf90_def_dim(his_file%ncid, 'structures', nrstructures, his_file%structures_dimid)) ! nr of structures (weir)
    endif   
    !
+   if (nr_runup_gauges > 0) then   
+      NF90(nf90_def_dim(his_file%ncid, 'runup_gauges', nr_runup_gauges, his_file%runup_gauges_dimid)) ! runup gauges
+   endif
+   !
    NF90(nf90_def_dim(his_file%ncid, 'pointnamelength', 256, his_file%pointnamelength_dimid)) ! length of station_name per obs point  
    NF90(nf90_def_dim(his_file%ncid, 'runtime', 1, his_file%runtime_dimid)) ! total_runtime, average_dt    
    !
-   !     
    ! Some metadata attributes 
    NF90(nf90_put_att(his_file%ncid,nf90_global, "Conventions", "Conventions = 'CF-1.6, SGRID-0.3")) 
    NF90(nf90_put_att(his_file%ncid,nf90_global, "Build-Revision-Date-Netcdf-library", trim(nf90_inq_libvers()))) ! version of netcdf library
@@ -1472,6 +1477,10 @@ contains
    !
    if (nrcrosssections>0) then
       NF90(nf90_def_var(his_file%ncid, 'crosssection_name', NF90_CHAR, (/his_file%pointnamelength_dimid, his_file%crosssections_dimid/), his_file%crosssection_name_varid))
+   endif      
+   !
+   if (nr_runup_gauges > 0) then
+      NF90(nf90_def_var(his_file%ncid, 'runup_gauge_name', NF90_CHAR, (/his_file%pointnamelength_dimid, his_file%runup_gauges_dimid/), his_file%runup_gauge_name_varid))
    endif      
    !
    !NF90(nf90_put_att(his_file%ncid, his_file%station_name_varid, 'units', '-')) !not wanted in fews   
@@ -1811,6 +1820,16 @@ contains
       NF90(nf90_put_att(his_file%ncid, his_file%discharge_varid, 'coordinates', 'drainage_name'))
       !
    endif   
+   !   
+   if (nr_runup_gauges > 0) then
+      !
+      NF90(nf90_def_var(his_file%ncid, 'runup_gauge_zs', NF90_FLOAT, (/his_file%runup_gauges_dimid, his_file%time_dimid/), his_file%runup_gauge_zs_varid)) ! time-varying crossection discharge 
+      NF90(nf90_put_att(his_file%ncid, his_file%runup_gauge_zs_varid, '_FillValue', FILL_VALUE))   
+      NF90(nf90_put_att(his_file%ncid, his_file%runup_gauge_zs_varid, 'units', 'm'))
+      NF90(nf90_put_att(his_file%ncid, his_file%runup_gauge_zs_varid, 'long_name', 'run-up elevation'))
+      NF90(nf90_put_att(his_file%ncid, his_file%runup_gauge_zs_varid, 'coordinates', 'runup_gauge_name'))
+      !
+   endif
    !
    ! Add for final output:
    NF90(nf90_def_var(his_file%ncid, 'total_runtime', NF90_FLOAT, (/his_file%runtime_dimid/), his_file%total_runtime_varid))
@@ -1836,6 +1855,10 @@ contains
    !
    if (nrcrosssections>0) then
       NF90(nf90_put_var(his_file%ncid, his_file%crosssection_name_varid, namecrs))  ! write station_name      ! , (/1, nobs/)
+   endif   
+   !
+   if (nr_runup_gauges > 0) then
+      NF90(nf90_put_var(his_file%ncid, his_file%runup_gauge_name_varid, runup_gauge_name))  ! write rug name
    endif   
    !
    if (nrstructures>0) then
@@ -2645,6 +2668,7 @@ contains
    !
    use sfincs_data   
    use sfincs_crosssections
+   use sfincs_runup_gauges
    use sfincs_snapwave
    !
    implicit none   
@@ -2684,7 +2708,7 @@ contains
    real*4, dimension(nobs) :: betaobs
    real*4, dimension(nobs) :: srcigobs
    real*4, dimension(nobs) :: alphaigobs
-   real*4, dimension(:), allocatable :: qq
+   real*4, dimension(:), allocatable :: qq, zz
    !
    zobs         = FILL_VALUE
    zsmobs       = FILL_VALUE
@@ -2911,6 +2935,16 @@ contains
       call get_discharges_through_crosssections(qq)
       !
       NF90(nf90_put_var(his_file%ncid, his_file%discharge_varid, qq, (/1, nthisout/))) ! write discharge
+      !
+   endif
+   !
+   if (nr_runup_gauges>0) then
+      !
+      ! Get run-up elevations
+      !
+      call get_runup_levels(zz)
+      !
+      NF90(nf90_put_var(his_file%ncid, his_file%runup_gauge_zs_varid, zz, (/1, nthisout/))) ! write run up level
       !
    endif
    !

--- a/source/src/sfincs_output.f90
+++ b/source/src/sfincs_output.f90
@@ -56,21 +56,26 @@ module sfincs_output
       !
       ! No restart file required
       !
-      trstout     = 1.0e9
+      trstout = 1.0e9
       !
    endif
    !
    ! Create his file if either observation points, cross-sections, structures or drains present
    !
-   if ((dthisout>1.0e-6) .and. ((nobs>0) .or. (nrcrosssections>0) .or. (nrstructures>0) .or. (ndrn>0))) then
+   if (dthisout>1.0e-6 .and. (nobs>0 .or. nrcrosssections>0 .or. nrstructures>0 .or. ndrn>0 .or. nr_runup_gauges>0 )) then
+      !
       thisout     = t0
+      !
       if (outputtype_his == 'net') then    
          call ncoutput_his_init()
       else      
          call open_his_output()
       endif
+      !
    else
+      !
      thisout     = 1.0e9
+      !
    endif
    !   
    end subroutine
@@ -223,7 +228,7 @@ module sfincs_output
    !      
    ! Water level time series
    !
-   if (write_his .and. (nobs>0 .or. nrcrosssections>0)) then
+   if (write_his .and. (nobs>0 .or. nrcrosssections>0 .or. nr_runup_gauges>0)) then
       !      
       if (outputtype_his == 'net') then
          !      

--- a/source/src/sfincs_runup_gauges.f90
+++ b/source/src/sfincs_runup_gauges.f90
@@ -1,0 +1,184 @@
+module sfincs_runup_gauges
+
+contains
+
+   subroutine read_rug_file()
+   !
+   ! Reads rug file
+   !
+   use sfincs_data
+   use geometry
+   use quadtree
+   !
+   implicit none
+   !
+   integer ip, nrows, ncols, irow, stat, irug, nmq, nrpmx
+   !
+   real      :: dummy
+   real*4    :: xru0, yru0, xru1, yru1, x, y
+   real*4    :: rlen, rdx, rdy, dxstep
+   !
+   character(len=256) :: cdummy
+   !
+   ! Read cross sections file
+   !
+   nr_runup_gauges = 0
+   !
+   if (rugfile(1:4) /= 'none') then
+      ! 
+      call write_log('Info    : reading run-up gauges', 0)
+      !
+      ! First count number of polylines
+      !
+      open(500, file=trim(rugfile))
+      do while(.true.)
+         read(500,*,iostat = stat)cdummy
+         if (stat<0) exit         
+         read(500,*,iostat = stat)nrows, ncols
+         if (stat<0) exit
+         if (nrows > 2) then
+            call write_log('Warning : Invalid run-up gauge! May only contain begin and end point. Run-up gauge skipped.', 1)
+         endif   
+         nr_runup_gauges = nr_runup_gauges + 1
+         do irow = 1, nrows
+            read(500,*)dummy
+         enddo
+      enddo
+      rewind(500)
+      !
+      if (nr_runup_gauges == 0) then
+         !
+         call write_log('Warning : no valid run-up gauges found', 1)
+         return         
+         !
+      endif
+      !
+      ! Get nr points in longest runup gauge
+      !
+      nrpmx = 0
+      !
+      dxstep = 0.2 * dxyr(nref)
+      !
+      do irug = 1, nr_runup_gauges
+         !
+         read(500,*,iostat = stat)cdummy
+         read(500,*,iostat = stat)nrows,ncols
+         if (stat<0) exit
+         read(500,*)xru0, yru0
+         read(500,*)xru1, yru1
+         rdx = xru1 - xru0
+         rdy = yru1 - yru0
+         rlen = sqrt(rdx**2 + rdy**2)
+         nrpmx = max(nrpmx, int(rlen / dxstep) + 1)
+         !
+      enddo
+      rewind(500)
+      !
+      allocate(runup_gauge_nm(nrpmx, nr_runup_gauges))
+      allocate(runup_gauge_name(nr_runup_gauges))
+      allocate(runup_gauge_nrp(nr_runup_gauges))
+      !
+      runup_gauge_nm = 0
+      runup_gauge_nrp = 0
+      !
+      ! Loop through polylines
+      !
+      do irug = 1, nr_runup_gauges
+         !
+         read(500,*,iostat = stat)cdummy
+         read(500,*,iostat = stat)nrows,ncols
+         if (stat<0) exit
+         !
+         ! We only take the first two vertices
+         !
+         read(500,*)xru0, yru0
+         read(500,*)xru1, yru1
+         !
+         runup_gauge_name(irug) = trim(cdummy)
+         !
+         rdx = xru1 - xru0
+         rdy = yru1 - yru0
+         rlen = sqrt(rdx**2 + rdy**2)
+         runup_gauge_nrp(irug) = int(rlen / dxstep) + 1
+         !
+         do ip = 1, runup_gauge_nrp(irug)
+            !
+            x = xru0 + (ip - 1) * dxstep * rdx / rlen
+            y = yru0 + (ip - 1) * dxstep * rdy / rlen
+            !
+            ! Index in quadtree
+            !
+            nmq = find_quadtree_cell(x, y)
+            !
+            if (nmq > 0) then
+               !
+               ! Index in SFINCS domain
+               !
+               runup_gauge_nm(ip, irug) = index_sfincs_in_quadtree(nmq)
+               !
+            endif   
+            !
+         enddo   
+         !
+      enddo 
+      !
+      close(500)
+      !
+   endif
+   !
+   end subroutine
+
+   
+   subroutine get_runup_levels(zru)
+   !
+   use sfincs_data
+   !
+   implicit none
+   !
+   real*4, dimension(:), allocatable :: zru
+   !
+   integer :: ip, irug, nm
+   real*4  :: zst, zbt
+   !
+   allocate(zru(nr_runup_gauges))
+   !
+   zru = -999.0
+   !
+   do irug = 1, nr_runup_gauges
+      !
+      do ip = 1, runup_gauge_nrp(irug)
+         !
+         nm = runup_gauge_nm(ip, irug)
+         !         
+         zst = zs(nm)
+         !
+         if (subgrid) then
+            !
+            zbt = subgrid_z_zmin(nm)
+            !
+         else
+            !
+            zbt = zb(nm)
+            !
+         endif
+         !
+         if (zst > zbt + runup_gauge_depth) then
+            !
+            ! Point is okay
+            !
+            zru(irug) = zst
+            !
+         else
+            !
+            ! Shallower than runup_gauge_depth
+            !
+            exit
+            !
+         endif
+         !
+      enddo
+   enddo   
+   !
+   end subroutine
+   
+end module


### PR DESCRIPTION
added run-up gauges. should not affect any other results.
keywords: rugfile and rugdepth (default: 0.05m)
run-up elevations are stored at dthistout interval