### PR TITLE
timestep limiter diagnostics (csv) + unified timestep analysis 

### DIFF
--- a/docs/output.rst
+++ b/docs/output.rst
@@ -131,6 +131,8 @@ Possible problems can be:
 
 * In general the internal timesteps of SFINCS might be too large. Possible solution: reduce timesteps by supplying a lower value of alpha (e.g. 0.5), set a higher value for 'hmin_cfl' or set a low enough value of 'dtmax'.
 
+* To analyze which locations are limiting the global timestep, enable `timestep_diagnostics = 1` in `sfincs.inp` to write `timestep_diagnostics.csv` and `timestep_diagnostics_domain.csv`.
+
 * When only forcing discharges in a for the rest entirely dry domain, the initial time steps can be too coarse to account for the needed timesteps when the discharge starts to flow. Possible solution: Make sure that part of the river/domain initially has water (limiting the time step) by specifying either 'zsini' or an 'inifile'.
 
 * When forcing waves, the bzifile time-series might contain too rapid changes in water level, the internal timesteps of SFINCS are too large. Possible solution: reduce timesteps by supplying a lower value of alpha (e.g. 0.5).

--- a/docs/parameters.rst
+++ b/docs/parameters.rst
@@ -415,6 +415,17 @@ Parameters for model output
 	  :description:		Flag to turn on writing away every timestep to output as debug mode (debug = 1)
 	  :units:		-
 	  :default:		0	
+	timestep_diagnostics
+	  :description:		Flag to write timestep limiter diagnostics to csv files (timestep_diagnostics = 1). Writes `timestep_diagnostics.csv` during the run and `timestep_diagnostics_domain.csv` at the end of the run. Reason codes: 0=wave-speed limited, 1=velocity limited, 2=dtmax cap.
+	  :units:		-
+	  :default:		0
+	  :min:			0
+	  :max:			1
+	dt_timestep_diagnostics
+	  :description:		Write interval (in seconds) for `timestep_diagnostics.csv`; set to 0 to write every timestep.
+	  :units:		s
+	  :default:		0
+	  :min:			0
 	percentage_done
 	  :description:		Setting of how frequent to show progress of SFINCS in terms of % and time remaining, default = 5%
 	  :units:		integer

--- a/source/src/sfincs_data.f90
+++ b/source/src/sfincs_data.f90
@@ -94,6 +94,7 @@ module sfincs_data
       real*4 wiggle_threshold
       real*4 uvlim
       real*4 uvmax
+      real*4 dt_timestep_diagnostics
       !real*4 normbnd
       !real*4 dzdsbnd
       !real*4 manningbnd
@@ -232,6 +233,8 @@ module sfincs_data
       logical       :: ampr_block
       logical       :: global
       logical       :: store_tsunami_arrival_time
+      logical       :: timestep_analysis
+      logical       :: timestep_diagnostics
       logical       :: viscosity
       logical       :: spinup_meteo
       logical       :: snapwave
@@ -551,6 +554,11 @@ module sfincs_data
       real*4, dimension(:),   allocatable, target :: qext
       real*4, dimension(:),   allocatable, target :: uorb
       real*4, dimension(:),   allocatable :: gnapp2
+      !
+      real*4, dimension(:),   allocatable :: average_timestep
+      real*4, dimension(:),   allocatable :: min_timestep
+      integer*4, dimension(:),   allocatable :: times_limiting
+      integer*4, dimension(:),   allocatable :: times_wet
       !
       real*4, dimension(:),   allocatable :: tauwu
       real*4, dimension(:),   allocatable :: tauwv
@@ -979,6 +987,10 @@ module sfincs_data
     if(allocated(uv)) deallocate(uv)
     if(allocated(uv0)) deallocate(uv0)
     if(allocated(twet)) deallocate(twet)
+    if(allocated(average_timestep)) deallocate(average_timestep)
+    if(allocated(min_timestep)) deallocate(min_timestep)
+    if(allocated(times_limiting)) deallocate(times_limiting)
+    if(allocated(times_wet)) deallocate(times_wet)
     if(allocated(qext)) deallocate(qext)
     !
 !    if(allocated(huu)) deallocate(huu)

--- a/source/src/sfincs_domain.f90
+++ b/source/src/sfincs_domain.f90
@@ -2076,8 +2076,8 @@ contains
          ! Spatially-varying infiltration with CN numbers (old)
          !
          inftype = 'cna'
-         infiltration = .true.      
-         store_cumulative_precipitation = .true.
+         infiltration = .true.
+         store_cumulative_precipitation = .true.      
          !
       elseif (sefffile /= 'none') then  
          !
@@ -2628,6 +2628,17 @@ contains
    !
    if (store_tsunami_arrival_time) then
       allocate(tsunami_arrival_time(np))
+   endif
+   !
+   if (timestep_analysis) then
+      allocate(average_timestep(np))
+      allocate(min_timestep(np))
+      allocate(times_limiting(np))
+      allocate(times_wet(np))
+      average_timestep = 0.0
+      times_wet = 0
+      times_limiting   = 0
+      min_timestep = dtmax
    endif
    !
    ! Set initial conditions (found in module sfincs_initial_conditions)

