### PR TITLE
Fix issue found by Ligaya

### DIFF
--- a/source/src/sfincs_snapwave.f90
+++ b/source/src/sfincs_snapwave.f90
@@ -332,7 +332,7 @@ contains
    !
    ! Determine SnapWave wind
    !
-   if (store_wind) then
+   if (wind) then
       !
       do nm = 1, snapwave_no_nodes
          !


### PR DESCRIPTION
The exception was having snapwave_wind = 0, but storemeteo=1 (and therefore store_wind = true), which lead to memory error in sfincs_snapwave.f90 when converting the wind from sfincs to snapwave