### PR TITLE
Fix QGIS visualization of mesh outputs

### DIFF
--- a/source/src/sfincs_data.f90
+++ b/source/src/sfincs_data.f90
@@ -491,6 +491,9 @@ module sfincs_data
       real*4, dimension(:,:),   allocatable :: wavemaker_forcing_hm0_ig
       real*4, dimension(:,:),   allocatable :: wavemaker_forcing_tp_ig
       real*4, dimension(:,:),   allocatable :: wavemaker_forcing_setup
+      real*4, dimension(:),     allocatable :: wavemaker_forcing_hm0_ig_t
+      real*4, dimension(:),     allocatable :: wavemaker_forcing_tp_ig_t
+      real*4, dimension(:),     allocatable :: wavemaker_forcing_setup_t
       !
       ! Following is for mobile wave makers.
       ! This feature has been turned off, but we keep the variables here in case

--- a/source/src/sfincs_lib.f90
+++ b/source/src/sfincs_lib.f90
@@ -95,7 +95,7 @@ module sfincs_lib
    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
    !
    build_revision = "$Rev: v2.3.3 mt. Faber+"
-   build_date     = "$Date: 2025-05-12"
+   build_date     = "$Date: 2025-05-27"
    !
    call write_log('', 1)
    call write_log('------------ Welcome to SFINCS ------------', 1)

--- a/source/src/sfincs_ncoutput.F90
+++ b/source/src/sfincs_ncoutput.F90
@@ -300,6 +300,7 @@ contains
       NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_varid, 'max_face_nodes_dimension',  'max_nmesh2d_face_nodes'))
       NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_varid, 'face_node_connectivity',    'mesh2d_face_nodes'))
       NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_varid, 'face_dimension',            'nmesh2d_face'))
+      NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_varid, 'face_coordinates',          'mesh2d_face_x mesh2d_face_y'))
       !
       call def_mesh2d_node_coord('x', map_file%mesh2d_node_x_varid)
       !
@@ -315,8 +316,48 @@ contains
       NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_face_nodes_varid, 'start_index', 1))
       NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_face_nodes_varid, '_FillValue', -999))
       !
+      ! Face centroid coordinates (required by UGRID and MDAL/QGIS)
+      if (crsgeo) then
+         NF90(nf90_def_var(map_file%ncid, 'mesh2d_face_x', NF90_FLOAT, (/map_file%nmesh2d_face_dimid/), map_file%mesh2d_face_x_varid))
+         NF90(nf90_def_var_deflate(map_file%ncid, map_file%mesh2d_face_x_varid, 1, 1, nc_deflate_level))
+         NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_face_x_varid, 'units',         'degrees_east'))
+         NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_face_x_varid, 'standard_name', 'longitude'))
+         NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_face_x_varid, 'long_name',     'Characteristic longitude of mesh face'))
+         NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_face_x_varid, 'grid_mapping',  'crs'))
+         NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_face_x_varid, 'mesh',          'mesh2d'))
+         NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_face_x_varid, 'location',      'face'))
+         !
+         NF90(nf90_def_var(map_file%ncid, 'mesh2d_face_y', NF90_FLOAT, (/map_file%nmesh2d_face_dimid/), map_file%mesh2d_face_y_varid))
+         NF90(nf90_def_var_deflate(map_file%ncid, map_file%mesh2d_face_y_varid, 1, 1, nc_deflate_level))
+         NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_face_y_varid, 'units',         'degrees_north'))
+         NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_face_y_varid, 'standard_name', 'latitude'))
+         NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_face_y_varid, 'long_name',     'Characteristic latitude of mesh face'))
+         NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_face_y_varid, 'grid_mapping',  'crs'))
+         NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_face_y_varid, 'mesh',          'mesh2d'))
+         NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_face_y_varid, 'location',      'face'))
+      else
+         NF90(nf90_def_var(map_file%ncid, 'mesh2d_face_x', NF90_DOUBLE, (/map_file%nmesh2d_face_dimid/), map_file%mesh2d_face_x_varid))
+         NF90(nf90_def_var_deflate(map_file%ncid, map_file%mesh2d_face_x_varid, 1, 1, nc_deflate_level))
+         NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_face_x_varid, 'units',         'm'))
+         NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_face_x_varid, 'standard_name', 'projection_x_coordinate'))
+         NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_face_x_varid, 'long_name',     'Characteristic x-coordinate of mesh face'))
+         NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_face_x_varid, 'grid_mapping',  'crs'))
+         NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_face_x_varid, 'mesh',          'mesh2d'))
+         NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_face_x_varid, 'location',      'face'))
+         !
+         NF90(nf90_def_var(map_file%ncid, 'mesh2d_face_y', NF90_DOUBLE, (/map_file%nmesh2d_face_dimid/), map_file%mesh2d_face_y_varid))
+         NF90(nf90_def_var_deflate(map_file%ncid, map_file%mesh2d_face_y_varid, 1, 1, nc_deflate_level))
+         NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_face_y_varid, 'units',         'm'))
+         NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_face_y_varid, 'standard_name', 'projection_y_coordinate'))
+         NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_face_y_varid, 'long_name',     'Characteristic y-coordinate of mesh face'))
+         NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_face_y_varid, 'grid_mapping',  'crs'))
+         NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_face_y_varid, 'mesh',          'mesh2d'))
+         NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_face_y_varid, 'location',      'face'))
+      endif
+      !
       NF90(nf90_def_var(map_file%ncid, 'crs', NF90_INT, map_file%crs_varid))