--- a/source/src/sfincs_input.f90
+++ b/source/src/sfincs_input.f90
@@ -20,14 +20,16 @@ contains
    integer iradstr
    integer igeo
    integer icoriolis
-   integer iamprblock
-   integer iglobal
-   integer itsunamitime
-   integer ispinupmeteo
-   integer isnapwave
-   integer iwindmax
-   integer iwind   
-   integer ioutfixed
+    integer iamprblock
+    integer iglobal
+    integer itsunamitime
+    integer itimestep_analysis
+    integer itimestep_diagnostics
+    integer ispinupmeteo
+    integer isnapwave
+    integer iwindmax
+    integer iwind   
+    integer ioutfixed
    integer iadvection
    integer istorefw
    integer istorewavdir   
@@ -116,8 +118,8 @@ contains
    call read_int_input(500,'dtoutfixed', ioutfixed, 1)
    call read_real_input(500,'wmtfilter',wmtfilter,600.0)
    call read_real_input(500,'wmfred',wavemaker_freduv,0.99)
-   call read_char_input(500,'wmsignal',wmsigstr,'spectrum')   
-   call read_real_input(500, 'wmhmin', wavemaker_hmin, 0.1)
+   call read_char_input(500,'wmsignal',wmsigstr,'spectrum')
+   call read_real_input(500, 'wmhmin', wavemaker_hmin, 0.1)   
    call read_char_input(500,'advection_scheme',advstr,'upw1')   
    call read_real_input(500,'btrelax',btrelax,3600.0)
    call read_logical_input(500,'wiggle_suppression', wiggle_suppression, .true.)
@@ -224,12 +226,15 @@ contains
    call read_logical_input(500, 'storehmean', store_hmean, .false.)      
    call read_real_input(500,'twet_threshold',twet_threshold,0.01)
    call read_int_input(500,'store_tsunami_arrival_time',itsunamitime,0)
-   call read_real_input(500,'tsunami_arrival_threshold',tsunami_arrival_threshold,0.01)
-   call read_int_input(500,'storeqdrain',storeqdrain,1)
-   call read_int_input(500,'storezvolume',storezvolume,0)
-   call read_int_input(500,'storestoragevolume',storestoragevolume,0)
-   call read_int_input(500,'writeruntime',wrttimeoutput,0)
-   call read_logical_input(500,'debug',debug,.false.)
+    call read_real_input(500,'tsunami_arrival_threshold',tsunami_arrival_threshold,0.01)
+    call read_int_input(500,'timestep_analysis',itimestep_analysis,0)
+    call read_int_input(500,'timestep_diagnostics',itimestep_diagnostics,0)
+    call read_real_input(500,'dt_timestep_diagnostics',dt_timestep_diagnostics,0.0)
+    call read_int_input(500,'storeqdrain',storeqdrain,1)
+    call read_int_input(500,'storezvolume',storezvolume,0)
+    call read_int_input(500,'storestoragevolume',storestoragevolume,0)
+    call read_int_input(500,'writeruntime',wrttimeoutput,0)
+    call read_logical_input(500,'debug',debug,.false.)
    call read_int_input(500,'storemeteo',storemeteo,0)
    call read_int_input(500,'storemaxwind',iwindmax,0)
    call read_int_input(500,'storefw', istorefw, 0)
@@ -278,7 +283,6 @@ contains
    if (dtmapout==0.0) then
       call read_real_input(500,'dtmapout',dtmapout,0.0)
    endif   
-   !
    close(500)
    !
    ! Check whether epsg code has been specified:
@@ -516,8 +520,19 @@ contains
       store_tsunami_arrival_time = .true.
    endif      
    !
-   !   
-   viscosity = .false. 
+    timestep_analysis = .false. 
+    if (itimestep_analysis==1) then
+       timestep_analysis = .true.
+    endif      
+    !
+    timestep_diagnostics = .false.
+    if (itimestep_diagnostics==1) then
+       timestep_diagnostics = .true.
+    endif
+    dt_timestep_diagnostics = max(dt_timestep_diagnostics, 0.0)
+    !
+    !   
+    viscosity = .false. 
    if (iviscosity) then
       viscosity = .true. 
       call write_log('Info    : turning on process: Viscosity', 0)

--- a/source/src/sfincs_ncoutput.F90
+++ b/source/src/sfincs_ncoutput.F90
@@ -21,7 +21,7 @@ module sfincs_ncoutput
       integer :: patm_varid, wind_u_varid, wind_v_varid, precip_varid        
       integer :: hm0_varid, hm0ig_varid, snapwavemsk_varid, tp_varid, tpig_varid, wavdir_varid, dirspr_varid
       integer :: fwx_varid, fwy_varid, beta_varid, snapwavedepth_varid
-      integer :: zsm_varid, tsunami_arrival_time_varid
+      integer :: zsm_varid, tsunami_arrival_time_varid, average_timestep_varid, times_limiting_varid
       integer :: inp_varid, total_runtime_varid, average_dt_varid, status_varid
       integer :: pnonh_varid
       integer :: subgridslope_varid
