### PR TITLE
Fix uninitialized nm used instead of nmb in update_boundary_fluxes

### DIFF
--- a/source/src/sfincs_boundaries.f90
+++ b/source/src/sfincs_boundaries.f90
@@ -1106,7 +1106,7 @@ contains
             !
             if (store_t_zsmax) then
                 if (zs(nmb) > zsmax(nmb)) then
-                    t_zsmax(nm) = t
+                    t_zsmax(nmb) = t
                 endif
             endif
             !


### PR DESCRIPTION
In subroutine update_boundary_fluxes (sfincs_boundaries.f90, ~line 1109), t_zsmax(nm) was written using the declared-but-never-assigned scalar nm instead of the loop index nmb. This caused a write to a garbage array index when store_t_zsmax was active with boundary conditions, leading to potential memory corruption.

Fix: replace t_zsmax(nm) with t_zsmax(nmb).

The OpenMP PRIVATE clause already lists nmb correctly; no change needed there.