### PR TITLE
- Reading in iniq should be bigger, as the array written away is of s…

### DIFF
--- a/source/src/sfincs_initial_conditions.F90
+++ b/source/src/sfincs_initial_conditions.F90
@@ -38,7 +38,7 @@ contains
       !
       allocate(inizs(np))
       allocate(inizs4(np))      
-      allocate(iniq(npuv))
+      allocate(iniq(npuv+ncuv+1)) ! Note: q is actually larger than npuv! It has size npuv + ncuv + 1
       !
       inizs = zini
       inizs4 = zini      


### PR DESCRIPTION
…ize 'npuv+ncuv+1', as found by Maarten