@@ -627,6 +627,28 @@ contains
       NF90(nf90_put_att(map_file%ncid, map_file%tsunami_arrival_time_varid, 'long_name', 'tsunami_arrival_time')) 
       NF90(nf90_put_att(map_file%ncid, map_file%tsunami_arrival_time_varid, 'coordinates', 'x y'))   
       NF90(nf90_def_var_deflate(map_file%ncid, map_file%tsunami_arrival_time_varid, 1, 1, nc_deflate_level)) ! deflate
+      !
+   endif
+   !
+   if (timestep_analysis) then
+      ! 
+      ! Average time step
+      NF90(nf90_def_var(map_file%ncid, 'average_timestep', NF90_FLOAT, (/map_file%m_dimid, map_file%n_dimid, map_file%time_dimid/), map_file%average_timestep_varid))
+      NF90(nf90_put_att(map_file%ncid, map_file%average_timestep_varid, '_FillValue', FILL_VALUE))      
+      NF90(nf90_put_att(map_file%ncid, map_file%average_timestep_varid, 'units', 's'))
+      NF90(nf90_put_att(map_file%ncid, map_file%average_timestep_varid, 'standard_name', 'average_timestep'))
+      NF90(nf90_put_att(map_file%ncid, map_file%average_timestep_varid, 'long_name', 'average_timestep')) 
+      NF90(nf90_put_att(map_file%ncid, map_file%average_timestep_varid, 'coordinates', 'x y'))   
+      NF90(nf90_def_var_deflate(map_file%ncid, map_file%average_timestep_varid, 1, 1, nc_deflate_level)) ! deflate
+      !
+      ! Times limiting
+      NF90(nf90_def_var(map_file%ncid, 'times_limiting', NF90_FLOAT, (/map_file%m_dimid, map_file%n_dimid, map_file%time_dimid/), map_file%times_limiting_varid))
+      NF90(nf90_put_att(map_file%ncid, map_file%times_limiting_varid, '_FillValue', FILL_VALUE))      
+      NF90(nf90_put_att(map_file%ncid, map_file%times_limiting_varid, 'units', '-'))
+      NF90(nf90_put_att(map_file%ncid, map_file%times_limiting_varid, 'standard_name', 'times_limiting'))
+      NF90(nf90_put_att(map_file%ncid, map_file%times_limiting_varid, 'long_name', 'number_of_times_cell_was_limiting_timestep')) 
+      NF90(nf90_put_att(map_file%ncid, map_file%times_limiting_varid, 'coordinates', 'x y'))   
+      NF90(nf90_def_var_deflate(map_file%ncid, map_file%times_limiting_varid, 1, 1, nc_deflate_level)) ! deflate
       !
    endif
    !
@@ -1323,6 +1345,25 @@ contains
       NF90(nf90_put_att(map_file%ncid, map_file%tsunami_arrival_time_varid, 'long_name', 'tsunami_arrival_time')) 
       NF90(nf90_def_var_deflate(map_file%ncid, map_file%tsunami_arrival_time_varid, 1, 1, nc_deflate_level)) ! deflate
       !
+   endif
+   !
+   if (timestep_analysis) then
+      ! 
+      ! Average time step
+      NF90(nf90_def_var(map_file%ncid, 'average_timestep', NF90_FLOAT, (/map_file%nmesh2d_face_dimid, map_file%time_dimid/), map_file%average_timestep_varid))       
+      NF90(nf90_put_att(map_file%ncid, map_file%average_timestep_varid, '_FillValue', FILL_VALUE))      
+      NF90(nf90_put_att(map_file%ncid, map_file%average_timestep_varid, 'units', 's'))
+      NF90(nf90_put_att(map_file%ncid, map_file%average_timestep_varid, 'standard_name', 'average_timestep'))
+      NF90(nf90_put_att(map_file%ncid, map_file%average_timestep_varid, 'long_name', 'average_timestep')) 
+      NF90(nf90_def_var_deflate(map_file%ncid, map_file%average_timestep_varid, 1, 1, nc_deflate_level)) ! deflate
+      !
+      ! Times limiting
+      NF90(nf90_def_var(map_file%ncid, 'times_limiting', NF90_FLOAT, (/map_file%nmesh2d_face_dimid, map_file%time_dimid/), map_file%times_limiting_varid))       
+      NF90(nf90_put_att(map_file%ncid, map_file%times_limiting_varid, '_FillValue', FILL_VALUE))      
+      NF90(nf90_put_att(map_file%ncid, map_file%times_limiting_varid, 'units', '-'))
+      NF90(nf90_put_att(map_file%ncid, map_file%times_limiting_varid, 'standard_name', 'times_limiting'))
+      NF90(nf90_put_att(map_file%ncid, map_file%times_limiting_varid, 'long_name', 'number_of_times_cell_was_limiting_timestep')) 
+      NF90(nf90_def_var_deflate(map_file%ncid, map_file%times_limiting_varid, 1, 1, nc_deflate_level)) ! deflate
    endif
    !   
    if (infiltration) then
@@ -3353,6 +3394,31 @@ contains
       NF90(nf90_put_var(map_file%ncid, map_file%tmax_varid, zstmp, (/1, 1, ntmaxout/))) ! write tmax   
    endif
    !
