### PR TITLE
Fix 32-bit integer overflow in subroutine timing and use omp_get_wtime() in sfincs_lib

### DIFF
--- a/source/src/sfincs_advection_diffusion.f90
+++ b/source/src/sfincs_advection_diffusion.f90
@@ -10,10 +10,10 @@ contains
    !
    implicit none
    !
-   integer   :: count0
-   integer   :: count1
-   integer   :: count_rate
-   integer   :: count_max
+   integer*8 :: count0
+   integer*8 :: count1
+   integer*8 :: count_rate
+   integer*8 :: count_max
    real      :: tloop
    !
    real*4    :: dt

--- a/source/src/sfincs_bathtub.f90
+++ b/source/src/sfincs_bathtub.f90
@@ -121,10 +121,10 @@ contains
    !
    implicit none
    !
-   integer  :: count0
-   integer  :: count1
-   integer  :: count_rate
-   integer  :: count_max
+   integer*8 :: count0
+   integer*8 :: count1
+   integer*8 :: count_rate
+   integer*8 :: count_max
    real     :: tloop
    !
    integer :: nm, i1, i2

--- a/source/src/sfincs_boundaries.f90
+++ b/source/src/sfincs_boundaries.f90
@@ -1133,10 +1133,10 @@ contains
    !
    implicit none
    !
-   integer  :: count0
-   integer  :: count1
-   integer  :: count_rate
-   integer  :: count_max
+   integer*8 :: count0
+   integer*8 :: count1
+   integer*8 :: count_rate
+   integer*8 :: count_max
    real     :: tloop
    !
    real*8           :: t

--- a/source/src/sfincs_continuity.f90
+++ b/source/src/sfincs_continuity.f90
@@ -11,10 +11,10 @@ contains
    real*4           :: dt
    real*8           :: t
    !
-   integer          :: count0
-   integer          :: count1
-   integer          :: count_rate
-   integer          :: count_max
+   integer*8        :: count0
+   integer*8        :: count1
+   integer*8        :: count_rate
+   integer*8        :: count_max
    real             :: tloop
    !
    call system_clock(count0, count_rate, count_max)

--- a/source/src/sfincs_date.f90
+++ b/source/src/sfincs_date.f90
@@ -365,9 +365,9 @@ CONTAINS
    !
    subroutine timer(t)
    real*4,intent(out)               :: t
-   integer*4                        :: count,count_rate,count_max
+   integer*8                        :: count,count_rate,count_max
    call system_clock (count,count_rate,count_max)
-   t = dble(count)/count_rate
+   t = real(count)/real(count_rate)
    end subroutine timer
    !
 end module

--- a/source/src/sfincs_discharges.f90
+++ b/source/src/sfincs_discharges.f90
@@ -318,10 +318,10 @@ contains
    !
    implicit none
    !
-   integer  :: count0
-   integer  :: count1
-   integer  :: count_rate
-   integer  :: count_max
+   integer*8 :: count0
+   integer*8 :: count1
+   integer*8 :: count_rate
+   integer*8 :: count_max
    real     :: tloop
    !
    real*8           :: t

--- a/source/src/sfincs_infiltration.f90
+++ b/source/src/sfincs_infiltration.f90
@@ -619,10 +619,10 @@ contains
    real*4  :: hh_local, a
    real*4  :: dt   
    !
-   integer   :: count0
-   integer   :: count1
-   integer   :: count_rate
-   integer   :: count_max
+   integer*8 :: count0
+   integer*8 :: count1
+   integer*8 :: count_rate
+   integer*8 :: count_max
    real      :: tloop
    !
    call system_clock(count0, count_rate, count_max)

--- a/source/src/sfincs_lib.f90
+++ b/source/src/sfincs_lib.f90
@@ -41,13 +41,10 @@ module sfincs_lib
    !
    private
    !
-   integer*8  :: count0
-   integer*8  :: count00
-   integer*8  :: countdt0
-   integer*8  :: countdt1
-   integer*8  :: count1
-   integer*8  :: count_rate
-   integer*8  :: count_max
+   real*8     :: t0_clock
+   real*8     :: t00_clock
+   real*8     :: tdt0_clock
+   real*8     :: t1_clock
    integer    :: nt
    !
    integer  :: ntmapout
