### PR TITLE
Fix directional edge boundary conditions in snapwave wind solver

### DIFF
--- a/source/src/sfincs_lib.f90
+++ b/source/src/sfincs_lib.f90
@@ -94,8 +94,8 @@ module sfincs_lib
    !
    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
    !
-   build_revision = "$Rev: v2.4.0 Galibier Release"
-   build_date     = "$Date: 2026-06-11"
+   build_revision = "$Rev: v2.4.0 Galibier+branch:fix_snapwave_wind_directional_dependency"
+   build_date     = "$Date: 2026-07-10"
    !
    call write_log('', 1)
    call write_log('------------ Welcome to SFINCS ------------', 1)

--- a/source/src/snapwave/snapwave_solver.f90
+++ b/source/src/snapwave/snapwave_solver.f90
@@ -788,10 +788,8 @@ contains
             !
          enddo
          !
-         ! Directional edge BCs: first-order upwind, open at the grid ends.
-         ! (solve_tridiag is a plain Thomas solver and ignores A(1)/C(ntheta),
-         !  so a periodic wrap here is silently dropped; use the same upwind
-         !  scheme as the IG (ee_ig) and action (aa) balances instead.)
+         ! Directional edge BCs: first-order upwind, open at the grid ends, 
+         ! same upwind scheme as the IG (ee_ig) and action (aa) balances
          !
          if (ctheta(1, k) < 0.0) then
             A(1) = 0.0

--- a/source/src/snapwave/snapwave_solver.f90
+++ b/source/src/snapwave/snapwave_solver.f90
@@ -788,13 +788,30 @@ contains
             !
          enddo
          !
-         A(1) = - ctheta(ntheta, k) * oneover2dtheta
-         B(1) = oneoverdt + cg(k) / ds(1, k) + DoverE(k)
-         C(1) = ctheta(2, k) * oneover2dtheta
+         ! Directional edge BCs: first-order upwind, open at the grid ends.
+         ! (solve_tridiag is a plain Thomas solver and ignores A(1)/C(ntheta),
+         !  so a periodic wrap here is silently dropped; use the same upwind
+         !  scheme as the IG (ee_ig) and action (aa) balances instead.)
          !
-         A(ntheta) = -ctheta(ntheta - 1, k) * oneover2dtheta
-         B(ntheta) =  oneoverdt + cg(k) / ds(ntheta, k) + DoverE(k)
-         C(ntheta) =  ctheta(1, k) * oneover2dtheta
+         if (ctheta(1, k) < 0.0) then
+            A(1) = 0.0
+            B(1) = oneoverdt - ctheta(1, k) / dtheta + cg(k) / ds(1, k) + DoverE(k)
+            C(1) = ctheta(2, k) / dtheta
+         else
+            A(1) = 0.0
+            B(1) = oneoverdt + cg(k) / ds(1, k) + DoverE(k)
+            C(1) = 0.0
+         endif
+         !
+         if (ctheta(ntheta, k) > 0.0) then
+            A(ntheta) = -ctheta(ntheta - 1, k) / dtheta
+            B(ntheta) =  oneoverdt + ctheta(ntheta, k) / dtheta + cg(k) / ds(ntheta, k) + DoverE(k)
+            C(ntheta) =  0.0
+         else
+            A(ntheta) = 0.0
+            B(ntheta) = oneoverdt + cg(k) / ds(ntheta, k) + DoverE(k)
+            C(ntheta) = 0.0
+         endif
          !
          if (wind) R(:) = R(:) + WsorE(:, k)
          !


### PR DESCRIPTION
## Summary

Fix the directional edge boundary conditions in the snapwave wind energy balance solver.

The previous code applied a **periodic wrap** at the directional grid ends via `A(1)` / `C(ntheta)`. However `solve_tridiag` is a plain Thomas solver that ignores `A(1)` and `C(ntheta)`, so the periodic coupling was silently dropped, leaving an inconsistent boundary treatment.

This replaces it with **first-order upwind, open boundaries** at the directional grid ends — the same scheme already used in the IG (`ee_ig`) and action (`aa`) balances.

## Changes

- `source/src/snapwave/snapwave_solver.f90`: upwind directional edge BCs at `k=1` and `k=ntheta`, branching on the sign of `ctheta`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)