+   ! Timestep analysis
+   if (timestep_analysis) then
+      ! 
+      ! Average time step
+      zstmp = FILL_VALUE
+      do nm = 1, np
+         if (average_timestep(nm) > 0.0) then
+             n              = z_index_z_n(nm)
+             m              = z_index_z_m(nm)
+             zstmp(m, n)    = average_timestep(nm) 
+         endif
+      enddo
+      NF90(nf90_put_var(map_file%ncid, map_file%average_timestep_varid, zstmp, (/1, 1, ntmaxout/))) ! write average_timestep   
+      ! 
+      ! Times limiting
+      zstmp = FILL_VALUE
+      do nm = 1, np
+        n              = z_index_z_n(nm)
+        m              = z_index_z_m(nm)
+        zstmp(m, n)    = real(times_limiting(nm))
+      enddo
+      NF90(nf90_put_var(map_file%ncid, map_file%times_limiting_varid, zstmp, (/1, 1, ntmaxout/))) ! write times limiting
+      !
+   endif
+   !
    ! When zsmax => t
    !
    if (store_t_zsmax) then
@@ -3558,6 +3624,34 @@ contains
            endif
        enddo
       NF90(nf90_put_var(map_file%ncid, map_file%tmax_varid, zstmp, (/1, ntmaxout/))) ! write twet   
+   endif
+   !
+   ! Time step analysis
+   if (timestep_analysis) then
+    !
+    ! Average time
+    zstmp = FILL_VALUE       
+    do nmq = 1, quadtree_nr_points
+        nm = index_sfincs_in_quadtree(nmq)
+        if (nm>0) then                                 
+            if (kcs(nm)>0 .and. average_timestep(nm) > 0.0) then
+                zstmp(nmq) = average_timestep(nm)
+            endif
+        endif
+    enddo
+    NF90(nf90_put_var(map_file%ncid, map_file%average_timestep_varid, zstmp, (/1, ntmaxout/))) ! write average_timestep   
+    !
+    ! Times limitings
+    zstmp = FILL_VALUE       
+    do nmq = 1, quadtree_nr_points
+        nm = index_sfincs_in_quadtree(nmq)
+        if (nm>0) then                                 
+            if (kcs(nm)>0 .and. times_limiting(nm) > 0) then
+                zstmp(nmq) = real(times_limiting(nm))
+            endif
+        endif
+    enddo
+    NF90(nf90_put_var(map_file%ncid, map_file%times_limiting_varid, zstmp, (/1, ntmaxout/))) ! write times_limiting   
    endif
    !
    ! When zsmax occured
@@ -3865,8 +3959,8 @@ contains
         ! SnapWave related:
         !
         NF90(nf90_put_att(ncid, varid, 'snapwave', logical2int(snapwave))) 
-        NF90(nf90_put_att(ncid, varid, 'snapwave_gamma', gamma)) 
-        NF90(nf90_put_att(ncid, varid, 'snapwave_gammax', gammax))         
+        NF90(nf90_put_att(ncid, varid, 'snapwave_gamma', gamma))
+        NF90(nf90_put_att(ncid, varid, 'snapwave_gammax', gammax))
         NF90(nf90_put_att(ncid, varid, 'snapwave_alpha', alpha)) 
         NF90(nf90_put_att(ncid, varid, 'snapwave_hmin',hmin)) 
         NF90(nf90_put_att(ncid, varid, 'snapwave_fw',fw0)) 

--- a/source/src/sfincs_output.f90
+++ b/source/src/sfincs_output.f90
@@ -332,11 +332,20 @@ module sfincs_output
       if (store_cumulative_precipitation) then
           open(unit = 903, file = 'cumprcp.txt')
       endif      
+      if (timestep_analysis) then
+         open(unit = 909, file = 'average_timestep.txt')
+         open(unit = 910, file = 'times_limiting.txt')
+      endif
    else
       open(unit = 900, status = 'replace', file = 'zs.dat', form = 'unformatted')
       !
       if (store_zvolume) then
-        open(unit = 908, status = 'replace', file = 'z_volume.dat', form = 'unformatted')
+         open(unit = 908, status = 'replace', file = 'z_volume.dat', form = 'unformatted')
+      endif
+      !
+      if (timestep_analysis) then
+         open(unit = 909, status = 'replace', file = 'average_timestep.dat', form = 'unformatted')
+         open(unit = 910, status = 'replace', file = 'times_limiting.dat', form = 'unformatted')
       endif
    endif
    !
@@ -458,6 +467,10 @@ module sfincs_output
           write(908)z_volume
       endif
       !
+      if (timestep_analysis) then
+         write(909)average_timestep
+         write(910)times_limiting
+      endif
 !   endif
    !
    end subroutine
@@ -535,12 +548,23 @@ module sfincs_output
    implicit none
    !
    if (dtmapout>1.e-6) then
-      close(900)
-      close(901)
-      close(902)
+      if (trim(outputtype_map) == 'asc') then
+         close(900)
+         close(901)
+         close(902)
+         if (store_cumulative_precipitation) then
+            close(903)
+         endif
+      else
+         close(900)
+         if (store_zvolume) then
+            close(908)
+         endif
+      endif
       !
-      if (store_zvolume) then
-         close(908)
+      if (timestep_analysis) then
+         close(909)
+         close(910)
       endif
    endif   
    !