@@ -134,7 +131,7 @@ module sfincs_lib
    call write_log('Build-Date: '//trim(build_date), 1)
    call write_log('', 1)
    !
-   call system_clock(count0, count_rate, count_max)
+   t0_clock = omp_get_wtime()
    !
    call write_log('------ Preparing model simulation --------', 1)
    call write_log('', 1)
@@ -270,9 +267,9 @@ module sfincs_lib
       !
    endif   
    !
-   call system_clock(count1, count_rate, count_max)
+   t1_clock = omp_get_wtime()
    !
-   tinput  = 1.0 * (count1 - count0) / count_rate
+   tinput  = real(t1_clock - t0_clock)
    !
    ! Initialize some parameters
    !
@@ -328,7 +325,7 @@ module sfincs_lib
    call write_log(logstr, 1)
    call write_log('', 1)
    !
-   call system_clock(count00, count_rate, count_max)   
+   t00_clock = omp_get_wtime()
    !
    end function sfincs_initialize
    !
@@ -378,7 +375,7 @@ module sfincs_lib
    !
    do while (t < tend)
       !
-      call system_clock(countdt0, count_rate, count_max)
+      tdt0_clock = omp_get_wtime()
       !
       write_map = .false.
       write_his = .false.
@@ -654,9 +651,9 @@ module sfincs_lib
          ! percdoneval is increment of % to show to log, default=+5%
          percdonenext = 1.0 * (int(percdone) + percdoneval) 
          !
-         call system_clock(count1, count_rate, count_max)
+         t1_clock = omp_get_wtime()
          !
-         trun  = 1.0*(count1 - count00)/count_rate
+         trun  = real(t1_clock - t00_clock)
          trem = trun / max(0.01*percdone, 1.0e-6) - trun
          !
          if (int(percdone)>0) then
@@ -688,10 +685,10 @@ module sfincs_lib
    !
    integer :: ierr
    !
-   call system_clock(count1, count_rate, count_max)
+   t1_clock = omp_get_wtime()
    !
    tstart_all = 0.0
-   tfinish_all = 1.0 * (count1 - count00) / count_rate
+   tfinish_all = real(t1_clock - t00_clock)
    !
    if (timestep_analysis) then
       !

--- a/source/src/sfincs_meteo.f90
+++ b/source/src/sfincs_meteo.f90
@@ -1234,10 +1234,10 @@ contains
    !
    implicit none
    !   
-   integer  :: count0
-   integer  :: count1
-   integer  :: count_rate
-   integer  :: count_max
+   integer*8 :: count0
+   integer*8 :: count1
+   integer*8 :: count_rate
+   integer*8 :: count_max
    real     :: tloop
    !
    real*8                           :: t
@@ -1549,10 +1549,10 @@ contains
    !
    implicit none
    !
-   integer  :: count0
-   integer  :: count1
-   integer  :: count_rate
-   integer  :: count_max
+   integer*8 :: count0
+   integer*8 :: count1
+   integer*8 :: count_rate
+   integer*8 :: count_max
    real     :: tloop
    !
    integer  :: nm

--- a/source/src/sfincs_momentum.f90
+++ b/source/src/sfincs_momentum.f90
@@ -10,10 +10,10 @@ contains
    !
    ! Computes fluxes over subgrid u and v points
    !
-   integer   :: count0
-   integer   :: count1
-   integer   :: count_rate
-   integer   :: count_max
+   integer*8 :: count0
+   integer*8 :: count1
+   integer*8 :: count_rate
+   integer*8 :: count_max
    real      :: tloop
    !
    real*4    :: dt

--- a/source/src/sfincs_nonhydrostatic.f90
+++ b/source/src/sfincs_nonhydrostatic.f90
@@ -397,10 +397,10 @@ contains
    !
    implicit none
    !
-   integer   :: count0
-   integer   :: count1
-   integer   :: count_rate
-   integer   :: count_max
+   integer*8 :: count0
+   integer*8 :: count1
+   integer*8 :: count_rate
+   integer*8 :: count_max
    real      :: tloop
    !
    real*4    :: dt

--- a/source/src/sfincs_output.f90
+++ b/source/src/sfincs_output.f90
@@ -87,10 +87,10 @@ module sfincs_output
    !
    implicit none
    !
-   integer  :: count0
-   integer  :: count1
-   integer  :: count_rate
-   integer  :: count_max
+   integer*8 :: count0
+   integer*8 :: count1
+   integer*8 :: count_rate
+   integer*8 :: count_max
    real     :: tloop
    !
    logical  :: write_map   

--- a/source/src/sfincs_snapwave.f90
+++ b/source/src/sfincs_snapwave.f90
@@ -291,10 +291,10 @@ contains
    !
    implicit none
    !
-   integer  :: count0
-   integer  :: count1
-   integer  :: count_rate
-   integer  :: count_max
+   integer*8 :: count0
+   integer*8 :: count1
+   integer*8 :: count_rate
+   integer*8 :: count_max
    real     :: tloop
    !
    real*4   :: u10, u10dir

--- a/source/src/sfincs_structures.f90
+++ b/source/src/sfincs_structures.f90
@@ -614,12 +614,12 @@
    real*4                       :: h2
    real*4                       :: qstruc
    !
-   integer  :: count0
-   integer  :: count1
-   integer  :: count_rate
-   integer  :: count_max
+   integer*8 :: count0
+   integer*8 :: count1
+   integer*8 :: count_rate
+   integer*8 :: count_max
    real     :: tloop
-   !   
+   !
    call system_clock(count0, count_rate, count_max)
    !
    !$acc parallel, present(zs, q, uv, structure_uv_index, uv_index_z_nm, uv_index_z_nmu, structure_parameters, structure_type, structure_length)

--- a/source/src/sfincs_wavemaker.f90
+++ b/source/src/sfincs_wavemaker.f90
@@ -1360,10 +1360,10 @@
    real*4  :: wave_steepness, betas, zinc, zig, dwvm, ztot, hm0_inc
    real*4  :: ui, ub, dzuv, facint, zsuv, depthuv, uvm0
    !
-   integer  :: count0
-   integer  :: count1
-   integer  :: count_rate
-   integer  :: count_max
+   integer*8 :: count0
+   integer*8 :: count1
+   integer*8 :: count_rate
+   integer*8 :: count_max
    real     :: tloop
    !
    real*4, dimension(:),     allocatable :: wavemaker_forcing_hm0_ig_t

--- a/source/src/snapwave/snapwave_solver.f90
+++ b/source/src/snapwave/snapwave_solver.f90
@@ -1351,9 +1351,9 @@ module snapwave_solver
 
    subroutine timer(t)
    real*4,intent(out)               :: t
-   integer*4                        :: count,count_rate,count_max
+   integer*8                        :: count,count_rate,count_max
    call system_clock (count,count_rate,count_max)
-   t = real(count)/count_rate
+   t = real(count)/real(count_rate)
    end subroutine timer
 
    subroutine vegatt(sigm, no_nodes, kwav, no_secveg, veg_ah, veg_bstems, veg_Nstems, veg_Cd, depth, rho, g, H, Dveg) 


### PR DESCRIPTION
> **Note:** This fix was developed with the assistance of Claude (Anthropic AI).
> The changes have been reviewed and validated by the OceanLedger team.

## Summary

Fixes two related timing bugs that cause nonsensical substep timing output:
negative elapsed times (e.g. "Time in continuity: -3486 s"), percentages
above 100% (e.g. "Time in momentum: 335%"), and time-remaining estimates
that reset every ~10% of the run.

### Bug 1 — 32-bit integer overflow in subroutine timing (`integer` → `integer*8`)

Every compute subroutine times itself with:

```fortran
integer :: count0, count1, count_rate, count_max   ! ← 32-bit
call system_clock(count0, count_rate, count_max)
! ... computation ...
call system_clock(count1, count_rate, count_max)
tloop = tloop + 1.0*(count1 - count0)/count_rate
```

On a nanosecond-resolution clock (`count_rate = 10⁹`), a 32-bit counter wraps
every **2.147 seconds**. If the clock rolls over between the two `system_clock`
calls, `count1 - count0` silently produces a large negative integer (~−2.1×10⁹),
and `tloop` accumulates −2.147 s per event. Over tens of thousands of timesteps
this produces the large erroneous values seen in the logs.

`sfincs_lib.f90` already correctly declared `integer*8` for its module-level
counters — this fix applies the same widening to the local variables in all 14
affected subroutines. No algorithmic change; just type widening.

**Files changed:** `sfincs_continuity.f90`, `sfincs_momentum.f90`,
`sfincs_meteo.f90`, `sfincs_boundaries.f90`, `sfincs_output.f90`,
`sfincs_advection_diffusion.f90`, `sfincs_wavemaker.f90`, `sfincs_bathtub.f90`,
`sfincs_structures.f90`, `sfincs_snapwave.f90`, `sfincs_discharges.f90`,
`sfincs_nonhydrostatic.f90`, `sfincs_infiltration.f90`,
`sfincs_date.f90` (timer()), `snapwave/snapwave_solver.f90` (timer()).

### Bug 2 — Monotonic wall-clock time in `sfincs_lib.f90` (`system_clock` → `omp_get_wtime()`)

The module-level timing in `sfincs_lib.f90` used `integer*8` counters with
`system_clock`, which is correct for GNU Fortran but may measure **CPU time**
rather than wall time under nvfortran with OpenACC GPU offloading. When the GPU
is computing, the CPU thread is largely idle, so `system_clock` barely advances
— this can produce a reported "Total time: 953 s" for a run that actually took
6 hours of wall time, and causes the time-remaining estimates to reset abruptly
at regular intervals.

`omp_lib` is already imported by `sfincs_lib.f90`. `omp_get_wtime()` returns
wall-clock seconds as `real*8`, guaranteed monotonically increasing on any
OpenMP-compliant runtime, immune to both NTP adjustments and CPU-vs-wall
ambiguity. The module-level `integer*8` counters are replaced with `real*8`
wall-clock timestamps; the arithmetic simplifies since `omp_get_wtime()` already
returns seconds.

## Testing

- [x] Compiles with gfortran (`-fopenmp -Ofast -fallow-argument-mismatch`) — verified locally
- [x] Compiles with nvfortran (`-acc=gpu -O3 -tp=px -gpu=ccall`) — GPU build verified on g4dn.xlarge
- [x] End-to-end GPU run shows substep times summing to approximately the total simulation time (496 s simulation, 499 s total)
- [x] All substep percentages ≤ 100%
- [x] Time-remaining estimates decrease monotonically from 489 s at 1% to 0 s at 100% — no resets, no negative values