### PR TITLE
- Add sanity check warning;

### DIFF
--- a/source/src/sfincs_meteo.f90
+++ b/source/src/sfincs_meteo.f90
@@ -126,6 +126,19 @@ contains
             spw_ye(it) = yy
          enddo
          !
+      else
+         !
+         ! utmzone not set: sanity check for a projected SFINCS model combined with
+         ! spiderweb eye coordinates that still look like geographic lon/lat (degrees).
+         ! In that case the spiderweb will not overlap the projected grid -> zero wind.
+         !
+         if (.not. crsgeo .and. abs(spw_xe(1)) <= 360.0 .and. abs(spw_ye(1)) <= 90.0) then
+            !
+            call write_log('Warning : SFINCS model is projected but utmzone is not set, while the spiderweb eye coordinates look like geographic lon/lat (degrees).', 1)
+            call write_log('Warning : the spiderweb likely does not overlap the model domain, resulting in (near-)zero wind. Set "utmzone" in sfincs.inp to reproject the spiderweb.', 1)
+            !
+         endif
+         !
       endif
       !
    endif   


### PR DESCRIPTION
A spiderweb storm silently produced (near-)zero wind when the SFINCS model used a projected CRS but utmzone was left unset. Spiderweb eye coordinates are stored in geographic degrees, so without utmzone they are never reprojected and land far outside the meters-based grid, so the storm never overlaps the domain.

Add a sanity check in read_meteo_data: when the model is projected (.not. crsgeo), utmzone is unset, and the eye coordinates fall within valid lon/lat ranges (|x| <= 360, |y| <= 90), log a warning pointing the user to set utmzone. The range heuristic avoids false positives on legitimately projected spiderwebs. Warning only; the run continues.