--- a/source/src/sfincs_timestep_diagnostics.f90
+++ b/source/src/sfincs_timestep_diagnostics.f90
@@ -1,0 +1,463 @@
+module sfincs_timestep_diagnostics
+   !
+   use sfincs_data
+   use sfincs_log
+   !
+   implicit none
+   !
+   integer, parameter :: UNIT_TIMESTEP_DIAGNOSTICS = 971
+   !
+   logical, save :: timestep_diag_initialized = .false.
+   real*8,  save :: timestep_diag_next_write_time = 0.0d0
+   !
+   integer*4, save :: timestep_diag_total_steps = 0
+   integer*4, save :: timestep_diag_dtmax_steps = 0
+   !
+   integer*4, dimension(:), allocatable, save :: timestep_diag_times_limiting_uv
+   integer*4, dimension(:), allocatable, save :: timestep_diag_times_limiting_wave
+   integer*4, dimension(:), allocatable, save :: timestep_diag_times_limiting_vel
+   real*4,    dimension(:), allocatable, save :: timestep_diag_min_limited_dt_uv
+   !
+contains
+   !
+   subroutine timestep_diagnostics_initialize()
+   !
+   implicit none
+   !
+   if (.not. timestep_diagnostics) then
+      return
+   endif
+   !
+   if (timestep_diag_initialized) then
+      return
+   endif
+   !
+   timestep_diag_total_steps = 0
+   timestep_diag_dtmax_steps = 0
+   !
+   allocate(timestep_diag_times_limiting_uv(npuv))
+   allocate(timestep_diag_times_limiting_wave(npuv))
+   allocate(timestep_diag_times_limiting_vel(npuv))
+   allocate(timestep_diag_min_limited_dt_uv(npuv))
+   !
+   timestep_diag_times_limiting_uv   = 0
+   timestep_diag_times_limiting_wave = 0
+   timestep_diag_times_limiting_vel  = 0
+   timestep_diag_min_limited_dt_uv   = 1.0e30
+   !
+   timestep_diag_next_write_time = real(t0, kind(timestep_diag_next_write_time))
+   !
+   open(unit = UNIT_TIMESTEP_DIAGNOSTICS, status = 'replace', file = 'timestep_diagnostics.csv')
+   write(UNIT_TIMESTEP_DIAGNOSTICS,'(a)') &
+      'nt,t,dt_used,dt_next,min_dt,dt_uv_min,reason,ip,nm,nmu,x,y,hu,abs_uv,c_wave,dx,iref,itype,idir'
+   !
+   timestep_diag_initialized = .true.
+   !
+   call write_log('Info    : timestep diagnostics enabled (timestep_diagnostics.csv, timestep_diagnostics_domain.csv)', 0)
+   !
+   end subroutine
+   !
+   subroutine timestep_diagnostics_update(nt, t, dt_used)
+   !
+   integer, intent(in) :: nt
+   real*8, intent(in) :: t
+   real*4, intent(in) :: dt_used
+   !
+   integer*4 :: ip_lim, nm_lim, nmu_lim
+   integer*4 :: iref_lim, itype_lim, idir_lim
+   integer*4 :: reason
+   real*4    :: dt_uv_min
+   real*4    :: hu_lim, abs_uv_lim, c_wave_lim, dx_lim
+   real*4    :: x_lim, y_lim
+   real*4    :: dt_next
+   !
+   if (.not. timestep_diagnostics .and. .not. timestep_analysis) then
+      return
+   endif
+   !
+   if (timestep_diagnostics) then
+      if (.not. timestep_diag_initialized) then
+         call timestep_diagnostics_initialize()
+      endif
+   endif
+   !
+   !$acc update host(zs, uv)
+   !
+   call find_timestep_limiter_uv(dt_uv_min, reason, ip_lim, nm_lim, nmu_lim, x_lim, y_lim, hu_lim, abs_uv_lim, &
+                                 c_wave_lim, dx_lim, iref_lim, itype_lim, idir_lim, timestep_analysis, timestep_diagnostics)
+   !
+   if (timestep_diagnostics) then
+      timestep_diag_total_steps = timestep_diag_total_steps + 1
+      !
+      if (reason == 2) then
+         timestep_diag_dtmax_steps = timestep_diag_dtmax_steps + 1
+      else
+         timestep_diag_times_limiting_uv(ip_lim) = timestep_diag_times_limiting_uv(ip_lim) + 1
+         if (reason == 0) then
+            timestep_diag_times_limiting_wave(ip_lim) = timestep_diag_times_limiting_wave(ip_lim) + 1
+         elseif (reason == 1) then
+            timestep_diag_times_limiting_vel(ip_lim) = timestep_diag_times_limiting_vel(ip_lim) + 1
+         endif
+         timestep_diag_min_limited_dt_uv(ip_lim) = min(timestep_diag_min_limited_dt_uv(ip_lim), min_dt)
+      endif
+   endif
+   !
+   dt_next = alfa * min_dt
+   !
+   if (timestep_diagnostics) then
+      if (dt_timestep_diagnostics <= 0.0) then
+         call write_timestep_diagnostics_line(nt, t, dt_used, dt_next, dt_uv_min, reason, ip_lim, nm_lim, nmu_lim, &
+                                              x_lim, y_lim, hu_lim, abs_uv_lim, c_wave_lim, dx_lim, &
+                                              iref_lim, itype_lim, idir_lim)
+      else
+         if (t + 1.0d-9 >= timestep_diag_next_write_time) then
+            call write_timestep_diagnostics_line(nt, t, dt_used, dt_next, dt_uv_min, reason, ip_lim, nm_lim, nmu_lim, &
+                                                 x_lim, y_lim, hu_lim, abs_uv_lim, c_wave_lim, dx_lim, &
+                                                 iref_lim, itype_lim, idir_lim)
+            do while (t + 1.0d-9 >= timestep_diag_next_write_time)
+               timestep_diag_next_write_time = timestep_diag_next_write_time + &
+                                               real(dt_timestep_diagnostics, kind(timestep_diag_next_write_time))
+            end do
+         endif
+      endif
+   endif
+   !
+   if (timestep_analysis) then
+      call update_timestep_analysis(dt_next)
+   endif
+   !
+   end subroutine
+   !
+   subroutine timestep_diagnostics_finalize()
+   !
+   implicit none
+   !
+   integer*4 :: ip, nm, nmu
+   real*4    :: xuv, yuv
+   real*4    :: dt_min_alpha
+   !
+   if (.not. timestep_diagnostics) then
+      return
+   endif
+   !
+   if (timestep_diag_initialized) then
+      close(UNIT_TIMESTEP_DIAGNOSTICS)
+   endif
+   !
+   open(unit = UNIT_TIMESTEP_DIAGNOSTICS + 1, status = 'replace', file = 'timestep_diagnostics_domain.csv')
+   write(UNIT_TIMESTEP_DIAGNOSTICS + 1,'(a)') &
+      'ip,nm,nmu,x,y,times_limiting,times_limiting_wave,times_limiting_vel,dt_min,min_dt_min'
+   !
+   if (timestep_diag_dtmax_steps > 0) then
+      dt_min_alpha = alfa * dtmax
+      write(UNIT_TIMESTEP_DIAGNOSTICS + 1,'(i0,a,i0,a,i0,a,es16.8,a,es16.8,a,i0,a,i0,a,i0,a,es16.8,a,es16.8)') &
+         0, ',', 0, ',', 0, ',', 0.0, ',', 0.0, ',', timestep_diag_dtmax_steps, ',', 0, ',', 0, ',', dt_min_alpha, ',', dtmax
+   endif
+   !
+   do ip = 1, npuv
+      if (timestep_diag_times_limiting_uv(ip) <= 0) then
+         cycle
+      endif
+      nm  = uv_index_z_nm(ip)
+      nmu = uv_index_z_nmu(ip)
+      xuv = 0.5 * (z_xz(nm) + z_xz(nmu))
+      yuv = 0.5 * (z_yz(nm) + z_yz(nmu))
+      dt_min_alpha = alfa * timestep_diag_min_limited_dt_uv(ip)
+      write(UNIT_TIMESTEP_DIAGNOSTICS + 1,'(i0,a,i0,a,i0,a,es16.8,a,es16.8,a,i0,a,i0,a,i0,a,es16.8,a,es16.8)') &
+         ip, ',', nm, ',', nmu, ',', xuv, ',', yuv, ',', timestep_diag_times_limiting_uv(ip), ',', &
+         timestep_diag_times_limiting_wave(ip), ',', timestep_diag_times_limiting_vel(ip), ',', dt_min_alpha, ',', &
+         timestep_diag_min_limited_dt_uv(ip)
+   enddo
+   !
+   close(UNIT_TIMESTEP_DIAGNOSTICS + 1)
+   !
+   if (allocated(timestep_diag_times_limiting_uv)) deallocate(timestep_diag_times_limiting_uv)
+   if (allocated(timestep_diag_times_limiting_wave)) deallocate(timestep_diag_times_limiting_wave)
+   if (allocated(timestep_diag_times_limiting_vel)) deallocate(timestep_diag_times_limiting_vel)
+   if (allocated(timestep_diag_min_limited_dt_uv)) deallocate(timestep_diag_min_limited_dt_uv)
+   !
+   timestep_diag_initialized = .false.
+   !
+   end subroutine
+   !
+   subroutine write_timestep_diagnostics_line(nt, t, dt_used, dt_next, dt_uv_min, reason, ip_lim, nm_lim, nmu_lim, x_lim, y_lim, &
+                                              hu_lim, abs_uv_lim, c_wave_lim, dx_lim, iref_lim, itype_lim, idir_lim)
+   !
+   integer, intent(in) :: nt
+   real*8,  intent(in) :: t
+   real*4,  intent(in) :: dt_used
+   real*4,  intent(in) :: dt_next
+   real*4,  intent(in) :: dt_uv_min
+   integer*4, intent(in) :: reason, ip_lim, nm_lim, nmu_lim, iref_lim, itype_lim, idir_lim
+   real*4,  intent(in) :: x_lim, y_lim, hu_lim, abs_uv_lim, c_wave_lim, dx_lim
+   !
+   write(UNIT_TIMESTEP_DIAGNOSTICS,'(i0,a,es16.8,a,es16.8,a,es16.8,a,es16.8,a,es16.8,a,i0,a,i0,a,i0,a,i0,a,es16.8,a,&
+&es16.8,a,es16.8,a,es16.8,a,es16.8,a,es16.8,a,i0,a,i0,a,i0)') &
+      nt, ',', t, ',', dt_used, ',', dt_next, ',', min_dt, ',', dt_uv_min, ',', reason, ',', ip_lim, ',', nm_lim, ',', &
+      nmu_lim, ',', x_lim, ',', y_lim, ',', hu_lim, ',', abs_uv_lim, ',', c_wave_lim, ',', dx_lim, ',', iref_lim, ',', &
+      itype_lim, ',', idir_lim
+   !
+   end subroutine
+   !
+   subroutine find_timestep_limiter_uv(dt_uv_min, reason, ip_lim, nm_lim, nmu_lim, x_lim, y_lim, hu_lim, abs_uv_lim, &
+                                       c_wave_lim, dx_lim, iref_lim, itype_lim, idir_lim, compute_cell_mins, &
+                                       compute_limiter_details)
+   !
+   real*4,    intent(out) :: dt_uv_min
+   integer*4, intent(out) :: reason, ip_lim, nm_lim, nmu_lim
+   real*4,    intent(out) :: x_lim, y_lim, hu_lim, abs_uv_lim, c_wave_lim, dx_lim
+   integer*4, intent(out) :: iref_lim, itype_lim, idir_lim
+   logical,   intent(in)  :: compute_cell_mins
+   logical,   intent(in)  :: compute_limiter_details
+   !
+   integer*4 :: ip, nm, nmu
+   integer*4 :: iref, itype, idir
+   integer*4 :: iuv
+   real*4    :: zsu
+   real*4    :: zmin, zmax
+   real*4    :: dzuv, facint
+   real*4    :: hu
+   real*4    :: dxuvinv
+   real*4    :: absu, cwave, speed, dtip
+   logical   :: iok
+   real*4    :: best_dt_uv
+   !
+   best_dt_uv = 1.0e30
+   ip_lim     = 0
+   nm_lim     = 0
+   nmu_lim    = 0
+   reason     = 2
+   dt_uv_min  = -1.0
+   x_lim      = 0.0
+   y_lim      = 0.0
+   hu_lim     = 0.0
+   abs_uv_lim = 0.0
+   c_wave_lim = 0.0
+   dx_lim     = 0.0
+   iref_lim   = 0
+   itype_lim  = 0
+   idir_lim   = 0
+   !
+   if (.not. compute_cell_mins .and. .not. compute_limiter_details) then
+      return
+   endif
+   !
+   if (compute_cell_mins) then
+      if (allocated(min_timestep)) then
+         min_timestep = 1.0e30
+      endif
+   endif
+   !
+   do ip = 1, npuv
+      !
+      if (.not. (kcuv(ip) == 1 .or. kcuv(ip) == 6)) then
+         cycle
+      endif
+      !
+      nm  = uv_index_z_nm(ip)
+      nmu = uv_index_z_nmu(ip)
+      !
+      zsu = max(real(zs(nm), kind(zsu)), real(zs(nmu), kind(zsu)))
+      !
+      iok = .false.
+      !
+      if (subgrid) then
+         zmin = subgrid_uv_zmin(ip)
+         if (zsu > zmin + huthresh) then
+            iok = .true.
+         endif
+      else
+         if (zsu > zbuvmx(ip)) then
+            iok = .true.
+         endif
+      endif
+      !
+      if (.not. iok) then
+         cycle
+      endif
+      !
+      if (use_quadtree) then
+         iref  = uv_flags_iref(ip)
+         itype = uv_flags_type(ip)
+      else
+         iref  = 1
+         itype = 0
+      endif
+      !
+      idir = uv_flags_dir(ip)
+      !
+      if (crsgeo) then
+         !
+         if (itype == 0) then
+            if (idir == 0) then
+               dxuvinv = dxminv(ip)
+            else
+               dxuvinv = dyrinv(iref)
+            endif
+         else
+            if (idir == 0) then
+               dxuvinv = 1.0 / (3*(1.0/dxminv(ip))/2)
+            else
+               dxuvinv = 1.0 / (3*(1.0/dyrinv(iref))/2)
+            endif
+         endif
+         !
+      else
+         !
+         if (itype == 0) then
+            if (idir == 0) then
+               dxuvinv = dxrinv(iref)
+            else
+               dxuvinv = dyrinv(iref)
+            endif
+         else
+            if (idir == 0) then
+               dxuvinv = dxrinvc(iref)
+            else
+               dxuvinv = dyrinvc(iref)
+            endif
+         endif
+         !
+      endif
+      !
+      if (subgrid) then
+         !
+         zmax = subgrid_uv_zmax(ip)
+         !
+         if (zsu > zmax) then
+            hu = subgrid_uv_havg_zmax(ip) + zsu
+         else
+            dzuv = (zmax - zmin) / (subgrid_nlevels - 1)
+            iuv = min(int((zsu - zmin) / dzuv) + 1, subgrid_nlevels - 1)
+            facint = (zsu - (zmin + (iuv - 1) * dzuv) ) / dzuv
+            hu = subgrid_uv_havg(iuv, ip) + (subgrid_uv_havg(iuv + 1, ip) - subgrid_uv_havg(iuv, ip)) * facint
+         endif
+         !
+      else
+         !
+         hu = max(zsu - zbuvmx(ip), huthresh)
+         !
+      endif
+      !
+      absu  = abs(uv(ip))
+      cwave = sqrt(g * hu)
+      speed = max(cwave, absu)
+      !
+      dtip = 1.0 / (speed * dxuvinv)
+      !
+      if (compute_cell_mins) then
+         if (allocated(min_timestep)) then
+            min_timestep(nm)  = min(min_timestep(nm),  dtip)
+            min_timestep(nmu) = min(min_timestep(nmu), dtip)
+         endif
+      endif
+      !
+      if (.not. compute_limiter_details) then
+         cycle
+      endif
+      !
+      if (dtip < best_dt_uv) then
+         best_dt_uv = dtip
+         ip_lim     = ip
+         nm_lim     = nm
+         nmu_lim    = nmu
+         x_lim      = 0.5 * (z_xz(nm) + z_xz(nmu))
+         y_lim      = 0.5 * (z_yz(nm) + z_yz(nmu))
+         hu_lim     = hu
+         abs_uv_lim = absu
+         c_wave_lim = cwave
+         dx_lim     = 1.0 / dxuvinv
+         iref_lim   = iref
+         itype_lim  = itype
+         idir_lim   = idir
+         if (cwave >= absu) then
+            reason = 0
+         else
+            reason = 1
+         endif
+      endif
+      !
+   enddo
+   !
+   if (.not. compute_limiter_details) then
+      return
+   endif
+   !
+   if (ip_lim > 0) then
+      dt_uv_min = best_dt_uv
+   endif
+   !
+   if (ip_lim <= 0) then
+      reason = 2
+      return
+   endif
+   !
+   if (best_dt_uv > dtmax + max(1.0e-12, 1.0e-6 * dtmax)) then
+      reason  = 2
+      ip_lim  = 0
+      nm_lim  = 0
+      nmu_lim = 0
+      x_lim   = 0.0
+      y_lim   = 0.0
+      hu_lim  = 0.0
+      abs_uv_lim = 0.0
+      c_wave_lim = 0.0
+      dx_lim     = 0.0
+      iref_lim   = 0
+      itype_lim  = 0
+      idir_lim   = 0
+   endif
+   !
+   end subroutine
+   !
+   subroutine update_timestep_analysis(dt_next)
+   !
+   real*4, intent(in) :: dt_next
+   !
+   integer*4 :: nm
+   integer*4 :: count_wet
+   real*4    :: dt_cell
+   real*4    :: dt_tol
+   !
+   if (.not. timestep_analysis) then
+      return
+   endif
+   !
+   if (.not. allocated(min_timestep)) then
+      return
+   endif
+   if (.not. allocated(average_timestep)) then
+      return
+   endif
+   if (.not. allocated(times_wet)) then
+      return
+   endif
+   if (.not. allocated(times_limiting)) then
+      return
+   endif
+   !
+   dt_tol = max(1.0e-12, 1.0e-6 * max(dt_next, 1.0e-12))
+   !
+   do nm = 1, np
+      !
+      if (min_timestep(nm) > 1.0e29) then
+         min_timestep(nm) = 0.0
+         cycle
+      endif
+      !
+      dt_cell = alfa * min_timestep(nm)
+      !
+      count_wet = times_wet(nm) + 1
+      times_wet(nm) = count_wet
+      !
+      average_timestep(nm) = average_timestep(nm) + (dt_cell - average_timestep(nm)) / real(count_wet, kind(average_timestep))
+      !
+      if (dt_cell <= dt_next + dt_tol) then
+         times_limiting(nm) = times_limiting(nm) + 1
+      endif
+      !
+   enddo
+   !
+   end subroutine
+   !
+end module sfincs_timestep_diagnostics


