### PR TITLE
in case wind turned on, always orient the directional grid around mea…

### DIFF
--- a/source/src/snapwave/snapwave_boundaries.f90
+++ b/source/src/snapwave/snapwave_boundaries.f90
@@ -472,11 +472,20 @@ subroutine update_boundary_conditions(t)
    ! Make directional grid around boundary mean wave/wind direction
    !
    thetamean = wdmean_bwv
-   if (wind) then  
+   if (wind) then
+      ! 
       thetamean=u10dmean
+      !
       call make_theta_grid(u10dmean)
+      !
+      call write_log('INFO SnapWave - Making directional grid around boundary mean wind direction', 0)
+      !
    else
+      !
       call make_theta_grid(wdmean_bwv)
+      !
+      call write_log('INFO SnapWave - Making directional grid around boundary mean wave direction', 0)
+      !
    endif 
    !
    ! Build spectra on the boundary support points


### PR DESCRIPTION
Always orient the thetagrid around the wind direction, even when there are boundary conditions imposed. See the associated issue for a figure showing the improvements for the DCA-Pilotsite 01 problem.