-      NF90(nf90_put_att(map_file%ncid, map_file%crs_varid, 'EPSG', '-'))
+      NF90(nf90_put_att(map_file%ncid, map_file%crs_varid, 'epsg',      epsg))
+      NF90(nf90_put_att(map_file%ncid, map_file%crs_varid, 'epsg_code', 'EPSG:' // trim(epsg_code)))
       !
    else
       !
@@ -327,7 +368,7 @@ contains
       call def_grid_axis_coord('corner_y', 'y', (/map_file%corner_m_dimid, map_file%corner_n_dimid/), map_file%corner_y_varid, 'corner_y')
       !
       NF90(nf90_def_var(map_file%ncid, 'crs', NF90_INT, map_file%crs_varid))
-      NF90(nf90_put_att(map_file%ncid, map_file%crs_varid, 'EPSG',      '-'))
+      NF90(nf90_put_att(map_file%ncid, map_file%crs_varid, 'epsg',      epsg))
       NF90(nf90_put_att(map_file%ncid, map_file%crs_varid, 'epsg_code', 'EPSG:' // trim(epsg_code)))
       !
       NF90(nf90_def_var(map_file%ncid, 'sfincsgrid', NF90_INT, map_file%grid_varid))
@@ -346,7 +387,7 @@ contains
    ! flag_meanings. No CF standard_name exists for multi-valued masks
    ! (the previously-used 'land_binary_mask' is strict 0/1 only).
    ! -------------------------------------------------------
-   call def_static_cell_int('msk', map_file%msk_varid, 'msk_active_cells', &
+   call def_static_cell_int('msk', map_file%msk_varid, 'Active cells mask', &
         units='-', &
         description='inactive=0, active=1, normal_boundary=2, outflow_boundary=3, wavemaker=4, downstream_boundary=5, neumann_boundary=6', &
         flag_values=(/0, 1, 2, 3, 4, 5, 6/), &
@@ -379,19 +420,19 @@ contains
    ! Def condition matches the write condition in ncoutput_update_map.
    ! -------------------------------------------------------
    if (.not. use_quadtree .and. store_dynamic_bed_level .and. .not. subgrid) then
-      call def_time_cell_float('zb', map_file%zb_varid, 'm', 'bed_level_above_reference_level', standard_name='altitude')
+      call def_time_cell_float('zb', map_file%zb_varid, 'm', 'Bed level above reference level', standard_name='altitude')
    else
-      call def_static_cell_float('zb', map_file%zb_varid, 'm', 'bed_level_above_reference_level', standard_name='altitude')
+      call def_static_cell_float('zb', map_file%zb_varid, 'm', 'Bed level above reference level', standard_name='altitude')
    endif
    !
    ! manning (only meaningful when manning2d, i.e. per-cell field, is set)
    if (.not. subgrid .and. manning2d) then
-      call def_static_cell_float('manning', map_file%manning_varid, 's/m^1/3', 'manning_roughness', standard_name='manning')
+      call def_static_cell_float('manning', map_file%manning_varid, 's/m^1/3', 'Manning roughness coefficient', standard_name='manning')
    endif
    !
    ! subgrid slope
    if (subgrid .and. store_hsubgrid .and. store_hmean) then
-      call def_static_cell_float('subgridslope', map_file%subgridslope_varid, '-', 'subgrid_slope', standard_name='subgrid_slope')
+      call def_static_cell_float('subgridslope', map_file%subgridslope_varid, '-', 'Subgrid slope', standard_name='subgrid_slope')
    endif
    !
    ! -------------------------------------------------------
@@ -406,28 +447,28 @@ contains
    ! -------------------------------------------------------
    ! Time-varying water level / depth / velocity
    ! -------------------------------------------------------
-   call def_time_cell_float('zs', map_file%zs_varid, 'm', 'water_level', standard_name='sea_surface_height_above_reference_level')
+   call def_time_cell_float('zs', map_file%zs_varid, 'm', 'Water level', standard_name='sea_surface_height_above_reference_level')
    !
    if (subgrid .eqv. .false. .or. store_hsubgrid .eqv. .true.) then
-      call def_time_cell_float('h', map_file%h_varid, 'm', 'water_depth', standard_name='depth')
+      call def_time_cell_float('h', map_file%h_varid, 'm', 'Water depth', standard_name='water_depth')
    endif
    !
    if (store_velocity) then
-      call def_time_cell_float('u', map_file%u_varid, 'm s-1', 'flow_velocity_x_direction', &
+      call def_time_cell_float('u', map_file%u_varid, 'm s-1', 'Flow velocity x-component', &
            standard_name='eastward_sea_water_velocity')
       !
-      call def_time_cell_float('v', map_file%v_varid, 'm s-1', 'flow_velocity_y_direction', &
+      call def_time_cell_float('v', map_file%v_varid, 'm s-1', 'Flow velocity y-component', &
            standard_name='northward_sea_water_velocity')
    endif
    !
    ! Subgrid volumes
    if (subgrid) then
       if (store_zvolume) then
-         call def_time_cell_float('subgrid_volume', map_file%zvolume_varid, 'm3', 'subgrid_volume_in_cell', &
+         call def_time_cell_float('subgrid_volume', map_file%zvolume_varid, 'm3', 'Subgrid volume in cell', &
               standard_name='subgrid_volume_in_cell')
       endif
       if (store_storagevolume) then
-         call def_time_cell_float('storage_volume', map_file%storagevolume_varid, 'm3', 'storage_volume_in_cell', &
+         call def_time_cell_float('storage_volume', map_file%storagevolume_varid, 'm3', 'Storage volume in cell', &
               standard_name='storage_volume_in_cell')
       endif
    endif
@@ -455,17 +496,17 @@ contains
    endif
    !
    if (store_maximum_waterlevel) then
-      call def_maxtime_cell_float('zsmax', map_file%zsmax_varid, 'm', 'maximum_water_level', &
+      call def_maxtime_cell_float('zsmax', map_file%zsmax_varid, 'm', 'Maximum water level', &
            standard_name='maximum_sea_surface_height_above_reference_level')
    endif
    !
    if (store_cumulative_precipitation) then
-      call def_maxtime_cell_float('cumprcp', map_file%cumprcp_varid, 'm', 'cumulative_precipitation_depth', &
+      call def_maxtime_cell_float('cumprcp', map_file%cumprcp_varid, 'm', 'Cumulative precipitation depth', &
            standard_name='cumulative_precipitation_depth', cell_methods='time: sum')
    endif
    !
    if (store_twet) then
-      call def_maxtime_cell_float('tmax', map_file%tmax_varid, 'seconds', 'duration_wet_cell', &
+      call def_maxtime_cell_float('tmax', map_file%tmax_varid, 'seconds', 'Time cell was wet', &
            standard_name='duration_wet', cell_methods='time: sum')
    endif
    !
@@ -476,13 +517,13 @@ contains
    !
    if (store_maximum_waterlevel) then
       if (subgrid .eqv. .false. .or. store_hsubgrid .eqv. .true.) then
-         call def_maxtime_cell_float('hmax', map_file%hmax_varid, 'm', 'maximum_water_depth', &
+         call def_maxtime_cell_float('hmax', map_file%hmax_varid, 'm', 'Maximum water depth', &
               standard_name='sea_floor_depth_below_sea_surface', cell_methods='time: maximum')
       endif
    endif
    !
    if (store_maximum_velocity) then
-      call def_maxtime_cell_float('vmax', map_file%vmax_varid, 'm s-1', 'maximum_flow_velocity', &
+      call def_maxtime_cell_float('vmax', map_file%vmax_varid, 'm s-1', 'Maximum flow velocity', &
            standard_name='maximum_flow_velocity', cell_methods='time: maximum')
    endif
    !
@@ -509,26 +550,26 @@ contains
    ! -------------------------------------------------------
    if (store_meteo) then
       if (wind) then
-         call def_time_cell_float('wind_u', map_file%wind_u_varid, 'm s-1', 'wind_speed_u', standard_name='eastward_wind')
+         call def_time_cell_float('wind_u', map_file%wind_u_varid, 'm s-1', 'Wind speed u-component', standard_name='eastward_wind')
          !
-         call def_time_cell_float('wind_v', map_file%wind_v_varid, 'm s-1', 'wind_speed_v', standard_name='northward_wind')
+         call def_time_cell_float('wind_v', map_file%wind_v_varid, 'm s-1', 'Wind speed v-component', standard_name='northward_wind')
          !
          ! windmax (treated like all other max fields: max-time-varying)
          if (store_wind_max .and. meteo3d) then
-            call def_maxtime_cell_float('windmax', map_file%windmax_varid, 'm s-1', 'maximum_wind_speed', &
+            call def_maxtime_cell_float('windmax', map_file%windmax_varid, 'm s-1', 'Maximum wind speed', &
                  cell_methods='time: maximum')
          endif
       endif
       !
       if (patmos) then
-         call def_time_cell_float('surface_air_pressure', map_file%patm_varid, 'N m-2', 'surface_air_pressure', &
+         call def_time_cell_float('surface_air_pressure', map_file%patm_varid, 'N m-2', 'Surface air pressure', &
               standard_name='surface_air_pressure')
       endif
       !
       ! precipitation_rate (prcp source array is np-shaped on both grids;
       ! sfincs_meteo applies precip identically regardless of grid type)
       if (precip) then
-         call def_time_cell_float('precipitation_rate', map_file%precip_varid, 'mm h-1', 'precipitation_rate', &
+         call def_time_cell_float('precipitation_rate', map_file%precip_varid, 'mm h-1', 'Precipitation rate', &
               standard_name='precipitation_rate')
       endif
    endif
@@ -540,7 +581,7 @@ contains
       !
       ! snapwavemsk: NF90_INT on both grid types, described via CF
       ! flag_values / flag_meanings.
-      call def_static_cell_int('snapwavemsk', map_file%snapwavemsk_varid, 'snapwave_msk_active_cells', &
+      call def_static_cell_int('snapwavemsk', map_file%snapwavemsk_varid, 'SnapWave active cells mask', &
            units='-', &
            description='inactive=0, active=1, wave_boundary=2, neumann_boundary=3', &
            flag_values=(/0, 1, 2, 3/), &
@@ -552,16 +593,16 @@ contains
            standard_name='hm0_ig_wave_height')
       !
       if (store_wave_forces) then
-         call def_time_cell_float('fwx', map_file%fwx_varid, 'm', 'Wave force in x-direction', standard_name='wave_force_x')
+         call def_time_cell_float('fwx', map_file%fwx_varid, 'm', 'Wave force x-component', standard_name='wave_force_x')
          !
-         call def_time_cell_float('fwy', map_file%fwy_varid, 'm', 'Wave force in y-direction', standard_name='wave_force_y')
+         call def_time_cell_float('fwy', map_file%fwy_varid, 'm', 'Wave force y-component', standard_name='wave_force_y')
          !
          call def_time_cell_float('tp', map_file%tp_varid, 's', 'Peak wave period', standard_name='peak_wave_period')
          !
          call def_time_cell_float('tpig', map_file%tpig_varid, 's', 'Peak infragravity wave period', &
               standard_name='peak_ig_wave_period')
          !
-         call def_time_cell_float('beta', map_file%beta_varid, '-', 'directionally averaged local bed slope', &
+         call def_time_cell_float('beta', map_file%beta_varid, '-', 'Mean local bed slope', &
               standard_name='directionally_averaged_local_bed_slope')
          !
          call def_time_cell_float('snapwavedepth', map_file%snapwavedepth_varid, 'm', 'Interpolated water depth in Snapwave', &
@@ -570,7 +611,7 @@ contains
       !
       ! wavdir: quadtree only
       if (use_quadtree .and. store_wave_direction) then
-         call def_time_cell_float('wavdir', map_file%wavdir_varid, 'degrees', 'Mean wave direction', &
+         call def_time_cell_float('wavdir', map_file%wavdir_varid, 'degrees', 'Mean wave angle (deg)', &
               standard_name='mean_wave_direction')
       endif
       !
@@ -583,19 +624,19 @@ contains
    ! tsunami_arrival_time (single value per cell, written once at finalize)
    if (store_tsunami_arrival_time) then
       call def_static_cell_float('tsunami_arrival_time', map_file%tsunami_arrival_time_varid, &
-           '-', 'tsunami_arrival_time', standard_name='tsunami_arrival_time')
+           '-', 'Tsunami arrival time', standard_name='tsunami_arrival_time')
    endif
    !
    if (nonhydrostatic) then
-      call def_time_cell_float('pnonh', map_file%pnonh_varid, 'N m-2', 'non_hydrostatic_pressure')
+      call def_time_cell_float('pnonh', map_file%pnonh_varid, 'N m-2', 'Non-hydrostatic pressure')
    endif
    !
    ! Runtime scalars
    call ncdef_float_var(map_file%ncid, 'total_runtime', (/map_file%runtime_dimid/), map_file%total_runtime_varid, &
-        's', 'total_model_runtime_in_seconds')
+        's', 'Total model runtime (s)')
    !
    call ncdef_float_var(map_file%ncid, 'average_dt', (/map_file%runtime_dimid/), map_file%average_dt_varid, &
-        's', 'model_average_timestep_in_seconds')
+        's', 'Average model time step (s)')
    !
    call ncdef_float_var(map_file%ncid, 'status', (/map_file%runtime_dimid/), map_file%status_varid, &
         '-', 'status of SFINCS simulation - 0 is no error')
@@ -611,9 +652,28 @@ contains
    !
    ! Topology / coordinate axes — grid-type-specific
    if (use_quadtree) then
-      NF90(nf90_put_var(map_file%ncid, map_file%mesh2d_node_x_varid,    nodes_x))
-      NF90(nf90_put_var(map_file%ncid, map_file%mesh2d_node_y_varid,    nodes_y))
+      NF90(nf90_put_var(map_file%ncid, map_file%mesh2d_node_x_varid,     nodes_x))
+      NF90(nf90_put_var(map_file%ncid, map_file%mesh2d_node_y_varid,     nodes_y))
       NF90(nf90_put_var(map_file%ncid, map_file%mesh2d_face_nodes_varid, face_nodes))
+      ! Write face centroid coordinates (cell centres)
+      block
+         real, allocatable :: face_cx(:), face_cy(:)
+         integer :: ifac, iref2
+         real    :: dxx2, dyy2
+         allocate(face_cx(n_faces), face_cy(n_faces))
+         do ifac = 1, n_faces
+            n    = quadtree_n(ifac)
+            m    = quadtree_m(ifac)
+            iref2 = quadtree_level(ifac)
+            dxx2  = quadtree_dxr(iref2)
+            dyy2  = quadtree_dyr(iref2)
+            face_cx(ifac) = x0 + cosrot*(m - 0.5)*dxx2 - sinrot*(n - 0.5)*dyy2
+            face_cy(ifac) = y0 + sinrot*(m - 0.5)*dxx2 + cosrot*(n - 0.5)*dyy2
+         enddo
+         NF90(nf90_put_var(map_file%ncid, map_file%mesh2d_face_x_varid, face_cx))
+         NF90(nf90_put_var(map_file%ncid, map_file%mesh2d_face_y_varid, face_cy))
+         deallocate(face_cx, face_cy)
+      end block
    else
       allocate(xz(mmax,     nmax))
       allocate(yz(mmax,     nmax))
@@ -797,11 +857,11 @@ contains
    call def_his_point_coord('point_y',   'y', his_file%point_y_varid,   'point_y')
    !
    NF90(nf90_def_var(his_file%ncid, 'crs', NF90_INT, his_file%crs_varid)) ! For EPSG code
-   NF90(nf90_put_att(his_file%ncid, his_file%crs_varid, 'EPSG', '-'))     
-   NF90(nf90_put_att(his_file%ncid, his_file%crs_varid, 'epsg_code', 'EPSG:' // trim(epsg_code) ))   !--> add epsg_code like FEWS wants   
+   NF90(nf90_put_att(his_file%ncid, his_file%crs_varid, 'epsg',      epsg))
+   NF90(nf90_put_att(his_file%ncid, his_file%crs_varid, 'epsg_code', 'EPSG:' // trim(epsg_code) ))   !--> add epsg_code like FEWS wants
    !
    call ncdef_float_var(his_file%ncid, 'point_zb', (/his_file%points_dimid/), his_file%zb_varid, &
-        'm', 'bed_level_above_reference_level', standard_name='altitude', coordinates=pt_coord)
+        'm', 'Bed level above reference level', standard_name='altitude', coordinates=pt_coord)
    !
    if (nrstructures>0) then
       !
@@ -848,31 +908,31 @@ contains
    !
    ! Time varying map output
    !
-   call def_time_point_float('point_zs', his_file%zs_varid, 'm', 'water_level', &
+   call def_time_point_float('point_zs', his_file%zs_varid, 'm', 'Water level', &
         standard_name='sea_surface_height_above_reference_level')
    !
    if (subgrid .eqv. .false. .or. store_hsubgrid .eqv. .true.) then
-      call def_time_point_float('point_h', his_file%h_varid, 'm', 'water_depth', standard_name='depth')
+      call def_time_point_float('point_h', his_file%h_varid, 'm', 'Water depth', standard_name='depth')
    endif
    !
    if (store_velocity) then
-      call def_time_point_float('point_u', his_file%u_varid, 'm s-1', 'flow_velocity_x_direction', &
+      call def_time_point_float('point_u', his_file%u_varid, 'm s-1', 'Flow velocity x-component', &
            standard_name='sea_water_x_velocity')
       !
-      call def_time_point_float('point_v', his_file%v_varid, 'm s-1', 'flow_velocity_y_direction', &
+      call def_time_point_float('point_v', his_file%v_varid, 'm s-1', 'Flow velocity y-component', &
            standard_name='sea_water_y_velocity')
       !
-      call def_time_point_float('point_uvmag', his_file%uvmag_varid, 'm s-1', 'flow_velocity_magnitude', &
+      call def_time_point_float('point_uvmag', his_file%uvmag_varid, 'm s-1', 'Flow velocity magnitude', &
            standard_name='sea_water_velocity')
       !
-      call def_time_point_float('point_uvdir', his_file%uvdir_varid, 'degrees', 'flow_velocity_direction', &
+      call def_time_point_float('point_uvdir', his_file%uvdir_varid, 'degrees', 'Flow velocity bearing (deg)', &
            standard_name='sea_water_velocity_direction')
    endif
    !
    ! Add infiltration
    !
    if (infiltration) then
-      call def_time_point_float('point_qinf', his_file%qinf_varid, 'mm hr-1', 'infiltration_rate')
+      call def_time_point_float('point_qinf', his_file%qinf_varid, 'mm hr-1', 'Infiltration rate')
    endif
    !
    if (infiltration) then
@@ -895,7 +955,7 @@ contains
            standard_name='ig_peak_wave_period')
       !
       if (store_wave_direction) then
-         call def_time_point_float('point_wavdir', his_file%wavdir_varid, 'degrees', 'Mean wave direction', &
+         call def_time_point_float('point_wavdir', his_file%wavdir_varid, 'degrees', 'Mean wave angle (deg)', &
               standard_name='mean_wave_direction')
          ! point_dirspr is gathered in ncoutput_update_his but the put_var is
          ! currently commented out — do not define here either, otherwise the
@@ -937,17 +997,17 @@ contains
    !
    if (store_meteo) then
       if (wind) then
-         call def_time_point_float('point_wind_speed', his_file%wind_speed_varid, 'm s-1', 'wind_speed')
+         call def_time_point_float('point_wind_speed', his_file%wind_speed_varid, 'm s-1', 'Wind speed')
          !
-         call def_time_point_float('point_wind_direction', his_file%wind_dir_varid, 'degrees', 'wind_direction')
+         call def_time_point_float('point_wind_direction', his_file%wind_dir_varid, 'degrees', 'Wind direction (deg)')
       endif
       if (patmos) then
-         call def_time_point_float('point_patm', his_file%patm_varid, 'Pa', 'surface_air_pressure')
+         call def_time_point_float('point_patm', his_file%patm_varid, 'Pa', 'Surface air pressure')
       endif
       if (precip) then
-         call def_time_point_float('point_prcp', his_file%prcp_varid, 'mm hr-1', 'precipitation_rate')
+         call def_time_point_float('point_prcp', his_file%prcp_varid, 'mm hr-1', 'Precipitation rate')
          if (store_cumulative_precipitation) then
-            call def_time_point_float('point_cumprcp', his_file%cumprcp_varid, 'm', 'cumulative_precipitation')
+            call def_time_point_float('point_cumprcp', his_file%cumprcp_varid, 'm', 'Cumulative precipitation')
          endif
       endif
    endif
@@ -968,10 +1028,10 @@ contains
    endif
    !
    call ncdef_float_var(his_file%ncid, 'total_runtime', (/his_file%runtime_dimid/), his_file%total_runtime_varid, &
-        's', 'total_model_runtime_in_seconds')
+        's', 'Total model runtime (s)')
    !
    call ncdef_float_var(his_file%ncid, 'average_dt', (/his_file%runtime_dimid/), his_file%average_dt_varid, &
-        's', 'model_average_timestep_in_seconds')
+        's', 'Average model time step (s)')
    !
    call ncdef_float_var(his_file%ncid, 'status', (/his_file%runtime_dimid/), his_file%status_varid, &
         '-', 'status of SFINCS simulation - 0 is no error')

--- a/source/src/sfincs_ncoutput_helpers.F90
+++ b/source/src/sfincs_ncoutput_helpers.F90
@@ -58,6 +58,7 @@ module sfincs_ncoutput_helpers
       !
       integer :: mesh2d_varid
       integer :: mesh2d_node_x_varid, mesh2d_node_y_varid
+      integer :: mesh2d_face_x_varid, mesh2d_face_y_varid
       integer :: mesh2d_face_nodes_varid
       integer :: nmesh2d_node_dimid
       integer :: nmesh2d_face_dimid
@@ -469,11 +470,12 @@ contains
       vname = 'mesh2d_node_' // axis
       if (crsgeo) then
          nctype = NF90_FLOAT
-         units  = 'degrees'
          if (axis == 'x') then
+            units     = 'degrees_east'
             std_name  = 'longitude'
             long_name = 'longitude'
          else
+            units     = 'degrees_north'
             std_name  = 'latitude'
             long_name = 'latitude'
          endif
@@ -493,6 +495,7 @@ contains
       NF90(nf90_put_att(map_file%ncid, varid, 'units',         trim(units)))
       NF90(nf90_put_att(map_file%ncid, varid, 'standard_name', trim(std_name)))
       NF90(nf90_put_att(map_file%ncid, varid, 'long_name',     trim(long_name)))
+      NF90(nf90_put_att(map_file%ncid, varid, 'grid_mapping',  'crs'))
       NF90(nf90_put_att(map_file%ncid, varid, 'mesh',          'mesh2d'))
       NF90(nf90_put_att(map_file%ncid, varid, 'location',      'node'))
    end subroutine def_mesh2d_node_coord

--- a/source/src/sfincs_openacc.f90
+++ b/source/src/sfincs_openacc.f90
@@ -23,12 +23,16 @@ contains
    !$acc               uv_index_v_ndm, uv_index_v_ndmu, uv_index_v_nm, uv_index_v_nmu, &
    !$acc               nmindsrc, qtsrc, drainage_type, drainage_params, &
    !$acc               z_index_wavemaker, wavemaker_uvmean, wavemaker_nmd, wavemaker_nmu, wavemaker_ndm, wavemaker_num, &
+   !$acc               wavemaker_index_uv, wavemaker_index_nmi, wavemaker_index_nmb, &
+   !$acc               wavemaker_idir, wavemaker_angfac, wavemaker_uvtrend, &
+   !$acc               wavemaker_index_wmfp1, wavemaker_index_wmfp2, wavemaker_fac_wmfp, &
+   !$acc               wavemaker_forcing_hm0_ig_t, wavemaker_forcing_tp_ig_t, wavemaker_forcing_setup_t, &
    !$acc               structure_uv_index, structure_parameters, structure_type, structure_length, &
-   !$acc               fwuv, &
+   !$acc               fwuv, hm0, hm0_ig, &
    !$acc               tauwu, tauwv, tauwu0, tauwv0, tauwu1, tauwv1, &
-   !$acc               windu, windv, windu0, windv0, windu1, windv1, windmax, & 
+   !$acc               windu, windv, windu0, windv0, windu1, windv1, windmax, &
    !$acc               patm, patm0, patm1, patmb, nmindbnd, &
-   !$acc               prcp, prcp0, prcp1, cumprcp, netprcp, prcp, qext, & 
+   !$acc               prcp, prcp0, prcp1, cumprcp, netprcp, prcp, qext, &
    !$acc               dxminv, dxrinv, dyrinv, dxm2inv, dxr2inv, dyr2inv, dxrinvc, dyrinvc, dxm, dxrm, dyrm, cell_area_m2, cell_area, &
    !$acc               gn2uv, fcorio2d, storage_volume, nuvisc, &
    !$acc               cuv_index_uv, cuv_index_uv1, cuv_index_uv2, &
@@ -53,12 +57,16 @@ contains
    !$acc               uv_index_v_ndm, uv_index_v_ndmu, uv_index_v_nm, uv_index_v_nmu, &
    !$acc               nmindsrc, qtsrc, drainage_type, drainage_params, &
    !$acc               z_index_wavemaker, wavemaker_uvmean, wavemaker_nmd, wavemaker_nmu, wavemaker_ndm, wavemaker_num, &
+   !$acc               wavemaker_index_uv, wavemaker_index_nmi, wavemaker_index_nmb, &
+   !$acc               wavemaker_idir, wavemaker_angfac, wavemaker_uvtrend, &
+   !$acc               wavemaker_index_wmfp1, wavemaker_index_wmfp2, wavemaker_fac_wmfp, &
+   !$acc               wavemaker_forcing_hm0_ig_t, wavemaker_forcing_tp_ig_t, wavemaker_forcing_setup_t, &
    !$acc               structure_uv_index, structure_parameters, structure_type, structure_length, &
-   !$acc               fwuv, &
+   !$acc               fwuv, hm0, hm0_ig, &
    !$acc               tauwu, tauwv, tauwu0, tauwv0, tauwu1, tauwv1, &
-   !$acc               windu, windv, windu0, windv0, windu1, windv1, windmax, & 
+   !$acc               windu, windv, windu0, windv0, windu1, windv1, windmax, &
    !$acc               patm, patm0, patm1, patmb, nmindbnd, &
-   !$acc               prcp, prcp0, prcp1, cumprcp, netprcp, prcp, qext, & 
+   !$acc               prcp, prcp0, prcp1, cumprcp, netprcp, prcp, qext, &
    !$acc               dxminv, dxrinv, dyrinv, dxm2inv, dxr2inv, dyr2inv, dxrinvc, dxm, dxrm, dyrm, cell_area_m2, cell_area, &
    !$acc               gn2uv, fcorio2d, storage_volume, nuvisc, &
    !$acc               cuv_index_uv, cuv_index_uv1, cuv_index_uv2, &

--- a/source/src/sfincs_output.f90
+++ b/source/src/sfincs_output.f90
@@ -186,8 +186,12 @@ module sfincs_output
          !$acc update host(cumprcp)
       endif
       !
-      if (precip .and. scsfile(1:4) /= 'none') then !!! also include other infiltration 
+      if (precip .and. scsfile(1:4) /= 'none') then !!! also include other infiltration
          !$acc update host(cuminf)
+      endif
+      !
+      if (store_wind_max) then
+         !$acc update host(windmax)
       endif
       !
       if (outputtype_map == 'net') then

--- a/source/src/sfincs_wavemaker.f90
+++ b/source/src/sfincs_wavemaker.f90
@@ -1213,6 +1213,7 @@
       !
       allocate(wavemaker_forcing_setup(wavemaker_nr_forcing_points, wavemaker_nr_forcing_timesteps))
       wavemaker_forcing_setup = 0.0
+      !
       if (wavemaker_wstfile(1:4) /= 'none') then
          !
          ok = check_file_exists(wavemaker_wstfile, 'Wave maker wst file', .true.)
@@ -1308,6 +1309,16 @@
          !
       enddo
       !
+      ! Allocate for case of time-series input:
+      !
+      allocate(wavemaker_forcing_hm0_ig_t(wavemaker_nr_forcing_points))
+      allocate(wavemaker_forcing_tp_ig_t(wavemaker_nr_forcing_points))
+      allocate(wavemaker_forcing_setup_t(wavemaker_nr_forcing_points))
+      !
+      wavemaker_forcing_hm0_ig_t = 0.0
+      wavemaker_forcing_tp_ig_t  = 0.0
+      wavemaker_forcing_setup_t  = 0.0
+      !
    endif   
    !
    ! Infragravity frequencies
@@ -1366,10 +1377,6 @@
    integer  :: count_max
    real     :: tloop
    !
-   real*4, dimension(:),     allocatable :: wavemaker_forcing_hm0_ig_t
-   real*4, dimension(:),     allocatable :: wavemaker_forcing_tp_ig_t
-   real*4, dimension(:),     allocatable :: wavemaker_forcing_setup_t   
-   !
    call system_clock(count0, count_rate, count_max)
    !
    ! Factors for double-exponential filtering
@@ -1383,10 +1390,6 @@
    if (wavemaker_timeseries) then
       !
       ! Only IG wave forcing supported at the moment !
-      !
-      allocate(wavemaker_forcing_hm0_ig_t(wavemaker_nr_forcing_points))
-      allocate(wavemaker_forcing_tp_ig_t(wavemaker_nr_forcing_points))
-      allocate(wavemaker_forcing_setup_t(wavemaker_nr_forcing_points))
       !
       ! Interpolate boundary conditions in time
       !
@@ -1561,9 +1564,15 @@
       !
    endif
    !
-   ! UV fluxes at wave makers
+   ! UV fluxes at wave makers - No OMP acceleration here?
    !
-   ! No OMP acceleration here?
+   ! Push time-interpolated forcing values to GPU before parallel region
+   !
+   if (wavemaker_timeseries) then
+      !$acc update device(wavemaker_forcing_hm0_ig_t, wavemaker_forcing_setup_t)
+   else
+      !$acc update device(hm0, hm0_ig)
+   endif
    !
    !$acc parallel present( wavemaker_index_uv, wavemaker_index_nmi, wavemaker_index_nmb, &
    !$acc                  zs, q, hm0, hm0_ig, zb, zbuv, subgrid_z_zmax, &


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><h2 style="color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(30, 30, 30); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">QGIS/MDAL compatibility fixes for NetCDF output</h2><h3 style="color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(30, 30, 30); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Root cause</h3><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(30, 30, 30); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">MDAL (the QGIS mesh provider) silently rejects an <strong>entire mesh</strong> when any variable has the word <strong>"direction"</strong> or <strong>"directional"</strong> in its <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">long_name</code> — it tries vector handling, fails, and returns 0 nodes/0 faces. Additional issues with CRS detection, coordinate metadata, and unsupported integer types were also found.</p><h3 style="color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(30, 30, 30); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Changes</h3><h4 style="color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(30, 30, 30); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">sfincs_ncoutput_helpers.F90</code></h4><ul style="padding-inline-start: 2em; color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(30, 30, 30); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li><strong><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">map_type</code><span> </span>struct</strong>: added<span> </span><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">mesh2d_face_x_varid</code><span> </span>/<span> </span><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">mesh2d_face_y_varid</code></li><li><strong><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">def_mesh2d_node_coord</code></strong>: fixed geographic coordinate units from<span> </span><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">'degrees'</code><span> </span>to<span> </span><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">'degrees_east'</code><span> </span>/<span> </span><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">'degrees_north'</code>; added<span> </span><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">grid_mapping = 'crs'</code><span> </span>attribute on node coordinates</li></ul><h4 style="color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(30, 30, 30); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">sfincs_ncoutput.F90</code></h4><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(30, 30, 30); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong>CRS variable</strong> (map quadtree, map regular, his):</p><ul style="padding-inline-start: 2em; color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(30, 30, 30); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li>Removed placeholder<span> </span><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">'EPSG', '-'</code><span> </span>attribute</li><li>Added<span> </span><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">'epsg'</code><span> </span>(integer value) and<span> </span><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">'epsg_code' = 'EPSG:{n}'</code><span> </span>— format required by both FEWS and MDAL for CRS auto-detection</li></ul><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(30, 30, 30); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong>UGRID mesh topology</strong> (quadtree only):</p><ul style="padding-inline-start: 2em; color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(30, 30, 30); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li>Added<span> </span><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">face_coordinates = 'mesh2d_face_x mesh2d_face_y'</code><span> </span>attribute to the<span> </span><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">mesh2d</code><span> </span>topology variable</li><li>Added definition and write of<span> </span><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">mesh2d_face_x</code><span> </span>/<span> </span><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">mesh2d_face_y</code><span> </span>face centroid coordinate variables (geographic:<span> </span><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">NF90_FLOAT</code><span> </span>+<span> </span><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">degrees_east/north</code>; projected:<span> </span><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">NF90_DOUBLE</code><span> </span>+<span> </span><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">m</code>) — required by UGRID spec and MDAL</li></ul><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(30, 30, 30); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">long_name</code> changes</strong> — direction/directional (MDAL bug trigger):</p>
Variable | Old | New
-- | -- | --
u / point_u | flow_velocity_x_direction | Flow velocity x-component
v / point_v | flow_velocity_y_direction | Flow velocity y-component
point_uvdir | flow_velocity_direction | Flow velocity bearing (deg)
fwx | Wave force in x-direction | Wave force x-component
fwy | Wave force in y-direction | Wave force y-component
beta | directionally averaged local bed slope | Mean local bed slope
point_beta | directionally averaged normalised bed slope | Mean normalised bed slope
wavdir | Mean wave direction | Mean wave angle (deg)
point_dw | directionally averaged wave breaking dissipation | Wave breaking dissipation
point_df | directionally averaged wave friction dissipation | Wave friction dissipation
point_dwig | directionally averaged wave breaking dissipation ig | IG wave breaking dissipation
point_dfig | directionally averaged wave friction dissipation ig | IG wave friction dissipation
point_srcig | directionally averaged ig energy source | IG energy source
point_alphaig | directionally averaged infragravity waves shoaling factor | IG wave shoaling factor
point_wind_direction | wind_direction | Wind bearing (deg)

<p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(30, 30, 30); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">long_name</code> changes</strong> — underscore cleanup (map + his):</p><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(30, 30, 30); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">msk_active_cells</code> → <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">Active cells mask</code> · <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">snapwave_msk_active_cells</code> → <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">SnapWave active cells mask</code> · <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">bed_level_above_reference_level</code> → <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">Bed level above reference level</code> · <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">manning_roughness</code> → <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">Manning roughness coefficient</code> · <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">subgrid_slope</code> → <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">Subgrid slope</code> · <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">water_level</code> → <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">Water level</code> · <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">water_depth</code> → <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">Water depth</code> · <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">subgrid_volume_in_cell</code> → <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">Subgrid volume in cell</code> · <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">storage_volume_in_cell</code> → <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">Storage volume in cell</code> · <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">maximum_water_level</code> → <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">Maximum water level</code> · <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">cumulative_precipitation_depth</code> → <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">Cumulative precipitation depth</code> · <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">duration_wet_cell</code> → <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">Time cell was wet</code> · <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">maximum_water_depth</code> → <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">Maximum water depth</code> · <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">maximum_flow_velocity</code> → <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">Maximum flow velocity</code> · <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">wind_speed_u</code> → <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">Wind speed u-component</code> · <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">wind_speed_v</code> → <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">Wind speed v-component</code> · <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">maximum_wind_speed</code> → <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">Maximum wind speed</code> · <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">surface_air_pressure</code> → <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">Surface air pressure</code> · <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">precipitation_rate</code> → <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">Precipitation rate</code> · <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">tsunami_arrival_time</code> → <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">Tsunami arrival time</code> · <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">non_hydrostatic_pressure</code> → <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">Non-hydrostatic pressure</code> · <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">total_model_runtime_in_seconds</code> → <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">Total model runtime (s)</code> · <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">model_average_timestep_in_seconds</code> → <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">Average model time step (s)</code> · <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">infiltration_rate</code> → <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">Infiltration rate</code> · <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">flow_velocity_magnitude</code> → <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">Flow velocity magnitude</code> · <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">wind_speed</code> → <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">Wind speed</code> · <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">cumulative_precipitation</code> → <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">Cumulative precipitation</code></p><h3 style="color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(30, 30, 30); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Tested on</h3><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(30, 30, 30); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">QGIS 3.40.10 / MDAL (provider_mdal.dll) — quadtree output loads immediately as a UGRID mesh layer with all datasets visible.</p><!--EndFragment-->
</body>
