### PR TITLE
docs: update input.rst wrt info on storage volumes

### DIFF
--- a/docs/input.rst
+++ b/docs/input.rst
@@ -537,6 +537,8 @@ Storage volume
 Storage volume for green infrastructure on the 2D grid, specifies the maximum storage volume of water per grid cell in cubic meters.
 Water will be stored in this storage volume before it will contribute to surface runoff.
 
+**NOTE - Only useable in subgrid mode (on either regular or quadtree grid)**
+
 **volfile = sfincs.vol**
 
 .. code-block:: text


### PR DESCRIPTION
Dear SFINCS dev-team,

Update the documentation on storage volumes which works on both quadtree and regular grids if I understand well from the latest SFINCS release. Plus fix some typos.

Keep on the good work!