### PR DESCRIPTION
I combined the timestep analysis idea from #267/#280 with my timestep diagnostics implementation.

Main changes:
- The limiting determination is now done outside the parallel momentum loop (after compute_fluxes) in `sfincs_timestep_diagnostics.f90`
- `timestep_analysis` produces the NetCDF map variables `average_timestep` and `times_limiting` (with `coordinates = "x y"`).
- Diagnostics outputs include x/y for the limiting UV point, and the dtmax-cap case is explicitly reported as `reason=2` (ip/nm/nmu/x/y set to 0).

I rebuilt and ran short CPU tests (diag off/on, every/interval writes, analysis on, and dtmax-cap). All runs completed cleanly and outputs look consistent.

Inputs/Outputs
- Inputs (sfincs.inp):
  - `timestep_diagnostics` (0/1)
  - `dt_timestep_diagnostics` (s; 0 = every timestep)
  - `timestep_analysis` (0/1)
- Outputs when `timestep_diagnostics=1`:
  - `timestep_diagnostics.csv`
  - `timestep_diagnostics_domain.csv`
- Outputs when `timestep_analysis=1` (netcdf map):
  - `average_timestep`
  - `times_limiting`

Edge cases handled
- When `dtmax` is limiting, diagnostics report `reason=2` with limiter metadata set to zero.

Best,
Egemen