### PR TITLE
Qsrc array + urban drainage + drainage structure rewrite

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -103,10 +103,11 @@ The SFINCS team also includes Koen van Asselt, Tycho Bovenschen, Ap van Dongeren
    :maxdepth: 3
    :hidden:
    :caption: User manual:
-   
+
    input
    input_forcing
-   input_structures     
+   input_structures
+   input_urban_drainage
 
 .. toctree::
    :maxdepth: 3   

--- a/docs/input.rst
+++ b/docs/input.rst
@@ -1,5 +1,5 @@
-﻿User manual - general
-=====
+﻿General
+=======
 
 Overview
 -----
@@ -359,12 +359,35 @@ SFINCS allows the specification of the following options for accounting for infi
 3.	The Curve Number method: empirical rainfall-runoff model 
 4.	The Green-Ampt method: empirical rainfall-runoff model
 5.	The Horton infiltration method
+6.	The bucket model: linear reservoir with losses
 
-Infiltration is specified with either constant in time values in mm/hr (both uniform and spatially varying), or using more detailed parameters for the Curve Number method, The Green-Ampt method or Horton method.
+Spatially uniform infiltration is still specified directly in sfincs.inp with ``qinf``. All modern spatially varying infiltration and bucket-model input should be provided through ``infiltrationfile`` together with ``infiltrationtype``. The older binary keywords (``qinffile``, ``scsfile``, ``smaxfile``, ``sefffile``, ``ksfile``, ``psifile``, ``sigmafile``, ``f0file``, ``fcfile`` and ``kdfile``) remain available for backward compatibility only and should be removed in a future cleanup.
 
 **NOTE - Infiltration in SFINCS is only turned on when any rainfall is forced** 
 
 **NOTE - Infiltration methods in SFINCS are not designed to be stacked**
+
+
+NetCDF infiltration input (recommended):
+%%%%%
+
+For all spatially varying infiltration methods the recommended interface is:
+
+.. code-block:: text
+
+	infiltrationfile = sfincs.infiltration.nc
+	infiltrationtype = c2d | cna | cnb | gai | hor | bkt
+
+The required variables in ``infiltrationfile`` depend on ``infiltrationtype``:
+
+* ``c2d``: ``qinf``
+* ``cna``: ``scs``
+* ``cnb``: ``smax``, ``seff``, ``ks``
+* ``gai``: ``psi``, ``sigma``, ``ks``
+* ``hor``: ``f0``, ``fc``, ``kd``
+* ``bkt``: ``bucket_smax``, ``bucket_k``, ``bucket_loss``
+
+The older separate binary infiltration keywords are still supported for backward compatibility only. The former separate inputs ``bucketfile`` and ``bucket_loss_frac`` have been removed; for the bucket model, all required variables must now be present in ``infiltrationfile``.
 
 
 Spatially uniform constant in time:
@@ -383,7 +406,7 @@ Specify the keyword:
 Spatially varying constant in time:
 %%%%%
 
-For spatially varying infiltration values per cell use the qinffile option, with the same grid based input as the depfile using a binary file.
+For spatially varying infiltration values per cell use ``infiltrationfile`` with ``infiltrationtype = c2d``. The ``qinffile`` option below is kept for backward compatibility only and should be removed in a future cleanup.
 
 **qinffile = sfincs.qinf**
 
@@ -426,7 +449,7 @@ where Smax = the soil's maximum moisture storage capacity. Smax typically derive
 
 **Without recovery**
 
-For spatially varying infiltration values per cell using the Curve Number method without recovery use the scsfile option, with the same grid based input as the depfile using a binary file. Note here that in pre-processing the wanted CN values should be converted to S values following:
+For spatially varying infiltration values per cell using the Curve Number method without recovery use ``infiltrationfile`` with ``infiltrationtype = cna``. The ``scsfile`` option below is kept for backward compatibility only and should be removed in a future cleanup. Note here that in pre-processing the wanted CN values should be converted to S values following:
 * scsfile: maximum soil moisture storage capacity in inches
 
 .. code-block:: text
@@ -458,7 +481,7 @@ This option doesn't support restart functionality.
 
 **With recovery**
 
-Within SFINCS, the Curve number method with recovery can be used as follows. The user needs to provide the following variables. For all variables, one needs to specify these values per cell with the same grid based input as the depfile using a binary file:
+Within SFINCS, the Curve number method with recovery is preferably supplied through ``infiltrationfile`` with ``infiltrationtype = cnb``. The separate binary files listed below are kept for backward compatibility only. For all variables, one needs to specify these values per cell with the same grid based input as the depfile using a binary file:
 
 * smaxfile: maximum soil moisture storage capacity in m
 * sefffile: soil moisture storage capacity at the start in m
@@ -498,7 +521,7 @@ The basic form of the Green-Ampt equation is expressed as follows:
 
 In which t is time, K is the saturated hydraulic conductivity, delta_theta is defined as the soil capacity (the difference between the saturated and initial moisture content) and sigma is the soil suction head.
 
-Within SFINCS, the Green-Ampt method can be used as follows. The user needs to provide the following variables. For a range of typical values see Table 1. For all variables, one needs to specify these values per cell with the same grid based input as the depfile using a binary file:
+Within SFINCS, the Green-Ampt method is preferably supplied through ``infiltrationfile`` with ``infiltrationtype = gai``. The separate binary files listed below are kept for backward compatibility only. For a range of typically values see Table 1. For all variables, one needs to specify these values per cell with the same grid based input as the depfile using a binary file:
 
 * ksfile: saturated hydraulic conductivity in mm/hr
 * sigmafile: soil moisture deficit in [-]
@@ -522,7 +545,7 @@ The basic form of the Horton equation is expressed as follows:
 
 In which f_t is the infiltration rate at time, f_c is the final, constant infiltration rate, f_0 is the initial infiltration rate, k is a decay constant and t is the time since the start of infiltration.
 
-Within SFINCS, the Horton method can be used as follows. The user needs to provide the following variables. For all variables, one needs to specify these values per cell with the same grid based input as the depfile using a binary file:
+Within SFINCS, the Horton method is preferably supplied through ``infiltrationfile`` with ``infiltrationtype = hor``. The separate binary files listed below are kept for backward compatibility only. For all variables, one needs to specify these values per cell with the same grid based input as the depfile using a binary file:
 
 * f0file: maximum (Initial) Infiltration Capacity in mm/hr
 * fcfile: Minimum (Asymptotic) Infiltration Rate in mm/hr
@@ -531,6 +554,37 @@ Within SFINCS, the Horton method can be used as follows. The user needs to provi
 The recovery of the infiltration rate during dry weather (kr) is calculated as factor of the empirical decay constant. By default, this keyword (horton_kr_kd) is set to 10.0 meaning that the recovery goes 10 times as slow as the decay.
 
 This option also supports restart functionality. 
+
+
+The bucket model:
+%%%%%
+
+The bucket model is a linear-reservoir representation of infiltration and losses. It is configured with:
+
+.. code-block:: text
+
+	infiltrationfile = sfincs.infiltration.nc
+	infiltrationtype = bkt
+
+The ``infiltrationfile`` must contain the following variables:
+
+* ``bucket_smax``: maximum bucket storage in mm
+* ``bucket_k``: drainage coefficient in 1/hr
+* ``bucket_loss``: loss fraction in the range 0-1
+
+The former separate inputs ``bucketfile`` and ``bucket_loss_frac`` are no longer supported.
+
+
+Drainage mimic:
+%%%%%
+
+Drainage mimic is configured separately from infiltration and now only supports ``drainagefile``:
+
+.. code-block:: text
+
+	drainagefile = sfincs.drainage
+
+This file may be a binary map or a NetCDF file containing ``drainage_rate`` in mm/hr. The former uniform ``qdrain`` keyword has been removed.
 
 
 Storage volume

--- a/docs/input_structures.rst
+++ b/docs/input_structures.rst
@@ -1,14 +1,13 @@
-﻿User manual - structures
-=====
+﻿Structures
+==========
 
 Overview
 -----
 
 The input for SFINCS is supplied using various text and binary files, which are linked through the main input file: sfincs.inp.
-Within this section of the user manual all different types of structures to reduce flood hazards with input settings and files are discussed.
-The figure below gives an overview of all different types of input files and whether they are required or not.
-Below an example is given of this file, which uses a keyword/value layout. 
-For more information regarding specific parameters see the pages 'Input parameters' or 'Output parameters'.
+This section of the user manual describes the different types of structures that can be used to represent flood hazard reduction measures, together with their input settings and files.
+The figure below gives an overview of the input files and indicates whether each one is required or optional.
+For more information regarding specific parameters, see the pages 'Input parameters' or 'Output parameters'.
 
 **NOTE - In the manual below, blocks named 'Python example using HydroMT-SFINCS' are included, referring to easy setup functions of the HydroMT-SFINCS Python toolbox: https://deltares.github.io/hydromt_sfincs/latest/**
 
@@ -16,18 +15,18 @@ For more information regarding specific parameters see the pages 'Input paramete
    :width: 800px
    :align: center
 
-   Overview of input file of SFINCS with indication whther they are required or not
+   Overview of input file of SFINCS with indication whether they are required or not
 
-Structures
------
+Flow-blocking structures
+------------------------
 
-SFINCS consists of multiple options for adding structures that can divert or block flow of water, which can be used to simulate flood hazard reduction methods.
+SFINCS provides several types of structures that block or throttle the flow of water between grid cells, which can be used to simulate flood hazard reduction measures.
 
 Thin dam
 ^^^^^
 
-With a thin dam flow through certain grid cells is completely blocked (i.e. an infinitely high wall).
-One can provide multiple polylines within one file, a maximum of 5000 supplied points is supported.
+A thin dam blocks the cell-to-cell connections (u/v faces) that the polyline snaps to, acting as an infinitely high wall along those faces. Flow parallel to the dam is unaffected — only the normal-component fluxes across the snapped faces are set to zero.
+Multiple polylines can be supplied within a single file.
 The supplied polylines are snapped onto the SFINCS grid within the model.
 
 .. figure:: ./figures/SFINCS_thindam_grid.png
@@ -77,14 +76,27 @@ The supplied polylines are snapped onto the SFINCS grid within the model.
 Weirs
 ^^^^^
 
-Weirs are in principle the same as a thin dam, but then with a certain height (levee).
-When the water level on either or both sides of the weir are higher than that of the weir, a flux over the weir is calculated.
-Hereby a situation where the weir is partly or fully submerged is distinguished.
-Besides the x&y locations per points, also the elevation z and a Cd coefficient for the weir formula (recommended to use 0.6).
+Weirs are similar to a thin dam, but with a finite crest elevation (like a levee).
+When the water level on either or both sides of the weir is higher than the weir crest, a flux over the weir is calculated.
+A distinction is made between free (modular) flow and submerged flow, using a broad-crested weir formula:
+
+.. math::
+
+   q =
+   \begin{cases}
+   C_d \cdot 1.7049 \cdot h_1^{3/2},                     & h_2 \le \tfrac{2}{3}\, h_1 \quad\text{(free flow)} \\
+   C_d \cdot h_2 \cdot \sqrt{2\, g\, (h_1 - h_2)},       & h_2 >   \tfrac{2}{3}\, h_1 \quad\text{(submerged)}
+   \end{cases}
+
+where :math:`h_1 = \max(z_{s,\text{up}} - z_\text{weir},\, 0)` is the head above the crest on the upstream side, :math:`h_2 = \max(z_{s,\text{dn}} - z_\text{weir},\, 0)` is the head on the downstream side, :math:`z_\text{weir}` is the user-supplied crest elevation, :math:`C_d` is the user-supplied discharge coefficient (0.6 is a typical value), and :math:`g = 9.81` m/s². The discharge :math:`q` is per unit width; SFINCS multiplies by the length of the weir segment inside each grid cell. The constant 1.7049 is :math:`\tfrac{2}{3}\sqrt{\tfrac{2}{3} g}`, the standard broad-crested free-flow coefficient.
+
+Each point in the weir file carries its x and y location, the crest elevation z, and the :math:`C_d` coefficient.
 The supplied polylines are snapped onto the SFINCS grid within the model.
-While running SFINCS the number of structure uv points found is displayed, e.g.:
-	Info : 7932 structure u/v points found
-Note that SFINCS displays the points found after snapping to the grid (max 2 per grid cell), not how many were specified in the input.
+While running SFINCS, the number of structure uv-points found (after snapping) is displayed, e.g.::
+
+   Info : 7932 structure u/v points found
+
+Note that this is the count after snapping to the grid (at most 2 per grid cell), not the number of points supplied in the input.
 
 The snapped coordinates are available in sfincs_his.nc as structure_x, structure_y & structure_height from SFINCS v2.0.2 onwards.
 
@@ -131,30 +143,38 @@ The snapped coordinates are available in sfincs_his.nc as structure_x, structure
 
 **NOTE - If your weir elevation is unknown a priori, you can also let HydroMT-SFINCS derive this from an input (low-resolution) DEM by specifying 'dep' and adding a certain assumed elevation 'dz'**
 
-Drainage Pumps and Culverts
-^^^^^
+Drainage Structures
+-------------------
 
-**Introduction**
+.. important::
 
-In SFINCS, drainage pumps, culverts and check valves (one way culverts) are specified using the same input file format, with the structure type distinguished by an indicator:
+   **Drainage structures do not block flow.** They simply transfer water
+   from one grid cell (the intake, ``src_1``) to another (the outfall,
+   ``src_2``), without representing any physical barrier. If the drainage
+   path passes through an embankment, dam face, or culvert wall that is
+   not already resolved by the model topography, that blocking
+   geometry must be added separately using a thin dam or a weir. Without
+   it, water will simply flow around the drainage structure as if it were
+   not there.
 
-- type=1: Drainage pump
-- type=2: Culvert
-- type=3: Check valve
+**Overview**
 
-A drainage pump moves water from a retraction point (source location) to an outflow point (sink location) at a specified discharge rate, as long as there is enough water available at the retraction point. The discharge rate is defined using the par1 parameter.
+SFINCS supports four types of internal drainage structures that move water between two grid cells without resolving the flow through a physical momentum equation. They are configured through a single file (typically sfincs.drn, TOML format), referenced from ``sfincs.inp`` with the ``drnfile`` keyword:
 
-For culverts, par1 represents the discharge capacity. The actual flow through the culvert depends on the water level difference (head difference) between the upstream and downstream ends. This gradient determines how much water flows through the culvert based on the capacity defined in par1.
+.. code-block:: text
 
-The check valve requires the same par1 discharge capacity input as a culvert, but only allows flow in one direction, preventing backflow (e.g. for a one-way tide gate). Water is only flowing if the water level at input point 1 is larger than the water level at output point 2.
+   drnfile = sfincs.drn
 
-**Input Parameters**
+The four structure types are:
 
-- x & y locations: Coordinates for the retraction (source) and outflow (sink) points.
-- Type: Specifies if the structure is a drainage pump (type=1), a culvert (type=2) or a check valve (type=3).
-- par1: Sets the discharge capacity. Additional parameters (par2 to par5) are included as placeholders for future updates.
+- ``pump`` — drainage pump. Moves a prescribed discharge ``q`` from ``src_1`` to ``src_2``, limited by available water.
+- ``culvert_simple`` — lumped one-coefficient culvert. Bidirectional by default.
+- ``culvert`` — regime-aware detailed culvert with geometry (width, height, invert elevations) and a submergence threshold.
+- ``gate`` — bidirectional gate with a sill and an inertial culvert-style momentum update (Bates et al., 2010).
 
-You can know how much discharge is extracted by the model in the sfincs_his.nc output by specifying 'storeqdrain=1' from SFINCS v2.0.2 onwards, see the description in "Input parameters".
+All structures can be driven by optional rule expressions (see :ref:`open/close rules <drn_rules>` below) that open or close the structure based on water levels at user-chosen observation cells.
+
+You can record how much discharge each structure extracts in the ``sfincs_his.nc`` output by setting ``storeqdrain = 1`` in ``sfincs.inp``.
 
 .. figure:: ./figures/SFINCS_drainage_grid.png
    :width: 400px
@@ -162,61 +182,392 @@ You can know how much discharge is extracted by the model in the sfincs_his.nc o
 
    Example of how drainage pump/culvert input points with sink and source locations from 2 different structures are snapped to the grid of SFINCS.
 
-**drnfile = sfincs.drn**
+**Common input keys**
+
+Every ``[[src_structure]]`` block carries a small set of keys that are shared across all four types. Per-type required and optional keys are documented in the sub-subsections further below.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 14 64
+
+   * - Key
+     - Type
+     - Description
+   * - **name**
+     - string
+     - Unique identifier for the structure. Required.
+   * - **type**
+     - string
+     - One of ``"pump"``, ``"culvert_simple"``, ``"culvert"``, ``"gate"``. The legacy alias ``"check_valve"`` maps to ``culvert_simple`` with ``direction = "positive"``. Required.
+   * - **src_1_x, src_1_y**
+     - real
+     - Coordinates of the intake (``src_1``) cell, in the grid CRS. Required.
+   * - **src_2_x, src_2_y**
+     - real
+     - Coordinates of the outfall (``src_2``) cell, in the grid CRS. Required.
+   * - obs_1_x, obs_1_y
+     - real
+     - Coordinates of the observation cell feeding the ``z1`` atom in rule expressions. Default: the ``src_1`` coordinates.
+   * - obs_2_x, obs_2_y
+     - real
+     - Coordinates of the observation cell feeding the ``z2`` atom in rule expressions. Default: the ``src_2`` coordinates.
+   * - direction
+     - string
+     - Flow-direction filter. One of ``"both"`` (default), ``"positive"`` (allow flow ``src_1 -> src_2`` only), ``"negative"`` (allow flow ``src_2 -> src_1`` only). Meaningful for bidirectional types (``culvert_simple``, ``culvert``); ``pump`` is one-way by construction and ``gate`` is typically left bidirectional.
+   * - opening_duration
+     - real
+     - Ramp time (s) for the closed → open transition. Default: **600.0** for ``gate``; **0.0** (instant) for ``pump``, ``culvert_simple``, ``culvert``.
+   * - closing_duration
+     - real
+     - Ramp time (s) for the open → closed transition. Same defaults as ``opening_duration``.
+   * - rules_open
+     - string
+     - Water-level expression that triggers opening. See :ref:`open/close rules <drn_rules>`.
+   * - rules_close
+     - string
+     - Water-level expression that triggers closing. See :ref:`open/close rules <drn_rules>`.
+
+Pump
+^^^^
+
+A drainage pump moves water from the intake cell ``src_1`` to the outfall cell ``src_2`` at a prescribed discharge ``q`` (m³/s). The discharge is signed in the sense that ``q > 0`` pumps from ``src_1`` to ``src_2``; ``q < 0`` reverses the direction. As the upstream depth drops below a small internal threshold (0.1 m, hard-coded), the discharge is scaled linearly so the pump cannot pump a cell dry:
+
+.. math::
+
+   Q = q \cdot \min\!\left(1,\, \frac{h_\text{up}}{0.1~\text{m}}\right)
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 14 64
+
+   * - Key
+     - Type
+     - Description
+   * - **q**
+     - real
+     - Nominal pump discharge in m³/s. Required. The dry-prevention scaling above is an internal safety and is not user-tunable.
+
+All common keys (``name``, ``type``, ``src_*``, ``obs_*``, ``direction``, ``opening_duration``, ``closing_duration``, ``rules_open``, ``rules_close``) are accepted as documented in the common-keys table above.
+
+.. code-block:: toml
+
+   [[src_structure]]
+   name        = "south_pump"
+   type        = "pump"
+   src_1_x     =  50.0
+   src_1_y     =  25.0
+   src_2_x     = 150.0
+   src_2_y     =  25.0
+   q           = 0.345
+   rules_open  = "z1 > 0.20"
+   rules_close = "z1 < 0.05"
+
+Culvert (simple)
+^^^^^^^^^^^^^^^^
+
+The simple culvert uses a single lumped coefficient and a square-root head-difference law. It is the fastest choice when geometry is unknown or unimportant. Setting ``direction = "positive"`` (or equivalently using the ``check_valve`` type alias) turns the structure into a check valve that blocks backflow — useful for one-way tide gates and similar features.
+
+.. math::
+
+   Q = c_f \cdot \operatorname{sign}(\Delta h) \cdot \sqrt{|\Delta h|}
+
+with :math:`\Delta h = z_{s,1} - z_{s,2}`.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 14 64
+
+   * - Key
+     - Type
+     - Description
+   * - **flow_coef**
+     - real
+     - Lumped discharge coefficient :math:`c_f` from the formula above (units chosen so the formula returns m³/s when ``Δh`` is in m). Required.
+
+All common keys are accepted. Set ``direction = "positive"`` (or use ``type = "check_valve"``) to block backflow.
+
+.. code-block:: toml
+
+   [[src_structure]]
+   name      = "north_check_valve"
+   type      = "culvert_simple"
+   direction = "positive"
+   src_1_x   =  75.0
+   src_1_y   =  25.0
+   src_2_x   = 125.0
+   src_2_y   =  25.0
+   flow_coef = 0.345
+
+Culvert (detailed)
+^^^^^^^^^^^^^^^^^^
+
+The detailed culvert resolves the two usual culvert regimes — submerged (orifice-like) and free / inlet-controlled — based on the ratio of downstream to upstream heads above the controlling sill. The controlling sill is the higher of the two inverts, :math:`z_\text{sill} = \max(\text{invert}_1, \text{invert}_2)`; upstream and downstream are assigned on the fly from the sign of :math:`\Delta h`, so the structure is bidirectional (restrict with ``direction`` if needed).
+
+Let :math:`h_\text{up}`, :math:`h_\text{dn}` be the upstream and downstream depths above :math:`z_\text{sill}`, and :math:`A_\text{eff} = w \cdot \min(h_\text{up}, H)` (capped at barrel height). Then
+
+.. math::
+
+   Q =
+   \begin{cases}
+   c_f \cdot A_\text{eff} \cdot \sqrt{2 g\, |\Delta h|}, & h_\text{dn}/h_\text{up} \ge r_\text{sub} \quad\text{(submerged)} \\
+   c_f \cdot A_\text{eff} \cdot \sqrt{2 g\, h_\text{up}}, & h_\text{dn}/h_\text{up} < r_\text{sub} \quad\text{(free / inlet-controlled)}
+   \end{cases}
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 14 64
+
+   * - Key
+     - Type
+     - Description
+   * - **width**
+     - real
+     - Culvert barrel width (m). Required.
+   * - **height**
+     - real
+     - Culvert barrel height (m). Used to cap the flow area. Required.
+   * - **invert_1**
+     - real
+     - Invert elevation at the ``src_1`` end (m, same datum as ``zb``). Required.
+   * - **invert_2**
+     - real
+     - Invert elevation at the ``src_2`` end (m, same datum as ``zb``). Required.
+   * - flow_coef
+     - real
+     - Orifice discharge coefficient :math:`c_f`. Default: **0.6**.
+   * - submergence_ratio
+     - real
+     - Threshold :math:`r_\text{sub}` on :math:`h_\text{dn}/h_\text{up}` that switches between the two regimes. Default: **0.667** (the classic broad-crested-weir / Villemonte value).
+
+All common keys are accepted.
+
+.. code-block:: toml
+
+   [[src_structure]]
+   name              = "west_culvert"
+   type              = "culvert"
+   src_1_x           = 100.0
+   src_1_y           =  50.0
+   src_2_x           = 100.0
+   src_2_y           = 150.0
+   width             = 1.2
+   height            = 1.0
+   invert_1          = 0.20
+   invert_2          = 0.15
+   flow_coef         = 0.6
+   submergence_ratio = 0.667
+
+Gate
+^^^^
+
+The gate is a bidirectional opening with a horizontal sill. Discharge is computed from an inertial culvert-style momentum update (Bates et al., 2010), per unit width, and then multiplied by the gate ``width``. The previous-step discharge :math:`q^n` is carried through the relaxation blend, so the gate has memory on the order of ``structure_relax`` time steps.
+
+With :math:`h = \max(\max(z_{s,1}, z_{s,2}) - z_\text{sill},\, 0)` and :math:`\partial z_s/\partial s = (z_{s,2} - z_{s,1})/L`:
+
+.. math::
+
+   q^{n+1} =
+   \frac{q^n - g\, h\, (\partial z_s/\partial s)\, \Delta t}
+        {1 + g\, n^2\, \Delta t\, |q^n| / h^{7/3}}
+
+then :math:`Q = c_f \cdot q^{n+1} \cdot w \cdot \text{fraction\_open}`, where :math:`c_f` is ``flow_coef``.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 14 64
+
+   * - Key
+     - Type
+     - Description
+   * - **width**
+     - real
+     - Gate width (m). Required.
+   * - **sill_elevation**
+     - real
+     - Sill elevation :math:`z_\text{sill}` (m, same datum as ``zb``). Required.
+   * - mannings_n
+     - real
+     - Manning's roughness coefficient on the gate sill. Default: **0.024** (concrete-lined).
+   * - flow_coef
+     - real
+     - Lumped discharge coefficient :math:`c_f` from the formula above, accounting for additional losses not captured by the Manning friction term. Default: **1.0** (no extra loss).
+
+All common keys are accepted. The gate defaults ``opening_duration`` and ``closing_duration`` to **600 s** (matching legacy ``dtype = 4`` behaviour) rather than the 0 s default used by the other three types.
+
+.. code-block:: toml
+
+   [[src_structure]]
+   name             = "east_tide_gate"
+   type             = "gate"
+   src_1_x          = 200.0
+   src_1_y          =  25.0
+   src_2_x          = 250.0
+   src_2_y          =  25.0
+   obs_2_x          = 260.0   # observe water level just outside the gate
+   obs_2_y          =  25.0
+   width            = 3.0
+   sill_elevation   = 0.20
+   mannings_n       = 0.024
+   opening_duration = 300.0
+   closing_duration = 300.0
+   rules_open       = "z2-z1 > 0.10"
+   rules_close      = "z2-z1 < 0.0 | z2>1.0"
+
+.. _drn_rules:
+
+**Open/close rules and the state machine**
+
+Each structure has an internal state machine with four states:
+
+- ``0`` — closed
+- ``1`` — open
+- ``2`` — opening (transient, time-based)
+- ``3`` — closing (transient, time-based)
+
+At every time step, SFINCS checks the current state of the structure. If the structure is closed, it evaluates the ``rules_open`` expression; when that rule becomes true, the structure starts opening and ``fraction_open`` increases linearly from 0 to 1 over ``opening_duration`` seconds. If the structure is open, it evaluates the ``rules_close`` expression; when that rule becomes true, the structure starts closing and ``fraction_open`` decreases linearly from 1 to 0 over ``closing_duration`` seconds. While a structure is opening or closing, SFINCS only looks at the clock — the rules are not re-checked — so the structure cannot rapidly toggle on and off. Set ``opening_duration`` or ``closing_duration`` to ``0.0`` for an instantaneous transition. A structure without rules simply stays fully open for the entire simulation.
+
+The rules use a small expression language. The building blocks are:
+
+- ``z1`` — water level at the ``obs_1`` cell (m)
+- ``z2`` — water level at the ``obs_2`` cell (m)
+- ``z2-z1`` — the head difference (m); note there is no ``z1-z2`` form, so flip the comparison sign instead (``z1-z2 > 0.1`` becomes ``z2-z1 < -0.1``)
+
+You compare one of these against a number using ``<`` or ``>`` (the ``<=`` and ``>=`` forms are not supported). Multiple comparisons can be combined with ``&`` for "and" and ``|`` for "or", and you can use parentheses to group them. All names are case-insensitive.
+
+Examples:
 
 .. code-block:: text
 
-	<xsnk1> <ysnk1> <xsrc1> <ysrc1> <type1> <par1-1> par2-1 par3-1 par4-1 par5-1
-	<xsnk2> <ysnk2> <xsrc2> <ysrc2> <type2> <par1-2> par2-2 par3-2 par4-2 par5-2
+   rules_open  = "z1 > 0.5"                               # open whenever intake rises above 0.5 m
+   rules_close = "z2 > 2.0"                               # close when the outfall floods above 2 m
+   rules_open  = "(z1 < 0.5 | z2-z1 > 0.05) & z2 < 1.5"   # complex trigger
+   rules_close = "z2-z1 > 0.3"                            # close when outfall gets 0.3 m higher than intake
 
-	e.g. pump:
-	50.00        25.00       150.00        25.00 1    0.345    0.000    0.000    0.000    0.000
-       	75.00        25.00       125.00        25.00 1    0.345    0.000    0.000    0.000    0.000
-       
-       	e.g. culvert:
-       	50.00        25.00       150.00        25.00 2    0.345    0.000    0.000    0.000    0.000
-       	75.00        25.00       125.00        25.00 2    0.345    0.000    0.000    0.000    0.000
-	
+**Discharge relaxation: structure_relax**
+
+Discharges from drainage structures are relaxation-blended between time steps to damp oscillations:
+
+.. math::
+
+   q^{n+1}_{\text{blended}} = \alpha \, q^{n+1}_{\text{raw}} + (1 - \alpha) \, q^{n}, \qquad \alpha = \frac{1}{N}
+
+where :math:`N` is set by the ``structure_relax`` keyword in ``sfincs.inp`` — a dimensionless step count: a value of :math:`N` damps the discharge response over roughly :math:`N` time steps. Default is ``4.0``; typical range is 1 (no smoothing) to 10.
+
+**Output: storing structure discharges**
+
+Set ``storeqdrain = 1`` in ``sfincs.inp`` to write the time-series discharge per structure into ``sfincs_his.nc``.
+
+**Example sfincs.drn file**
+
+.. code-block:: toml
+
+   # sfincs.drn
+
+   [[src_structure]]
+   name             = "south_pump"
+   type             = "pump"
+   src_1_x          =  50.0
+   src_1_y          =  25.0
+   src_2_x          = 150.0
+   src_2_y          =  25.0
+   q                = 0.345                     # pump discharge (m^3/s)
+   rules_open       = "z1 > 0.20"               # start pumping when intake > 0.20 m
+   rules_close      = "z1 < 0.05"               # stop pumping when intake drops below 0.05 m
+
+   [[src_structure]]
+   name             = "north_check_valve"
+   type             = "culvert_simple"
+   direction        = "positive"                # one-way; blocks backflow
+   src_1_x          =  75.0
+   src_1_y          =  25.0
+   src_2_x          = 125.0
+   src_2_y          =  25.0
+   flow_coef        = 0.345
+
+   [[src_structure]]
+   name             = "west_culvert"
+   type             = "culvert"
+   src_1_x          = 100.0
+   src_1_y          =  50.0
+   src_2_x          = 100.0
+   src_2_y          = 150.0
+   width            = 1.2
+   height           = 1.0
+   invert_1         = 0.20
+   invert_2         = 0.15
+   flow_coef        = 0.6                       # orifice discharge coefficient
+   submergence_ratio = 0.667                    # h_dn/h_up threshold between submerged and inlet control
+
+   [[src_structure]]
+   name             = "east_tide_gate"
+   type             = "gate"
+   src_1_x          = 200.0
+   src_1_y          =  25.0
+   src_2_x          = 250.0
+   src_2_y          =  25.0
+   obs_2_x          = 260.0                     # observe water level just outside the gate
+   obs_2_y          =  25.0
+   width            = 3.0
+   sill_elevation   = 0.20
+   mannings_n       = 0.024
+   opening_duration = 300.0                     # 5-minute ramp open
+   closing_duration = 300.0
+   rules_open       = "z2-z1 > 0.10"            # open when outer level exceeds inner by 0.10 m
+   rules_close      = "z2-z1 < 0.0 | z2>1.0"    # close on reversal (prevents backflow) or when outer water level exceeds 1.0 m
+
 **Python example using HydroMT-SFINCS**
 
 .. code-block:: python
 
-	sf.drainage_structures.create(
-		locations="drainage_input.geojson",
-		stype='pump',
-		discharge=100.0,
-		merge=True
-	)
+   sf.drainage_structures.create(
+       locations="drainage_input.geojson",
+       stype='pump',
+       discharge=100.0,
+       merge=True
+   )
 
-	OR as a culvert:
+The ``discharge`` argument above is the pump discharge and applies to pumps only. Culverts and gates carry their own geometry-based parameters (width, height, inverts, flow coefficients, etc.) rather than a single discharge value — see the HydroMT-SFINCS documentation for the full argument list per structure type:
 
-	sf.drainage_structures.create(
-		locations="drainage_input.geojson",
-		stype='culvert',
-		discharge=100.0,
-		merge=True
-	)
+https://deltares.github.io/hydromt_sfincs/latest/_generated/hydromt_sfincs.components.geometries.SfincsDrainageStructures.create.html
 
-	More information: 
-	https://deltares.github.io/hydromt_sfincs/latest/_generated/hydromt_sfincs.components.geometries.SfincsDrainageStructures.create.html
+**Legacy fixed-column drn format**
 
-**Calculating Culvert Discharge Capacity**
+The legacy ASCII fixed-column ``.drn`` format is still accepted for back-compatibility. Each non-blank, non-comment line describes one structure with the columns:
 
-For culverts, par1 (discharge capacity) can be calculated as:
+.. code-block:: text
 
-``par1 = \(\mu \cdot A \cdot \sqrt{2g}\)``
+   <x1> <y1> <x2> <y2> <type> <par1>
 
-where:
+where ``type`` is:
 
-* \(\mu\) = dimensionless culvert loss coefficient, typically between 0 and 1
-* \(A\) = area of the culvert opening (m²)
-* \(g\) = gravitational acceleration (9.81 m/s²)
+- ``1`` — pump (``par1`` = pump discharge)
+- ``2`` — culvert (``par1`` = ``flow_coef``; maps to ``culvert_simple``)
+- ``3`` — check valve (``par1`` = ``flow_coef``; maps to ``culvert_simple`` with ``direction = "positive"``)
 
-This formula is derived from the Bernoulli Equation, which estimates flow based on the head difference.
+Example:
 
-* If \(\mu = 1\), the flow is assumed to be driven entirely by the head difference, with no friction or length-based losses.
-* If \(\mu < 1\), it accounts for additional energy losses, such as friction and entry/exit losses.
+.. code-block:: text
 
-**Planned Enhancements**
+   # pump:
+    50.00  25.00 150.00  25.00  1  0.345
+    75.00  25.00 125.00  25.00  1  0.345
 
-Future updates will incorporate the Darcy–Weisbach equation for more accurate discharge estimates by considering frictional and minor losses along the culvert length, which is particularly useful for longer or rougher conduits.
+   # culvert:
+    50.00  25.00 150.00  25.00  2  0.345
+    75.00  25.00 125.00  25.00  2  0.345
+
+When SFINCS sees a legacy ``.drn`` file it automatically transcribes it to a sibling TOML file (``sfincs.toml.drn`` if the input was ``sfincs.drn``) and then reads that. Water-level-triggered legacy gates (``type = 4``) are converted to TOML ``gate`` blocks with synthesised ``rules_open`` / ``rules_close`` expressions derived from the legacy ``zmin`` / ``zmax`` columns. Schedule-triggered legacy gates (``type = 5``) are refused; the rule grammar is water-level-only and has no time atom — rewrite those as TOML gates driven by observed water levels.
+
+.. important::
+
+   **After a legacy transcription, strongly consider renaming the generated
+   ``sfincs.toml.drn`` file to ``sfincs.drn`` (overwriting the original legacy
+   file) and pointing ``drnfile`` at it.** Future simulations will then read
+   the TOML directly, skipping the transcription step and giving you a single
+   source of truth that you can edit, version-control, and extend with the
+   newer keywords (``rules_open`` / ``rules_close``, ``reduction_depth``,
+   ``submergence_ratio``, ``direction``, per-structure invert pairs, etc.)
+   that the legacy format cannot express. Keep a backup of the original
+   legacy file elsewhere if you need it for reference.
+
+New models should be written directly in TOML; the legacy reader exists purely so that pre-TOML input decks keep running.

--- a/docs/input_structures.rst
+++ b/docs/input_structures.rst
@@ -430,9 +430,10 @@ The rules use a small expression language. The building blocks are:
 
 - ``z1`` — water level at the ``obs_1`` cell (m)
 - ``z2`` — water level at the ``obs_2`` cell (m)
-- ``z2-z1`` — the head difference (m); note there is no ``z1-z2`` form, so flip the comparison sign instead (``z1-z2 > 0.1`` becomes ``z2-z1 < -0.1``)
+- ``z2-z1`` — the head difference (m)
+- ``z1-z2`` — the negative head difference (m)
 
-You compare one of these against a number using ``<`` or ``>`` (the ``<=`` and ``>=`` forms are not supported). Multiple comparisons can be combined with ``&`` for "and" and ``|`` for "or", and you can use parentheses to group them. All names are case-insensitive.
+You compare one of these against a number using ``<``, ``>``, ``<=``, ``>=`` or ``=`` (``==`` is accepted as an alias for ``=``). Multiple comparisons can be combined with ``&`` for "and" and ``|`` for "or", and you can use parentheses to group them. All names are case-insensitive.
 
 Examples:
 

--- a/docs/input_urban_drainage.rst
+++ b/docs/input_urban_drainage.rst
@@ -1,0 +1,199 @@
+Urban Drainage
+==============
+
+Overview
+--------
+
+Urban drainage is a simple bulk sink/source model for two kinds of lumped drainage infrastructure: buried pipe networks that discharge to a receiving water body (**piped drainage**) and pumps that remove water from the model and store it underground (**injection wells**). Each **drainage zone** is a polygon in the horizontal plane and has exactly one ``type``:
+
+- ``piped_drainage`` — cells inside the polygon drain to a single outfall cell through a conceptual pipe network. Flow is bidirectional: during high water at the outfall (tide or surge), water can push back into the zone cells unless a check valve is configured. The per-zone net flux is deposited as a point source/sink at the outfall cell.
+- ``injection_well`` — cells inside the polygon are pumped down at a fixed total rate, split evenly across the cells, and the extracted water is *removed from the model* (it does not reappear at an outfall). Pumping stops when the cumulative injected volume reaches the well's maximum capacity.
+
+The approach is deliberately coarse: there is no pipe network, no hydraulic routing, no pressure head other than the difference between cell water level and outfall water level (piped_drainage) and no subsurface storage model (injection_well beyond the single capacity cap). It is intended for compound-flood applications where detailed geometry is unknown but municipal-scale design parameters (rainfall intensity, outfall pipe capacity, or pump rate + well capacity) are available.
+
+**IMPORTANT** — urban drainage does not represent physical pipes or wells. It is a mass-balance abstraction: water disappears from urban cells, and for ``piped_drainage`` reappears summed at the outfall cell. It does not block or route flow between cells.
+
+Inputs
+------
+
+The feature is activated by the ``urbfile`` keyword in ``sfincs.inp``:
+
+.. code-block:: text
+
+	urbfile                         = sfincs.urb
+	store_urban_drainage_discharge  = 1
+	store_cumulative_urban_drainage = 1
+
+``store_urban_drainage_discharge`` writes per-zone time series to ``sfincs_his.nc``: the zone total discharge and (for injection wells) the cumulative injection volume. ``store_cumulative_urban_drainage`` writes the cumulative drained depth (m) per cell to ``sfincs_map.nc``.
+
+The ``.urb`` file is a TOML document with one or more ``[[urban_drainage_zone]]`` entries.
+
+Zone definition
+---------------
+
+Every zone has three required keys regardless of type: ``name``, ``type``, and ``polygon_file``. The rest depends on the type.
+
+Piped drainage example
+^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: toml
+
+	[[urban_drainage_zone]]
+	name             = "downtown"
+	type             = "piped_drainage"
+	polygon_file     = "zones.tek"
+	outfall          = [950.0, 150.0]
+	design_precip    = 20.0
+	check_valve      = true
+
+	[[urban_drainage_zone]]
+	name             = "harbor_district"
+	type             = "piped_drainage"
+	polygon_file     = "zones.tek"
+	outfall          = [1020.0, 180.0]
+	max_outfall_rate = 6.0
+
+Injection well example
+^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: toml
+
+	[[urban_drainage_zone]]
+	name             = "north_well_field"
+	type             = "injection_well"
+	polygon_file     = "zones.tek"
+	injection_rate   = 0.5
+	maximum_capacity = 5000.0
+
+Common keys (both types)
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+``name`` (required, string)
+	Zone name. Must match a polygon name in ``polygon_file``. Used as the station identifier in ``sfincs_his.nc`` when discharge output is enabled.
+
+``type`` (required, string)
+	One of ``"piped_drainage"`` or ``"injection_well"``. Selects the per-zone physics and the set of remaining required keys.
+
+``polygon_file`` (required, string)
+	Path to a Delft3D-style ``.tek`` polygon file. Multiple zones can share the same file — each zone's ``name`` is matched against polygon names inside the file. See "Polygon file format" below.
+
+``h_threshold`` (optional, m, default ``0.0``)
+	Depth over which the drainage rate ramps linearly from zero to ``q_max``. At cell ponding depth ``h_cell = 0`` the drainage is zero; at ``h_cell >= h_threshold`` it is at full ``q_max``; in between it is ``(h_cell / h_threshold) * q_max``. Smooths the discharge time series compared to a hard on/off gate. Typical values: 0.02–0.05 m. Set to ``0.0`` to reproduce the hard-cap behaviour (full ``q_max`` for any ``h_cell > 0``).
+
+Piped drainage keys
+^^^^^^^^^^^^^^^^^^^
+
+``design_precip`` (conditional, mm/hr)
+	Design rainfall intensity the zone's drainage is sized for. Per-cell capacity is ``qmax = design_precip * cell_area / 3.6e6`` [m³/s]. Typical municipal values: 10–20 mm/hr for suburban residential, 20–40 mm/hr for dense city centre. **Exactly one of** ``design_precip`` **or** ``max_outfall_rate`` **must be provided for piped_drainage zones.**
+
+``max_outfall_rate`` (conditional, m³/s)
+	Total zone outfall capacity. Useful when you know what the outfall pipe can deliver but not the design storm it was sized for. SFINCS derives ``design_precip = max_outfall_rate / zone_area * 3.6e6`` from the zone's total polygon-covered area, so per-cell capacity is distributed proportionally to cell area. **Exactly one of** ``design_precip`` **or** ``max_outfall_rate`` **must be provided for piped_drainage zones.**
+
+``outfall`` (required when ``include_outfall = true``, 2-element array ``[x, y]``)
+	Coordinates of the single point where all zone discharge is summed and deposited. Snapped to the nearest active cell. If no active cell can be found, zone contributions are silently discarded and a warning is logged.
+
+``include_outfall`` (optional, bool, default ``true``)
+	Set to ``false`` to disable the outfall deposit step. Flow still leaves (or enters) cells, but does not reappear anywhere — treats the zone as an unconnected sink. Mostly useful for sensitivity tests.
+
+``check_valve`` (optional, bool, default ``false``)
+	When ``true``, the zone only drains outward. Backflow from the outfall into the cells (bay flooding through the pipe) is suppressed. Represents a flap valve / tide gate at the outfall.
+
+``dh_design_min`` (optional, m, default ``0.1``)
+	Floor on the per-cell design head used to compute the backflow coefficient. Per-cell backflow discharge is
+
+	.. math::
+		Q_{back}(nm) = \frac{q_{max}(nm)}{\sqrt{\max(z_b(nm) - z_b(outfall),\,\Delta h_{design,min})}} \cdot \sqrt{z_s(outfall) - z_s(nm)}
+
+	so that a cell at the outfall bed elevation, or below it, doesn't produce an infinite backflow coefficient.
+
+Injection well keys
+^^^^^^^^^^^^^^^^^^^
+
+``injection_rate`` (required, m³/s)
+	Total pumping rate across the zone. Distributed over the zone cells by cell area so the sum across zone cells is exactly ``injection_rate`` and quadtree refinement inside the polygon does not shift the per-cell flux relative to cell area:
+
+	.. math::
+		q_{max}(nm) = \text{injection\_rate} \cdot \frac{A(nm)}{A_{zone}}
+
+``maximum_capacity`` (required, m³)
+	Total volume the injection well can accept over the simulation. SFINCS tracks ``cumulative_injection_volume`` over time; once it reaches ``maximum_capacity`` pumping is skipped for that zone (flow drops to zero). There is a potential one-time-step overshoot at the transition step (per-cell flux is not scaled to hit the cap exactly).
+
+Polygon file format
+-------------------
+
+Zones are defined in a Delft3D-style ``.tek`` file — one or more named polygon blocks:
+
+.. code-block:: text
+
+	downtown
+	6 2
+	900.0  100.0
+	900.0  200.0
+	1000.0 200.0
+	1000.0 100.0
+	950.0   80.0
+	900.0  100.0
+	harbor_district
+	5 2
+	1000.0 150.0
+	1000.0 250.0
+	1100.0 250.0
+	1100.0 150.0
+	1000.0 150.0
+
+Each block has a name line, a ``nrows ncols`` line, and ``nrows`` vertex lines. If the last vertex does not equal the first, SFINCS closes the ring automatically at read time. A cell center falling inside multiple polygons is assigned to the **last** zone encountered — overlap warnings are not emitted, so order your zones with intent.
+
+Flow formulas
+-------------
+
+For each active cell ``nm`` inside zone ``iz``, with ``h_cell`` the cell ponding depth (``zs - subgrid_z_zmin`` in subgrid mode, ``zs - zb`` otherwise) and the rate ramp
+
+.. math::
+	r = \min(h_{cell} / h_{threshold},\; 1) \text{ if } h_{threshold} > 0, \text{ else } 1
+
+**Piped drainage** (``outfall cell io``):
+
+.. math::
+	\Delta z_s = z_s(nm) - z_s(io)
+
+Outflow (``Δz_s > 0`` and ``h_cell > 0``):
+
+.. math::
+	q = \min\left(r \cdot q_{max}(nm),\; \frac{h_{cell} \cdot A(nm)}{\Delta t}\right)
+
+Backflow (``Δz_s < 0`` and check valve off):
+
+.. math::
+	q = -\frac{q_{max}(nm)}{\sqrt{\max(z_b(nm) - z_b(io),\,\Delta h_{design,min})}} \cdot \sqrt{-\Delta z_s}
+
+capped at ``-q_{max}(nm)``. With ``check_valve = true`` backflow is skipped entirely.
+
+The zone's per-step net flux is deposited at the outfall cell, so mass is conserved (up to the outfall-snap warning above).
+
+**Injection well** (no outfall):
+
+.. math::
+	q = \min\left(r \cdot q_{max}(nm),\; \frac{h_{cell} \cdot A(nm)}{\Delta t}\right)
+
+where :math:`q_{max}(nm) = \text{injection\_rate} \cdot A(nm) / A_{zone}` (area-weighted split; sums to ``injection_rate`` across the zone). Flow is positive (water leaves cells) only; there is no backflow. Pumping is skipped entirely once :math:`\text{cumulative\_injection\_volume}(iz) \geq \text{maximum\_capacity}(iz)`.
+
+Outputs
+-------
+
+**``sfincs_his.nc``** — when ``store_urban_drainage_discharge = 1``:
+
+``urban_drainage_discharge(urban_drainage_zones, time)``
+	Per-zone total discharge in m³/s. Positive means net outflow from the cells (to outfall or to injection well); negative means net inflow (backflow from the outfall, piped_drainage with check valve off). Named ``urban drainage zone total discharge`` in the long_name attribute.
+
+``cumulative_injection_volume(urban_drainage_zones, time)``
+	Per-zone cumulative injection volume in m³. Tracked for all zones, but only physically meaningful for ``injection_well`` zones; ``piped_drainage`` zones keep this at 0.0 (there is no underground storage).
+
+``urban_drainage_zone_name(urban_drainage_zones)``
+	Zone names, in the order they appear in the ``.urb`` file.
+
+**``sfincs_map.nc``** — when ``store_cumulative_urban_drainage = 1``:
+
+``urban_drainage_cumulative_depth(m, n, timemax)`` (regular) or ``(nmesh2d_face, timemax)`` (quadtree)
+	Cumulative drained volume divided by cell area (m), written at the ``dtmaxout`` interval. Positive means net outflow from the cell over the simulation; negative means net inflow.
+
+At init time a per-zone summary block is written to the SFINCS log listing zone name, type, polygon file, number of cells assigned, total area, design precipitation / max outfall rate / qmax (piped_drainage) or injection rate / maximum capacity (injection_well), thresholds, outfall coords + snapped cell index (piped_drainage), and check-valve state.

--- a/docs/parameters.rst
+++ b/docs/parameters.rst
@@ -396,7 +396,15 @@ Parameters for model output
 	storeqdrain
 	  :description:		Flag to turn on writing away drainage discharge during simulation (storeqdrain = 1)
 	  :units:		-
-	  :default:		0	
+	  :default:		0
+	store_urban_drainage_discharge
+	  :description:		Flag to turn on writing away per-zone outfall discharge to 'sfincs_his.nc' on 'dthisout' interval (only effective when 'urbfile' is specified).
+	  :units:		-
+	  :default:		0
+	store_cumulative_urban_drainage
+	  :description:		Flag to turn on writing away cumulative urban drainage depth (drained volume / cell area, in m) per cell to 'sfincs_map.nc' on 'dtmaxout' interval (only effective when 'urbfile' is specified).
+	  :units:		-
+	  :default:		0
 	storezvolume
 	  :description:		Flag to turn on writing away water volumes for the subgrid mode during simulation (storezvolume = 1)
 	  :units:		-
@@ -475,54 +483,68 @@ Domain
 	  :units:		s/m^(1/3)
 	  :required:		no in case of regular mode, ignored in case of subgrid mode	  
 	  :format:		bin	 
+	infiltrationfile = sfincs.infiltration.nc
+	  :description:		Recommended NetCDF input for spatially varying infiltration and bucket-model losses. Use together with infiltrationtype.
+	  :units:		depends on selected infiltrationtype and variables in the NetCDF file
+	  :required:		no
+	  :format:		net
+	infiltrationtype = c2d | cna | cnb | gai | hor | bkt
+	  :description:		Selects which infiltration method is read from infiltrationfile. Bucket mode requires bucket_smax, bucket_k and bucket_loss in infiltrationfile.
+	  :units:		-
+	  :required:		Only when infiltrationfile is used
+	  :format:		asc
+	drainagefile = sfincs.drainage
+	  :description:		Spatially varying drainage mimic input in mm/hr. Can be a binary map or a NetCDF file with variable drainage_rate. This replaces the removed qdrain keyword.
+	  :units:		mm/hr
+	  :required:		no
+	  :format:		bin or net
 	qinffile = sfincs.qinf
-	  :description:		For spatially varying constant in time infiltration values per cell use the qinffile option, with the same grid based input as the depfile using a binary file.
+	  :description:		Backward compatibility only. For spatially varying constant in time infiltration values per cell prefer infiltrationfile with infiltrationtype = c2d.
 	  :units:		mm/hr
 	  :required:		no	  
 	  :format:		bin	  
 	scsfile = sfincs.scs
-	  :description:		For spatially varying infiltration values per cell using the Curve Number method A (without recovery) use the scsfile option, with the same grid based input as the depfile using a binary file.
+	  :description:		Backward compatibility only. For Curve Number method A (without recovery) prefer infiltrationfile with infiltrationtype = cna.
 	  :units:		-
 	  :required:		no	  
 	  :format:		bin	  	  
 	smaxfile = sfincs.smax
-	  :description:		For spatially varying infiltration values per cell using the Curve Number method B (with recovery) provide the smaxfile (as well as the sefffile and ksfile) as maximum soil moisture storage capacity in m, with the same grid based input as the depfile using a binary file.
+	  :description:		Backward compatibility only. For Curve Number method B (with recovery) prefer infiltrationfile with infiltrationtype = cnb. The smaxfile contains the maximum soil moisture storage capacity in m.
 	  :units:		m
 	  :required:		no	  
 	  :format:		bin	  	
 	sefffile = sfincs.seff
-	  :description:		For spatially varying infiltration values per cell using the Curve Number method B (with recovery) provide the sefffile (as well as the smaxfile and ksfile) as soil moisture storage capacity at the start in m, with the same grid based input as the depfile using a binary file.
+	  :description:		Backward compatibility only. For Curve Number method B (with recovery) prefer infiltrationfile with infiltrationtype = cnb. The sefffile contains soil moisture storage capacity at the start in m.
 	  :units:		m
 	  :required:		no	  
 	  :format:		bin	  
 	ksfile = sfincs.ks
-	  :description:		For spatially varying infiltration values per cell using the Curve Number method B (with recovery) provide the ksfile (as well as the smaxfile and sefffile) as saturated hydraulic conductivity in mm/hr, with the same grid based input as the depfile using a binary file.
-	  :description:		For spatially varying infiltration values per cell using the Green & Ampt method (with recovery) provide the ksfile (as well as the sigmafile and psifile) as saturated hydraulic conductivity in mm/hr, with the same grid based input as the depfile using a binary file.
+	  :description:		Backward compatibility only. For Curve Number method B (with recovery) and Green & Ampt infiltration prefer infiltrationfile with infiltrationtype = cnb or gai. The ksfile contains saturated hydraulic conductivity in mm/hr.
 	  :units:		mm/hr
 	  :required:		no	  
 	  :format:		bin	  
 	sigmafile = sfincs.sigma
-	  :description:		For spatially varying infiltration values per cell using the Green & Ampt method (with recovery) provide the sigmafile (as well as the psifile and ksfile) as suction head at the wetting front in mm, with the same grid based input as the depfile using a binary file.
-	  :units:		mm
-	  :required:		no	  
-	  :format:		bin	 
-	psifile = sfincs.psi
-	  :description:		For spatially varying infiltration values per cell using the Green & Ampt method (with recovery) provide the psifile (as well as the sigmafile and ksfile) as soil moisture deficit in [-], with the same grid based input as the depfile using a binary file.
+	  :description:		Backward compatibility only. For Green & Ampt infiltration prefer infiltrationfile with infiltrationtype = gai. The sigmafile contains soil moisture deficit in [-].
 	  :units:		-
 	  :required:		no	  
 	  :format:		bin	 
+	psifile = sfincs.psi
+	  :description:		Backward compatibility only. For Green & Ampt infiltration prefer infiltrationfile with infiltrationtype = gai. The psifile contains suction head at the wetting front in mm.
+	  :units:		mm
+	  :required:		no	  
+	  :format:		bin	 
 	f0file = sfincs.f0
-	  :description:		For spatially varying infiltration values per cell using the Horton method (with recovery) provide the f0file (as well as the fcfile and kdfile) as maximum (Initial) Infiltration Capacity in mm/hr, with the same grid based input as the depfile using a binary file.
+	  :description:		Backward compatibility only. For Horton infiltration prefer infiltrationfile with infiltrationtype = hor. The f0file contains maximum (initial) infiltration capacity in mm/hr.
 	  :units:		mm/hr
 	  :required:		no	  
 	  :format:		bin	
 	fcfile = sfincs.fc
-	  :description:		For spatially varying infiltration values per cell using the Horton method (with recovery) provide the fcfile (as well as the f0file and kdfile) as Minimum (Asymptotic) Infiltration Rate in mm/hr, with the same grid based input as the depfile using a binary file.
+	  :description:		Backward compatibility only. For Horton infiltration prefer infiltrationfile with infiltrationtype = hor. The fcfile contains the minimum (asymptotic) infiltration rate in mm/hr.
 	  :units:		mm/hr
 	  :required:		no	  
 	  :format:		bin	 	
 	kdfile = sfincs.kd
-	  :description:		For spatially varying infiltration values per cell using the Horton method (with recovery) provide the kdfile (as well as the f0file and fcfile) as empirical constant (hr-1) of decay, with the same grid based input as the depfile using a binary file.
+	  :description:		Backward compatibility only. For Horton infiltration prefer infiltrationfile with infiltrationtype = hor. The kdfile contains the empirical decay constant in hr-1.
 	  :units:		hr-1
 	  :required:		no	  
 	  :format:		bin	 		  	   	  
@@ -676,5 +698,14 @@ Structures
 	  :description:		Drainage pumps, culverts and check valves are both specified using the same format file, put with a different indication of the type (type=1 is drainage pump, type=2 is culvert and type=3 is check valve).
 	  :units:		coordinates: m in projected UTM zone, discharges in m^3/s.
 	  :required:		no
-	  :format:		asc	 
-	  
+	  :format:		asc
+
+Urban drainage
+-----
+
+	urbfile = sfincs.urb
+	  :description:		TOML file declaring one or more urban-drainage zones. Each zone is a polygon mapped to a single outfall cell; zone cells drain to the outfall at a design rate (specified either as design_precip in mm/hr or max_outfall_rate in m^3/s), and the outfall can push water back into the cells unless a check valve is set. See 'Urban Drainage' in the user manual for the full schema.
+	  :units:		coordinates: m in projected UTM zone; design rate in mm/hr or m^3/s; thresholds in m.
+	  :required:		no
+	  :format:		toml
+

--- a/source/sfincs_lib/sfincs_lib.vfproj
+++ b/source/sfincs_lib/sfincs_lib.vfproj
@@ -29,6 +29,43 @@
 		<Filter Name="Header Files" Filter="fi;fd"/>
 		<Filter Name="Resource Files" Filter="rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe"/>
 		<Filter Name="Source Files" Filter="f90;for;f;fpp;ftn;def;odl;idl">
+			<Filter Name="toml-f">
+				<File RelativePath="..\third_party_open\utils\toml-f\src\tomlf.f90"/>
+				<File RelativePath="..\third_party_open\utils\toml-f\src\tomlf\all.f90"/>
+				<File RelativePath="..\third_party_open\utils\toml-f\src\tomlf\build.f90"/>
+				<File RelativePath="..\third_party_open\utils\toml-f\src\tomlf\build\build_array.f90"/>
+				<File RelativePath="..\third_party_open\utils\toml-f\src\tomlf\build\build_keyval.f90"/>
+				<File RelativePath="..\third_party_open\utils\toml-f\src\tomlf\build\merge.f90"/>
+				<File RelativePath="..\third_party_open\utils\toml-f\src\tomlf\build\path.f90"/>
+				<File RelativePath="..\third_party_open\utils\toml-f\src\tomlf\build\build_table.f90"/>
+				<File RelativePath="..\third_party_open\utils\toml-f\src\tomlf\constants.f90"/>
+				<File RelativePath="..\third_party_open\utils\toml-f\src\tomlf\datetime.f90"/>
+				<File RelativePath="..\third_party_open\utils\toml-f\src\tomlf\de.f90"/>
+				<File RelativePath="..\third_party_open\utils\toml-f\src\tomlf\de\abc.f90"/>
+				<File RelativePath="..\third_party_open\utils\toml-f\src\tomlf\de\context.f90"/>
+				<File RelativePath="..\third_party_open\utils\toml-f\src\tomlf\de\lexer.f90"/>
+				<File RelativePath="..\third_party_open\utils\toml-f\src\tomlf\de\parser.f90"/>
+				<File RelativePath="..\third_party_open\utils\toml-f\src\tomlf\de\token.f90"/>
+				<File RelativePath="..\third_party_open\utils\toml-f\src\tomlf\diagnostic.f90"/>
+				<File RelativePath="..\third_party_open\utils\toml-f\src\tomlf\error.f90"/>
+				<File RelativePath="..\third_party_open\utils\toml-f\src\tomlf\ser.f90"/>
+				<File RelativePath="..\third_party_open\utils\toml-f\src\tomlf\structure.f90"/>
+				<File RelativePath="..\third_party_open\utils\toml-f\src\tomlf\structure\array_list.f90"/>
+				<File RelativePath="..\third_party_open\utils\toml-f\src\tomlf\structure\list.f90"/>
+				<File RelativePath="..\third_party_open\utils\toml-f\src\tomlf\structure\map.f90"/>
+				<File RelativePath="..\third_party_open\utils\toml-f\src\tomlf\structure\node.f90"/>
+				<File RelativePath="..\third_party_open\utils\toml-f\src\tomlf\structure\ordered_map.f90"/>
+				<File RelativePath="..\third_party_open\utils\toml-f\src\tomlf\terminal.f90"/>
+				<File RelativePath="..\third_party_open\utils\toml-f\src\tomlf\type.f90"/>
+				<File RelativePath="..\third_party_open\utils\toml-f\src\tomlf\type\array.f90"/>
+				<File RelativePath="..\third_party_open\utils\toml-f\src\tomlf\type\keyval.f90"/>
+				<File RelativePath="..\third_party_open\utils\toml-f\src\tomlf\type\table.f90"/>
+				<File RelativePath="..\third_party_open\utils\toml-f\src\tomlf\type\value.f90"/>
+				<File RelativePath="..\third_party_open\utils\toml-f\src\tomlf\utils.f90"/>
+				<File RelativePath="..\third_party_open\utils\toml-f\src\tomlf\utils\io.f90"/>
+				<File RelativePath="..\third_party_open\utils\toml-f\src\tomlf\utils\sort.f90"/>
+				<File RelativePath="..\third_party_open\utils\toml-f\src\tomlf\version.f90"/>
+			</Filter>
 			<Filter Name="snapwave">
 				<File RelativePath="..\src\snapwave\interp.F90">
 				</File>
@@ -107,12 +144,14 @@
 			<File RelativePath="..\src\sfincs_continuity.f90">
 			</File>
 			<File RelativePath="..\src\sfincs_crosssections.f90"/>
-			<File RelativePath="..\src\sfincs_data.f90"/>
-			<File RelativePath="..\src\sfincs_data.f90"/>
-			<File RelativePath="..\src\sfincs_date.f90"/>
-			<File RelativePath="..\src\sfincs_discharges.f90">
+			<File RelativePath="..\src\sfincs_data.f90">
 			</File>
-			<File RelativePath="..\src\sfincs_domain.f90"/>
+			<File RelativePath="..\src\sfincs_date.f90"/>
+			<File RelativePath="..\src\sfincs_discharges.f90"/>
+			<File RelativePath="..\src\sfincs_rule_expression.f90"/>
+			<File RelativePath="..\src\sfincs_src_structures.f90"/>
+			<File RelativePath="..\src\sfincs_domain.f90">
+			</File>
 			<File RelativePath="..\src\sfincs_error.f90"/>
 			<File RelativePath="..\src\sfincs_infiltration.f90"/>
 			<File RelativePath="..\src\sfincs_initial_conditions.F90"/>
@@ -166,6 +205,8 @@
 			<File RelativePath="..\src\sfincs_timestep_analysis.f90"/>
 			<File RelativePath="..\src\sfincs_vegetation.f90">
 			</File>
+			<File RelativePath="..\src\utils\sfincs_polygons.f90"/>
+			<File RelativePath="..\src\sfincs_urban_drainage.f90"/>
 			<File RelativePath="..\src\sfincs_wave_enhanced_roughness.f90"/>
 			<File RelativePath="..\src\sfincs_wavemaker.f90"/>
 		</Filter>

--- a/source/sfincs_lib/sfincs_lib.vfproj
+++ b/source/sfincs_lib/sfincs_lib.vfproj
@@ -98,43 +98,6 @@
 				</File>
 				<File RelativePath="..\src\snapwave\snapwave_windsource.f90"/>
 			</Filter>
-			<Filter Name="toml-f">
-				<File RelativePath="..\third_party_open\utils\toml-f\src\tomlf\de\abc.f90"/>
-				<File RelativePath="..\third_party_open\utils\toml-f\src\tomlf\all.f90"/>
-				<File RelativePath="..\third_party_open\utils\toml-f\src\tomlf\type\array.f90"/>
-				<File RelativePath="..\third_party_open\utils\toml-f\src\tomlf\structure\array_list.f90"/>
-				<File RelativePath="..\third_party_open\utils\toml-f\src\tomlf\build.f90"/>
-				<File RelativePath="..\third_party_open\utils\toml-f\src\tomlf\build\build_array.f90"/>
-				<File RelativePath="..\third_party_open\utils\toml-f\src\tomlf\build\build_keyval.f90"/>
-				<File RelativePath="..\third_party_open\utils\toml-f\src\tomlf\build\build_table.f90"/>
-				<File RelativePath="..\third_party_open\utils\toml-f\src\tomlf\constants.f90"/>
-				<File RelativePath="..\third_party_open\utils\toml-f\src\tomlf\de\context.f90"/>
-				<File RelativePath="..\third_party_open\utils\toml-f\src\tomlf\datetime.f90"/>
-				<File RelativePath="..\third_party_open\utils\toml-f\src\tomlf\de.f90"/>
-				<File RelativePath="..\third_party_open\utils\toml-f\src\tomlf\diagnostic.f90"/>
-				<File RelativePath="..\third_party_open\utils\toml-f\src\tomlf\error.f90"/>
-				<File RelativePath="..\third_party_open\utils\toml-f\src\tomlf\utils\io.f90"/>
-				<File RelativePath="..\third_party_open\utils\toml-f\src\tomlf\type\keyval.f90"/>
-				<File RelativePath="..\third_party_open\utils\toml-f\src\tomlf\de\lexer.f90"/>
-				<File RelativePath="..\third_party_open\utils\toml-f\src\tomlf\structure\list.f90"/>
-				<File RelativePath="..\third_party_open\utils\toml-f\src\tomlf\structure\map.f90"/>
-				<File RelativePath="..\third_party_open\utils\toml-f\src\tomlf\build\merge.f90"/>
-				<File RelativePath="..\third_party_open\utils\toml-f\src\tomlf\structure\node.f90"/>
-				<File RelativePath="..\third_party_open\utils\toml-f\src\tomlf\structure\ordered_map.f90"/>
-				<File RelativePath="..\third_party_open\utils\toml-f\src\tomlf\de\parser.f90"/>
-				<File RelativePath="..\third_party_open\utils\toml-f\src\tomlf\build\path.f90"/>
-				<File RelativePath="..\third_party_open\utils\toml-f\src\tomlf\ser.f90"/>
-				<File RelativePath="..\third_party_open\utils\toml-f\src\tomlf\utils\sort.f90"/>
-				<File RelativePath="..\third_party_open\utils\toml-f\src\tomlf\structure.f90"/>
-				<File RelativePath="..\third_party_open\utils\toml-f\src\tomlf\type\table.f90"/>
-				<File RelativePath="..\third_party_open\utils\toml-f\src\tomlf\terminal.f90"/>
-				<File RelativePath="..\third_party_open\utils\toml-f\src\tomlf\de\token.f90"/>
-				<File RelativePath="..\third_party_open\utils\toml-f\src\tomlf.f90"/>
-				<File RelativePath="..\third_party_open\utils\toml-f\src\tomlf\type.f90"/>
-				<File RelativePath="..\third_party_open\utils\toml-f\src\tomlf\utils.f90"/>
-				<File RelativePath="..\third_party_open\utils\toml-f\src\tomlf\type\value.f90"/>
-				<File RelativePath="..\third_party_open\utils\toml-f\src\tomlf\version.f90"/>
-			</Filter>
 			<File RelativePath="..\third_party_open\Delft3D\astro.f90"/>
 			<File RelativePath="..\third_party_open\bicgstab\bicgstab_solver_ilu.f90"/>
 			<File RelativePath="..\third_party_open\utils\deg2utm.f90"/>

--- a/source/sfincs_lib/sfincs_lib.vfproj
+++ b/source/sfincs_lib/sfincs_lib.vfproj
@@ -168,6 +168,14 @@
 					<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/>
 				</FileConfiguration>
 			</File>
+			<File RelativePath="..\src\sfincs_ncoutput_helpers.F90">
+				<FileConfiguration Name="Release|x64">
+					<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/>
+				</FileConfiguration>
+				<FileConfiguration Name="Debug|x64">
+					<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/>
+				</FileConfiguration>
+			</File>
 			<File RelativePath="..\src\sfincs_ncoutput.F90">
 				<FileConfiguration Name="Release|x64">
 					<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/>

--- a/source/src/Makefile.am
+++ b/source/src/Makefile.am
@@ -38,6 +38,7 @@ libsfincs_la_SOURCES = \
 	../third_party_open/utils/toml-f/src/tomlf/type/keyval.f90 \
 	../third_party_open/utils/toml-f/src/tomlf/type/table.f90 \
 	../third_party_open/utils/toml-f/src/tomlf/type.f90 \
+	../third_party_open/utils/toml-f/src/tomlf/ser.f90 \
 	../third_party_open/utils/toml-f/src/tomlf/de/lexer.f90 \
 	../third_party_open/utils/toml-f/src/tomlf/de/parser.f90 \
 	../third_party_open/utils/toml-f/src/tomlf/de.f90 \
@@ -77,6 +78,10 @@ libsfincs_la_SOURCES = \
 	sfincs_continuity.f90 \
 	sfincs_crosssections.f90 \
 	sfincs_discharges.f90 \
+	sfincs_rule_expression.f90 \
+	sfincs_src_structures.f90 \
+	utils/sfincs_polygons.f90 \
+	sfincs_urban_drainage.f90 \
 	sfincs_subgrid.F90 \
 	sfincs_timestep_analysis.f90 \	
 	sfincs_infiltration.f90 \	

--- a/source/src/Makefile.am
+++ b/source/src/Makefile.am
@@ -95,6 +95,7 @@ libsfincs_la_SOURCES = \
 	sfincs_meteo.f90 \
         ../third_party_open/bicgstab/bicgstab_solver_ilu.f90 \
 	sfincs_nonhydrostatic.f90 \
+	sfincs_ncoutput_helpers.F90 \
 	sfincs_ncoutput.F90 \
 	sfincs_output.f90 \
 	sfincs_momentum.f90 \

--- a/source/src/Makefile.am
+++ b/source/src/Makefile.am
@@ -38,7 +38,6 @@ libsfincs_la_SOURCES = \
 	../third_party_open/utils/toml-f/src/tomlf/type/keyval.f90 \
 	../third_party_open/utils/toml-f/src/tomlf/type/table.f90 \
 	../third_party_open/utils/toml-f/src/tomlf/type.f90 \
-	../third_party_open/utils/toml-f/src/tomlf/ser.f90 \
 	../third_party_open/utils/toml-f/src/tomlf/de/lexer.f90 \
 	../third_party_open/utils/toml-f/src/tomlf/de/parser.f90 \
 	../third_party_open/utils/toml-f/src/tomlf/de.f90 \

--- a/source/src/Makefile.am
+++ b/source/src/Makefile.am
@@ -72,19 +72,19 @@ libsfincs_la_SOURCES = \
 	snapwave/snapwave_windsource.f90 \
 	snapwave/snapwave_RFtable.f90 \
 	snapwave/snapwave_solver.f90 \
-	sfincs_input.f90 \
 	sfincs_initial_conditions.f90 \
 	sfincs_boundaries.f90 \
-	sfincs_continuity.f90 \
 	sfincs_crosssections.f90 \
 	sfincs_discharges.f90 \
 	sfincs_rule_expression.f90 \
 	sfincs_src_structures.f90 \
+	sfincs_input.f90 \
 	utils/sfincs_polygons.f90 \
 	sfincs_urban_drainage.f90 \
 	sfincs_subgrid.F90 \
-	sfincs_timestep_analysis.f90 \	
-	sfincs_infiltration.f90 \	
+	sfincs_timestep_analysis.f90 \
+	sfincs_infiltration.f90 \
+	sfincs_continuity.f90 \
 	sfincs_domain.f90 \
 	sfincs_structures.f90 \
 	sfincs_obspoints.f90 \

--- a/source/src/sfincs_continuity.f90
+++ b/source/src/sfincs_continuity.f90
@@ -1,165 +1,496 @@
 module sfincs_continuity
-
+   !
+   ! Water-level / volume update stage of the SFINCS time step. Runs after
+   ! sfincs_momentum has produced the face fluxes q on each cell edge and
+   ! is responsible for closing the volume balance on every active cell.
+   !
+   ! See the breakdown at the top of update_continuity for exactly
+   ! which terms are accumulated into qsrc, which operate on qinfmap, and
+   ! which come from the hydrodynamic fluxes q already computed upstream.
+   !
+   ! Data flow per step:
+   !   input  : q(nuv), qext(np) (optional BMI), river/structure state,
+   !            qinfmap, storage_volume (subgrid), zs/z_volume at t
+   !   output : zs (all paths) and z_volume (subgrid path) advanced to
+   !            t+dt; optional zsmax, vmax, qmax, twet accumulators
+   !
+   ! Subroutines:
+   !
+   !   update_continuity(t, dt, tloop)
+   !     Main per-timestep entry. Orchestrates river discharges, drainage
+   !     structures, optional BMI qext, infiltration, and dispatches the
+   !     water-level update. Called from sfincs_lib (main time-stepping
+   !     loop).
+   !
+   !   compute_water_levels_regular(dt, t)
+   !     Non-subgrid (bathtub / simple bathy) water-level update. Called
+   !     from update_continuity.
+   !
+   !   compute_water_levels_subgrid(dt, t)
+   !     Subgrid-tables water-level update with storage-volume
+   !     bookkeeping. Called from update_continuity.
+   !
+   !   compute_store_variables(dt)
+   !     Update optional per-cell vmax / qmax / twet diagnostics. Called
+   !     from update_continuity only when any of store_maximum_velocity,
+   !     store_maximum_flux or store_twet is enabled.
+   !
 contains
-   
-   subroutine compute_water_levels(t, dt, tloop)
    !
-   use sfincs_data
+   !-----------------------------------------------------------------------------------------------------!
    !
-   implicit none
-   !
-   real*4           :: dt
-   real*8           :: t
-   !
-   integer          :: count0
-   integer          :: count1
-   integer          :: count_rate
-   integer          :: count_max
-   real             :: tloop
-   !
-   call system_clock(count0, count_rate, count_max)
-   !
-   if (subgrid) then
+   subroutine update_continuity(t, dt, tloop)
       !
-      call compute_water_levels_subgrid(dt,t)
+      ! Unified continuity update: orchestrates all water balance terms
+      ! for one time step. Advances zs (and z_volume on the subgrid path),
+      ! and optionally updates the store_* running maxima.
       !
-   else
+      ! Called from: sfincs_lib (main time-stepping loop).
       !
-      call compute_water_levels_regular(dt,t)
+      ! Sources and sinks (all accumulated into qsrc, in m3/s):
+      !    1. Precipitation (+)                    => update_meteo_forcing (prcp * cell area),
+      !                                              already done before entering this routine
+      !    2. River discharges (+/-)               => update_discharges (adds to qsrc)
+      !    3. Drainage structures (+/-)            => update_src_structures (adds to qsrc)
+      !    4. Infiltration rate field qinfmap (-)  => update_infiltration_map (-qinfmap * cell area,
+      !                                              flavors: con, c2d, cna, cnb, gai, hor, bkt)
+      !    5. Urban drainage (+/-)                 => update_urban_drainage
+      !    6. External source/sink qext (+/-)      => added to qsrc here (BMI coupling)
       !
-   endif  
-   !
-   ! Put non-default store options in a separate subroutine (all but zsmax) to save computation time when not used (both regular and subgrid):
-   !
-   if ((store_maximum_velocity .eqv. .true.) .or. (store_maximum_flux .eqv. .true.) .or. (store_twet .eqv. .true.)) then    
-      ! 
-      call compute_store_variables(dt)       
-      !    
-   endif
-   !   
-   call system_clock(count1, count_rate, count_max)
-   tloop = tloop + 1.0*(count1 - count0)/count_rate
-   !
-   end subroutine
-
-   
-   subroutine compute_water_levels_regular(dt,t)
-   !
-   use sfincs_data
-   !
-   implicit none
-   !
-   real*4           :: dt
-   real*8           :: t   
-   !
-   integer          :: nm
-   integer          :: isrc
-   !
-   integer          :: iwm
-   !
-   integer          :: nmu
-   integer          :: nmd
-   integer          :: num
-   integer          :: ndm
-   !
-   real*4           :: qnmu
-   real*4           :: qnmd
-   real*4           :: qnum
-   real*4           :: qndm
-   real*4           :: factime
-   real*4           :: dvol    
-   !
-   if (snapwave) then ! need to compute filtered water levels for snapwave
+      ! qsrc itself is cleared at the end of compute_water_levels_{regular,
+      ! subgrid} (per active cell), so steps 1-6 above start from zero every
+      ! step without an explicit reset here.
       !
-      factime = min(dt / wavemaker_filter_time, 1.0)
+      ! Hydrodynamic fluxes q                      => computed in sfincs_momentum
       !
-   endif
-   !
-   !$acc parallel present( kcs, zs, zb, netprcp, prcp, q, qext, zsmax, zsm, maxzsm, &
-   !$acc                   z_flags_iref, uv_flags_iref, &
-   !$acc                   z_index_uv_md, z_index_uv_nd, z_index_uv_mu, z_index_uv_nu, &
-   !$acc                   dxm, dxrm, dyrm, dxminv, dxrinv, dyrinv, cell_area_m2, cell_area,  &
-   !$acc                   nmindsrc, qtsrc, &
-   !$acc                   z_index_wavemaker, wavemaker_uvmean, wavemaker_nmd, wavemaker_nmu, wavemaker_ndm, wavemaker_num )
-   !
-   ! First discharges (don't do this parallel, as it's probably not worth it)
-   !
-   if (nsrcdrn > 0) then
-      ! 
-      !$acc loop
-      do isrc = 1, nsrcdrn
-         ! 
-         nm = nmindsrc(isrc)
-         ! 
-         if (crsgeo) then
-            ! 
-            zs(nmindsrc(isrc)) = max(zs(nm) + qtsrc(isrc) * dt / cell_area_m2(nm), zb(nm))
-            ! 
-         else
-            ! 
-            zs(nmindsrc(isrc)) = max(zs(nm) + qtsrc(isrc) * dt / cell_area(z_flags_iref(nm)), zb(nm))
-            ! 
-         endif
-         ! 
-      enddo
-      ! 
-   endif
-   !
-   !$omp parallel &
-   !$omp private ( nm,dvol,nmd,nmu,ndm,num,qnmd,qnmu,qndm,qnum,iwm)
-   !$omp do schedule ( dynamic, 256 )
-   !$acc loop gang vector
-   do nm = 1, np
-      ! 
-      if (kcs(nm) == 1) then ! Regular point
+      ! compute_water_levels_{regular,subgrid} then updates zs/z_volume using:
+      !    - qsrc * dt                             => all sources/sinks above
+      !    - div(q) * dt                           => horizontal flux divergence
+      !    - storage volume                        => absorbs excess volume (subgrid only)
+      !
+      use sfincs_data
+      use sfincs_infiltration
+      use sfincs_discharges
+      use sfincs_src_structures
+      use sfincs_urban_drainage
+      !
+      implicit none
+      !
+      real*8           :: t
+      real*4           :: dt
+      real             :: tloop
+      !
+      integer          :: nm
+      !
+      integer          :: count0
+      integer          :: count1
+      integer          :: count_rate
+      integer          :: count_max
+      !
+      call system_clock(count0, count_rate, count_max)
+      !
+      ! 1. Precipitation was already accumulated into qsrc by
+      !    update_meteo_forcing (called from sfincs_lib before this routine).
+      !
+      ! 2. River discharges => update_discharges (adds to qsrc)
+      !
+      call update_discharges(t, dt)
+      !
+      ! 3. Drainage structures (pumps/gates/culverts/...) => update_src_structures (adds to qsrc)
+      !
+      call update_src_structures(t, dt)
+      !
+      ! 4. Compute infiltration rates; update_infiltration_map also subtracts
+      !    qinfmap * cell_area from qsrc.
+      !
+      if (infiltration) then
          !
-         if (precip) then
-            !
-            zs(nm) = zs(nm) + netprcp(nm) * dt
-            !
-         endif
-         !
-         if (use_qext) then
-            !
-            ! Add external source (e.g. from XMI coupling) 
-            ! 
-            zs(nm) = zs(nm) + qext(nm) * dt 
-            !
-         endif
-         !
-         nmd = z_index_uv_md(nm)
-         nmu = z_index_uv_mu(nm)
-         ndm = z_index_uv_nd(nm)
-         num = z_index_uv_nu(nm)
-         !
-         if (crsgeo) then
-            !
-            ! Use cell width dxm (which varies with latitude)
-            !
-            zs(nm)   = zs(nm) + ( (q(nmd) - q(nmu)) / dxm(nm) + (q(ndm) - q(num)) * dyrinv(z_flags_iref(nm)) ) * dt
-            !
-            ! Should really be:
-            !
-            ! zs(nm)   = zs(nm) + ( (q(nmd) - q(nmu)) / dxm(nm) + (q(ndm) * f - q(num) / f) * dyrinv(z_flags_iref(nm)) ) * dt
-            !
-            ! Where f if a correction factor for the ratio between cell width at cell centre and cell bottom:
-            !
-            ! f = cos(y - 0.5*dy) / cos(y) (this holds both in northern and southern hemisphere)
-            ! 
-         else   
-            !
-            zs(nm)   = zs(nm) + ( (q(nmd) - q(nmu)) * dxrinv(z_flags_iref(nm)) + (q(ndm) - q(num)) * dyrinv(z_flags_iref(nm)) ) * dt
-            !
-         endif
+         call update_infiltration_map(dt)
          !
       endif
       !
+      ! 5. Urban drainage => update_urban_drainage (adds to qsrc)
+      !
+      if (urban_drainage) then
+         !
+         call update_urban_drainage(t, dt)
+         !
+      endif
+      !
+      ! 6. External source/sink (+/-) => add qext to qsrc (set via BMI coupling)
+      !
+      if (use_qext) then
+         !
+         !$omp parallel &
+         !$omp private ( nm )
+         !$omp do
+         !$acc loop gang vector
+         do nm = 1, np
+            !
+            qsrc(nm) = qsrc(nm) + qext(nm)
+            !
+         enddo
+         !$acc end loop
+         !$omp end parallel
+         !
+      endif
+      !
+      ! Update water levels: applies qsrc * dt and flux divergence to zs/z_volume
+      !
+      if (subgrid) then
+         !
+         call compute_water_levels_subgrid(dt, t)
+         !
+      else
+         !
+         call compute_water_levels_regular(dt, t)
+         !
+      endif
+      !
+      ! Put non-default store options in a separate subroutine (all but zsmax) to save computation time when not used (both regular and subgrid):
+      !
+      if ((store_maximum_velocity .eqv. .true.) .or. (store_maximum_flux .eqv. .true.) .or. (store_twet .eqv. .true.)) then
+         !
+         call compute_store_variables(dt)
+         !
+      endif
+      !
+      call system_clock(count1, count_rate, count_max)
+      tloop = tloop + 1.0*(count1 - count0)/count_rate
+      !
+   end subroutine
+   !
+   !-----------------------------------------------------------------------------------------------------!
+   !
+   subroutine compute_water_levels_regular(dt, t)
+      !
+      ! Advance zs(np) by dt on the non-subgrid (bathtub / simple bathy)
+      ! path. Applies cell-wise qsrc contributions and the horizontal
+      ! flux divergence, handles the optional wavemaker cells (kcs == 4),
+      ! updates the snapwave-filtered water level zsm, and accumulates
+      ! zsmax / t_zsmax when requested.
+      !
+      ! Called from: update_continuity (when subgrid is false).
+      !
+      use sfincs_data
+      !
+      implicit none
+      !
+      real*4           :: dt
+      real*8           :: t
+      !
+      integer          :: nm
+      !
+      integer          :: iwm
+      !
+      integer          :: nmu
+      integer          :: nmd
+      integer          :: num
+      integer          :: ndm
+      !
+      real*4           :: qnmu
+      real*4           :: qnmd
+      real*4           :: qnum
+      real*4           :: qndm
+      real*4           :: factime
+      !
+      if (snapwave) then ! need to compute filtered water levels for snapwave
+         !
+         factime = min(dt / wavemaker_filter_time, 1.0)
+         !
+      endif
+      !
+      !$acc parallel present( kcs, zs, zb, q, qext, zsmax, zsm, maxzsm, &
+      !$acc                   z_flags_iref, uv_flags_iref, &
+      !$acc                   z_index_uv_md, z_index_uv_nd, z_index_uv_mu, z_index_uv_nu, &
+      !$acc                   dxm, dxrm, dyrm, dxminv, dxrinv, dyrinv, cell_area_m2, cell_area,  &
+      !$acc                   qsrc, &
+      !$acc                   z_index_wavemaker, wavemaker_uvmean, wavemaker_nmd, wavemaker_nmu, wavemaker_ndm, wavemaker_num )
+      !
+      !$omp parallel &
+      !$omp private ( nm, nmd, nmu, ndm, num, qnmd, qnmu, qndm, qnum, iwm )
+      !$omp do schedule ( dynamic, 256 )
+      !$acc loop gang vector
+      do nm = 1, np
+         !
+         if (kcs(nm) == 1) then ! Regular point
+            !
+            ! Apply cell-wise discharges qsrc (rivers, drainage structures, qext)
+            !
+            if (qsrc(nm) /= 0.0) then
+               !
+               if (crsgeo) then
+                  zs(nm) = max(zs(nm) + qsrc(nm) * dt / cell_area_m2(nm), zb(nm))
+               else
+                  zs(nm) = max(zs(nm) + qsrc(nm) * dt / cell_area(z_flags_iref(nm)), zb(nm))
+               endif
+               !
+            endif
+            !
+            nmd = z_index_uv_md(nm)
+            nmu = z_index_uv_mu(nm)
+            ndm = z_index_uv_nd(nm)
+            num = z_index_uv_nu(nm)
+            !
+            if (crsgeo) then
+               !
+               ! Use cell width dxm (which varies with latitude)
+               !
+               zs(nm)   = zs(nm) + ( (q(nmd) - q(nmu)) / dxm(nm) + (q(ndm) - q(num)) * dyrinv(z_flags_iref(nm)) ) * dt
+               !
+               ! Should really be:
+               !
+               ! zs(nm)   = zs(nm) + ( (q(nmd) - q(nmu)) / dxm(nm) + (q(ndm) * f - q(num) / f) * dyrinv(z_flags_iref(nm)) ) * dt
+               !
+               ! Where f if a correction factor for the ratio between cell width at cell centre and cell bottom:
+               !
+               ! f = cos(y - 0.5*dy) / cos(y) (this holds both in northern and southern hemisphere)
+               !
+            else
+               !
+               zs(nm)   = zs(nm) + ( (q(nmd) - q(nmu)) * dxrinv(z_flags_iref(nm)) + (q(ndm) - q(num)) * dyrinv(z_flags_iref(nm)) ) * dt
+               !
+            endif
+            !
+         endif
+         !
+         if (wavemaker) then
+            !
+            if (kcs(nm) == 4) then
+               !
+               ! Wave maker point (seaward of wave maker)
+               ! Here we use the mean flux at the location of the wave maker
+               !
+               iwm = z_index_wavemaker(nm)
+               !
+               if (wavemaker_nmd(iwm) > 0) then
+                  !
+                  ! Wave paddle on the left
+                  !
+                  qnmd = wavemaker_uvmean(wavemaker_nmd(iwm))
+                  !
+               else
+                  !
+                  qnmd = q(z_index_uv_md(nm))
+                  !
+               endif
+               !
+               if (wavemaker_nmu(iwm) > 0) then
+                  !
+                  ! Wave paddle on the right
+                  !
+                  qnmu = wavemaker_uvmean(wavemaker_nmu(iwm))
+                  !
+               else
+                  !
+                  qnmu = q(z_index_uv_mu(nm))
+                  !
+               endif
+               !
+               if (wavemaker_ndm(iwm) > 0) then
+                  !
+                  ! Wave paddle below
+                  !
+                  qndm = wavemaker_uvmean(wavemaker_ndm(iwm))
+                  !
+               else
+                  !
+                  qndm = q(z_index_uv_nd(nm))
+                  !
+               endif
+               !
+               if (wavemaker_num(iwm) > 0) then
+                  !
+                  ! Wave paddle above
+                  !
+                  qnum = wavemaker_uvmean(wavemaker_num(iwm))
+                  !
+               else
+                  !
+                  qnum = q(z_index_uv_nu(nm))
+                  !
+               endif
+               !
+               zs(nm)   = zs(nm) + (((qnmd - qnmu) * dxrinv(z_flags_iref(nm)) + (qndm - qnum) * dyrinv(z_flags_iref(nm)))) * dt
+               !
+            endif
+            !
+         endif
+         !
+         if (snapwave) then
+            !
+            ! Time-averaged water level used for SnapWave using exponential filter
+            !
+            ! Would double exponential filtering be better?
+            !
+            zsm(nm) = factime * zs(nm) + (1.0 - factime) * zsm(nm)
+            !
+            if (store_maximum_waterlevel) then
+                !
+                maxzsm(nm) = max(maxzsm(nm), zsm(nm))
+                !
+            endif
+            !
+         endif
+         !
+         ! No continuity update but keeping track of variables
+         ! zsmax used by default, therefore keep in standard continuity loop:
+         !
+         if (store_maximum_waterlevel) then
+            !
+            ! Store when the maximum water level changed
+            !
+            if (store_t_zsmax) then
+                if (zs(nm) > zsmax(nm)) then
+                    if ( (zs(nm) - zb(nm)) > huthresh) then
+                       t_zsmax(nm) = t
+                    endif
+                endif
+            endif
+            !
+            ! Store the maximum water level itself
+            !
+            zsmax(nm) = max(zsmax(nm), zs(nm))
+            !
+         endif
+         !
+         ! Reset qsrc to zero for the next time step
+         !
+         qsrc(nm) = 0.0
+         !
+      enddo
+      !$omp end do
+      !$omp end parallel
+      !$acc end parallel
+      !
+   end subroutine
+   !
+   !-----------------------------------------------------------------------------------------------------!
+   !
+   subroutine compute_water_levels_subgrid(dt,t)
+      !
+      ! Advance z_volume(np) and zs(np) by dt on the subgrid-tables path.
+      ! Accumulates the cell volume change dvol from qsrc and the
+      ! horizontal flux divergence, routes excess volume through
+      ! storage_volume (when use_storage_volume is set), updates
+      ! z_volume, and recovers the new water level via subgrid table
+      ! interpolation. Also handles wavemaker cells (kcs == 4), the
+      ! snapwave-filtered zsm, and zsmax / t_zsmax accumulation.
+      !
+      ! Called from: update_continuity (when subgrid is true).
+      !
+      use sfincs_data
+      !
+      implicit none
+      !
+      real*4           :: dt
+      real*8           :: t
+      !
+      integer          :: nm
+      !
+      integer          :: iwm
+      !
+      integer          :: nmu
+      integer          :: nmd
+      integer          :: num
+      integer          :: ndm
+      !
+      real*4           :: factime
+      real*4           :: dvol
+      !
+      real*4           :: qnmu
+      real*4           :: qnmd
+      real*4           :: qnum
+      real*4           :: qndm
+      !
+      integer          :: iuv
+      real*4           :: dzvol
+      real*4           :: facint
+      real*4           :: a
+      real*4           :: dv
+      real*4           :: zs00
+      real*4           :: zs11
+      !
       if (wavemaker) then
-         !      
-         if (kcs(nm) == 4) then
+         !
+         factime = min(dt / wavemaker_filter_time, 1.0)
+         !
+      endif
+      !
+      !$omp parallel &
+      !$omp private ( dvol, nmd, nmu, ndm, num, a, iuv, facint, dzvol, iwm, &
+      !$omp           qnmd, qnmu, qndm, qnum, dv, zs00, zs11 )
+      !$omp do schedule ( dynamic, 256 )
+      !$acc parallel present( kcs, zs, zs0, zb, z_volume, zsmax, zsm, maxzsm, zsderv, &
+      !$acc                   subgrid_z_zmin,  subgrid_z_zmax, subgrid_z_dep, subgrid_z_volmax, &
+      !$acc                   q, qext, z_flags_iref, uv_flags_iref, &
+      !$acc                   z_index_uv_md, z_index_uv_nd, z_index_uv_mu, z_index_uv_nu, &
+      !$acc                   dxm, dxrm, dyrm, dxminv, dxrinv, dyrinv, cell_area_m2, cell_area, &
+      !$acc                   z_index_wavemaker, wavemaker_uvmean, &
+      !$acc                   wavemaker_nmd, wavemaker_nmu, wavemaker_ndm, wavemaker_num, storage_volume)
+      !$acc loop gang vector
+      do nm = 1, np
+         !
+         ! And now water level changes due to horizontal fluxes
+         !
+         dvol = 0.0
+         !
+         if (kcs(nm) == 1) then
+            !
+            ! Apply cell-wise discharges qsrc (rivers, drainage structures, qext)
+            !
+            if (qsrc(nm) /= 0.0) then
+               !
+               dvol = dvol + qsrc(nm) * dt
+               !
+            endif
+            !
+            nmd = z_index_uv_md(nm)
+            nmu = z_index_uv_mu(nm)
+            ndm = z_index_uv_nd(nm)
+            num = z_index_uv_nu(nm)
+            !
+            if (crsgeo) then
+               !
+               ! dxm  = size of cell in x - direction (it varies for all cells)
+               ! dyrm = size of cell in y - direction (it varies for all zoom levels)
+               !
+               dvol = dvol + ( (q(nmd) - q(nmu)) * dyrm(z_flags_iref(nm)) + (q(ndm) - q(num)) * dxm(nm) ) * dt
+               !
+               ! Should really be:
+               !
+               ! dvol = dvol + ( (q(nmd) - q(nmu)) * dyrm(z_flags_iref(nm)) + (q(ndm) * f - q(num) / f) * dxm(nm) ) * dt
+               !
+               ! where f if a correction factor for the ratio between cell width at cell centre and cell bottom:
+               !
+               ! f = cos(y - 0.5*dy) / cos(y) (this holds both in northern and southern hemisphere)
+               !
+               ! This assumes that we can use the same factor f for q(ndm) and q(num), i.e.:
+               !
+               ! cos(y - 0.5*dy) / cos(y) ~= cos(y + 0.5*dy) / cos(y) or: cos(y - 0.5*dy) ~= cos(y + 0.5*dy) which is pretty much true for dy < 1.0 degree
+               !
+            else
+               !
+               if (use_quadtree) then
+                  !
+                  ! dxrm = size of cell in x - direction (it varies for all zoom levels)
+                  ! dyrm = size of cell in y - direction (it varies for all zoom levels)
+                  !
+                  dvol = dvol + ( (q(nmd) - q(nmu)) * dyrm(z_flags_iref(nm)) + (q(ndm) - q(num)) * dxrm(z_flags_iref(nm)) ) * dt
+                  !
+               else
+                  !
+                  dvol = dvol + ( (q(nmd) - q(nmu)) * dy + (q(ndm) - q(num)) * dx ) * dt
+                  !
+               endif
+               !
+            endif
+         endif ! kcs==1
+         !
+         if (wavemaker .and. kcs(nm) == 4) then
             !
             ! Wave maker point (seaward of wave maker)
-            ! Here we use the mean flux at the location of the wave maker 
+            ! Here we use the mean flux at the location of the wave maker
             !
             iwm = z_index_wavemaker(nm)
             !
@@ -173,7 +504,7 @@ contains
                !
                qnmd = q(z_index_uv_md(nm))
                !
-            endif   
+            endif
             !
             if (wavemaker_nmu(iwm) > 0) then
                !
@@ -185,7 +516,7 @@ contains
                !
                qnmu = q(z_index_uv_mu(nm))
                !
-            endif   
+            endif
             !
             if (wavemaker_ndm(iwm) > 0) then
                !
@@ -197,7 +528,7 @@ contains
                !
                qndm = q(z_index_uv_nd(nm))
                !
-            endif   
+            endif
             !
             if (wavemaker_num(iwm) > 0) then
                !
@@ -209,514 +540,279 @@ contains
                !
                qnum = q(z_index_uv_nu(nm))
                !
-            endif   
+            endif
             !
-            zs(nm)   = zs(nm) + (((qnmd - qnmu) * dxrinv(z_flags_iref(nm)) + (qndm - qnum) * dyrinv(z_flags_iref(nm)))) * dt
-            !
-         endif   
-         !
-      endif
-      !
-      if (snapwave) then
-         !
-         ! Time-averaged water level used for SnapWave using exponential filter
-         !
-         ! Would double exponential filtering be better?
-         !
-         zsm(nm) = factime * zs(nm) + (1.0 - factime) * zsm(nm)
-         !
-         if (store_maximum_waterlevel) then
-             !
-             maxzsm(nm) = max(maxzsm(nm), zsm(nm))             
-             !
-         endif         
-         !             
-      endif 
-      !
-      ! No continuity update but keeping track of variables         
-      ! zsmax used by default, therefore keep in standard continuity loop:
-      !
-      if (store_maximum_waterlevel) then
-         !
-         ! Store when the maximum water level changed
-         !
-         if (store_t_zsmax) then
-             if (zs(nm) > zsmax(nm)) then
-                 if ( (zs(nm) - zb(nm)) > huthresh) then
-                    t_zsmax(nm) = t
-                 endif
-             endif
-         endif
-         !
-         ! Store the maximum water level itself
-         !
-         zsmax(nm) = max(zsmax(nm), zs(nm))
-         !
-      endif
-      !
-   enddo
-   !$omp end do
-   !$omp end parallel
-   !$acc end parallel
-   !         
-   end subroutine
-
-   
-   subroutine compute_water_levels_subgrid(dt,t)
-   !
-   use sfincs_data
-   !
-   implicit none
-   !
-   real*4           :: dt
-   real*8           :: t
-   !
-   integer          :: nm
-   integer          :: isrc
-   !
-   integer          :: iwm
-   integer          :: ind
-   !
-   integer          :: nmu
-   integer          :: nmd
-   integer          :: num
-   integer          :: ndm
-   !
-   real*4           :: factime
-   real*4           :: dvol  
-   real*4           :: dzsdt
-   !
-   real*4           :: qnmu
-   real*4           :: qnmd
-   real*4           :: qnum
-   real*4           :: qndm
-   !
-   integer          :: iuv
-   real*4           :: dzvol
-   real*4           :: facint
-   real*4           :: a
-   real*4           :: dv
-   real*4           :: zs00
-   real*4           :: zs11
-   !
-   if (wavemaker) then
-      !
-      factime = min(dt / wavemaker_filter_time, 1.0)
-      !
-   endif   
-   !
-   ! First discharges (don't do this parallel, as it's probably not worth it)
-   ! NVFORTAN turns this into a sequential loop (!$acc loop seq)
-   !
-   if (nsrcdrn > 0) then
-      !
-      !$acc serial present( z_volume, nmindsrc, qtsrc )
-      do isrc = 1, nsrcdrn
-         !
-         nm = nmindsrc(isrc)
-         !
-         if ((z_volume(nm) >= 0) .or. ((qtsrc(isrc)<0.0) .and. (z_volume(nm) >= 0))) then
-            z_volume(nm) = z_volume(nm) + qtsrc(isrc) * dt
-         endif
-         !
-      enddo
-      !$acc end serial
-      !
-   endif
-   !
-   !$omp parallel &
-   !$omp private ( dvol,dzsdt,nmd,nmu,ndm,num,a,iuv,facint,dzvol,ind,iwm,qnmd,qnmu,qndm,qnum,dv,zs00,zs11 )
-   !$omp do schedule ( dynamic, 256 )
-   !$acc parallel present( kcs, zs, zs0, zb, z_volume, zsmax, zsm, maxzsm, zsderv, &
-   !$acc                   subgrid_z_zmin,  subgrid_z_zmax, subgrid_z_dep, subgrid_z_volmax, &
-   !$acc                   netprcp, prcp, q, qext, z_flags_iref, uv_flags_iref, &
-   !$acc                   z_index_uv_md, z_index_uv_nd, z_index_uv_mu, z_index_uv_nu, &
-   !$acc                   dxm, dxrm, dyrm, dxminv, dxrinv, dyrinv, cell_area_m2, cell_area, &   
-   !$acc                   z_index_wavemaker, wavemaker_uvmean, wavemaker_nmd, wavemaker_nmu, wavemaker_ndm, wavemaker_num, storage_volume)
-   !$acc loop gang vector
-   do nm = 1, np
-      !
-      ! And now water level changes due to horizontal fluxes
-      !
-      dvol = 0.0
-      !
-      if (kcs(nm) == 1) then
-         !
-         nmd = z_index_uv_md(nm)
-         nmu = z_index_uv_mu(nm)
-         ndm = z_index_uv_nd(nm)
-         num = z_index_uv_nu(nm)
-         !
-         if (crsgeo) then
-            !
-            ! dxm  = size of cell in x - direction (it varies for all cells)
-            ! dyrm = size of cell in y - direction (it varies for all zoom levels)
-            !
-            dvol = dvol + ( (q(nmd) - q(nmu)) * dyrm(z_flags_iref(nm)) + (q(ndm) - q(num)) * dxm(nm) ) * dt
-            !
-            ! Should really be:
-            !
-            ! dvol = dvol + ( (q(nmd) - q(nmu)) * dyrm(z_flags_iref(nm)) + (q(ndm) * f - q(num) / f) * dxm(nm) ) * dt
-            !
-            ! where f if a correction factor for the ratio between cell width at cell centre and cell bottom:
-            !
-            ! f = cos(y - 0.5*dy) / cos(y) (this holds both in northern and southern hemisphere)
-            !
-            ! This assumes that we can use the same factor f for q(ndm) and q(num), i.e.:
-            !
-            ! cos(y - 0.5*dy) / cos(y) ~= cos(y + 0.5*dy) / cos(y) or: cos(y - 0.5*dy) ~= cos(y + 0.5*dy) which is pretty much true for dy < 1.0 degree
-            !
-         else
-            !
-            if (use_quadtree) then   
+            if (use_quadtree) then
                !
-               ! dxrm = size of cell in x - direction (it varies for all zoom levels)
-               ! dyrm = size of cell in y - direction (it varies for all zoom levels)
-               !               
-               dvol = dvol + ( (q(nmd) - q(nmu)) * dyrm(z_flags_iref(nm)) + (q(ndm) - q(num)) * dxrm(z_flags_iref(nm)) ) * dt
-               ! 
+               dvol = dvol + ( (qnmd - qnmu) * dyrm(z_flags_iref(nm)) + (qndm - qnum) * dxrm(z_flags_iref(nm)) ) * dt
+               !
             else
-               ! 
-               dvol = dvol + ( (q(nmd) - q(nmu)) * dy + (q(ndm) - q(num)) * dx ) * dt
-               ! 
-            endif   
-            !
-         endif   
-      endif ! kcs==1
-      !
-      if (wavemaker .and. kcs(nm) == 4) then
-         !
-         ! Wave maker point (seaward of wave maker)
-         ! Here we use the mean flux at the location of the wave maker
-         !
-         iwm = z_index_wavemaker(nm)
-         !
-         if (wavemaker_nmd(iwm) > 0) then
-            !
-            ! Wave paddle on the left
-            !
-            qnmd = wavemaker_uvmean(wavemaker_nmd(iwm))
-            !
-         else
-            !
-            qnmd = q(z_index_uv_md(nm))
-            !
-         endif   
-         !
-         if (wavemaker_nmu(iwm) > 0) then
-            !
-            ! Wave paddle on the right
-            !
-            qnmu = wavemaker_uvmean(wavemaker_nmu(iwm))
-            !
-         else
-            !
-            qnmu = q(z_index_uv_mu(nm))
-            !
-         endif   
-         !
-         if (wavemaker_ndm(iwm) > 0) then
-            !
-            ! Wave paddle below
-            !
-            qndm = wavemaker_uvmean(wavemaker_ndm(iwm))
-            !
-         else
-            !
-            qndm = q(z_index_uv_nd(nm))
-            !
-         endif   
-         !
-         if (wavemaker_num(iwm) > 0) then
-            !
-            ! Wave paddle above
-            !
-            qnum = wavemaker_uvmean(wavemaker_num(iwm))
-            !
-         else
-            !
-            qnum = q(z_index_uv_nu(nm))
-            !
-         endif   
-         !
-         if (use_quadtree) then
-            ! 
-            dvol = dvol + ( (qnmd - qnmu) * dyrm(z_flags_iref(nm)) + (qndm - qnum) * dxrm(z_flags_iref(nm)) ) * dt
-            ! 
-         else
-            ! 
-            dvol = dvol + ( (qnmd - qnmu) * dy + (qndm - qnum) * dx ) * dt
-            !
-         endif   
-         !
-      endif
-      !
-      ! We got the volume change dvol in each active cell from fluxes
-      ! Now first add precip and qext
-      ! Then adjust for storage volume
-      ! Then update the volume and compute new water level           
-      !
-      if (kcs(nm) == 1 .or. kcs(nm) == 4) then
-         !
-         ! Obtain cell area
-         !
-         if (crsgeo) then
-            !
-            a = cell_area_m2(nm)
-            !
-         else   
-            !
-            a = cell_area(z_flags_iref(nm))
-            !
-         endif
-         !
-         if (precip .or. use_qext) then
-            !
-            dzsdt = 0.0
-            !   
-            if (precip) then
                !
-               ! Add nett rainfall 
-               !
-               dzsdt = dzsdt + netprcp(nm)
+               dvol = dvol + ( (qnmd - qnmu) * dy + (qndm - qnum) * dx ) * dt
                !
             endif
             !
-            if (use_qext) then
+         endif
+         !
+         ! We got the volume change dvol in each active cell from fluxes
+         ! Now first add precip and qext
+         ! Then adjust for storage volume
+         ! Then update the volume and compute new water level
+         !
+         if (kcs(nm) == 1 .or. kcs(nm) == 4) then
+            !
+            ! Obtain cell area
+            !
+            if (crsgeo) then
                !
-               ! Add external source (e.g. from XMI coupling) 
-               ! 
-               dzsdt = dzsdt + qext(nm)
+               a = cell_area_m2(nm)
+               !
+            else
+               !
+               a = cell_area(z_flags_iref(nm))
                !
             endif
             !
-            ! dzsdt is still in m/s, so multiply with a * dt to get m^3
+            ! C5. Storage volume
             !
-            dvol = dvol + dzsdt * a * dt         
-            !      
-         endif
-         !
-         if (use_storage_volume) then
-            !
-            ! If water enters the cell through a point discharge, it will NOT end up in storage volume !  
-            !   
-            if (storage_volume(nm) > 1.0e-6 .and. dvol > 0.0) then
+            if (use_storage_volume) then
                !
-               ! There is still some storage left, and water is entering the cell
+               ! If water enters the cell through a point discharge, it will NOT end up in storage volume !
                !
-               ! Compute remaining storage volume
-               !
-               dv = storage_volume(nm) - dvol
-               !
-               ! Update storage volume (it cannot become negative)) 
-               ! 
-               storage_volume(nm) = max(dv, 0.0)
-               !
-               if (dv < 0.0) then
+               if (storage_volume(nm) > 1.0e-6 .and. dvol > 0.0) then
                   !
-                  ! Overshoot, so add remaining volume to z_volume
+                  ! There is still some storage left, and water is entering the cell
                   !
-                  dvol = - dv
-                  ! 
-               else                   
+                  ! Compute remaining storage volume
                   !
-                  ! Everything went into storage  
-                  ! 
-                  dvol = 0.0 
+                  dv = storage_volume(nm) - dvol
+                  !
+                  ! Update storage volume (it cannot become negative))
+                  !
+                  storage_volume(nm) = max(dv, 0.0)
+                  !
+                  if (dv < 0.0) then
+                     !
+                     ! Overshoot, so add remaining volume to z_volume
+                     !
+                     dvol = - dv
+                     !
+                  else
+                     !
+                     ! Everything went into storage
+                     !
+                     dvol = 0.0
+                     !
+                  endif
                   !
                endif
                !
             endif
             !
+            ! Update volume
+            !
+            z_volume(nm) = z_volume(nm) + dvol
+            !
+            if (wiggle_suppression) then
+               !
+               ! Store previous water level to determine gradient
+               !
+               zs00    = zs0(nm) ! previous time step
+               zs11    = zs(nm)  ! current time step before updating
+               zs0(nm) = zs11    ! next previous time step
+               !
+            endif
+            !
+            ! Obtain new water level from subgrid tables
+            !
+            if (z_volume(nm) >= subgrid_z_volmax(nm) * 0.999) then
+               !
+               ! Entire cell is wet, no interpolation needed
+               !
+               zs(nm) = max(subgrid_z_zmax(nm), -20.0) + (z_volume(nm) - subgrid_z_volmax(nm)) / a
+               !
+            elseif (z_volume(nm) <= 1.0e-6) then
+               !
+               ! No water in this cell. Set zs to z_zmin.
+               !
+               zs(nm) = max(subgrid_z_zmin(nm), -20.0)
+               !
+            else
+               !
+               ! Interpolation from subgrid tables needed.
+               !
+               dzvol    = subgrid_z_volmax(nm) / (subgrid_nlevels - 1)
+               iuv      = int(z_volume(nm) / dzvol) + 1
+               facint   = (z_volume(nm) - (iuv - 1) * dzvol ) / dzvol
+               zs(nm)   = subgrid_z_dep(iuv, nm) + (subgrid_z_dep(iuv + 1, nm) - subgrid_z_dep(iuv, nm)) * facint
+               !
+            endif
+            !
+            !
+            if (wiggle_suppression) then
+               !
+               zsderv(nm) = zs(nm) - 2 * zs11 + zs00
+               !
+            endif
+            !
          endif
          !
-         ! Update volume 
-         !
-         z_volume(nm) = z_volume(nm) + dvol
-         !
-         if (wiggle_suppression) then
+         if (snapwave) then
             !
-            ! Store previous water level to determine gradient
-            ! 
-            zs00    = zs0(nm) ! previous time step
-            zs11    = zs(nm)  ! current time step before updating
-            zs0(nm) = zs11    ! next previous time step
-            ! 
-         endif
-         ! 
-         ! Obtain new water level from subgrid tables 
-         !
-         if (z_volume(nm) >= subgrid_z_volmax(nm) * 0.999) then
+            ! Time-averaged water level used for SnapWave using exponential filter
             !
-            ! Entire cell is wet, no interpolation needed
+            ! Would double exponential filtering be better?
             !
-            zs(nm) = max(subgrid_z_zmax(nm), -20.0) + (z_volume(nm) - subgrid_z_volmax(nm)) / a
+            zsm(nm) = factime * zs(nm) + (1.0 - factime) * zsm(nm)
             !
-         elseif (z_volume(nm) <= 1.0e-6) then
-            !
-            ! No water in this cell. Set zs to z_zmin.
-            !
-            zs(nm) = max(subgrid_z_zmin(nm), -20.0)
-            !
-         else
-            !
-            ! Interpolation from subgrid tables needed.
-            !
-            dzvol    = subgrid_z_volmax(nm) / (subgrid_nlevels - 1)
-            iuv      = int(z_volume(nm) / dzvol) + 1
-            facint   = (z_volume(nm) - (iuv - 1) * dzvol ) / dzvol
-            zs(nm)   = subgrid_z_dep(iuv, nm) + (subgrid_z_dep(iuv + 1, nm) - subgrid_z_dep(iuv, nm)) * facint
+            if (store_maximum_waterlevel) then
+                !
+                maxzsm(nm) = max(maxzsm(nm), zsm(nm))
+                !
+            endif
             !
          endif
-         !
-         !
-         if (wiggle_suppression) then 
-            ! 
-            zsderv(nm) = zs(nm) - 2 * zs11 + zs00
-            ! 
-         endif
-         !
-      endif
-      !
-      if (snapwave) then
-         !
-         ! Time-averaged water level used for SnapWave using exponential filter
-         !
-         ! Would double exponential filtering be better?
-         !
-         zsm(nm) = factime * zs(nm) + (1.0 - factime) * zsm(nm)
-         !
-         if (store_maximum_waterlevel) then
-             !
-             maxzsm(nm) = max(maxzsm(nm), zsm(nm))             
-             !
-         endif         
-         !    
-      endif 
-      !
-      ! No continuity update but keeping track of variables         
-      ! zsmax used by default, therefore keep in standard continuity loop:         
-      !
-      if (store_maximum_waterlevel) then
-         !
-         ! Store when the maximum water level changed
-         !
-         if (store_t_zsmax) then
-             if (zs(nm) > zsmax(nm)) then
-                 if ( (zs(nm) - subgrid_z_zmin(nm)) > huthresh) then
-                    t_zsmax(nm) = t
-                 endif
-             endif
-         endif
-         !
-         ! Store the maximum water level itself
-         !
-         zsmax(nm) = max(zsmax(nm), zs(nm))
-         !
-      endif
-      !
-   enddo
-   !$omp end do
-   !$omp end parallel
-   !         
-   !$acc end parallel
-   !         
-   end subroutine
-   
-   subroutine compute_store_variables(dt)
-   !
-   use sfincs_data
-   !
-   implicit none
-   !
-   real*4           :: dt
-   !   
-   integer          :: nm
-   !   
-   integer          :: nmu
-   integer          :: nmd
-   integer          :: num
-   integer          :: ndm
-   !
-   real*4           :: quz
-   real*4           :: qvz
-   real*4           :: qz
-   real*4           :: uvz      
-   !
-   !$omp parallel &
-   !$omp private ( nmd, nmu, ndm, num, quz, qvz, qz, uvz )
-   !$omp do schedule ( dynamic, 256 )
-   !$acc parallel present( kcs, zs, zb, subgrid_z_zmin, q, uv, vmax, qmax, twet, &
-   !$acc                   z_index_uv_md, z_index_uv_nd, z_index_uv_mu, z_index_uv_nu )
-   !$acc loop gang vector 
-   do nm = 1, np
-      !
-      ! And now water level changes due to horizontal fluxes
-      !
-      qz = 0.0
-      uvz = 0.0    
-      !
-      if (kcs(nm) == 1 .or. kcs(nm) == 4) then ! TL: kcs(nm)==4 also correct for regular?
-         !      
-         ! Regular point with four surrounding cells of the same size
-         !
-         nmd = z_index_uv_md(nm)
-         nmu = z_index_uv_mu(nm)
-         ndm = z_index_uv_nd(nm)
-         num = z_index_uv_nu(nm)
-         !
-         if (store_maximum_velocity) then
-            quz = (uv(nmd) + uv(nmu)) / 2   
-            qvz = (uv(ndm) + uv(num)) / 2      
-            uvz = sqrt(quz**2 + qvz**2)
-         endif
-         !
-         if (store_maximum_flux) then
-            quz = (q(nmd) + q(nmu)) / 2   
-            qvz = (q(ndm) + q(num)) / 2      
-            qz = sqrt(quz**2 + qvz**2)
-         endif   
          !
          ! No continuity update but keeping track of variables
-         ! 1. store vmax
-         if (store_maximum_velocity) then
-            !             
-            vmax(nm) = max(vmax(nm), uvz)
+         ! zsmax used by default, therefore keep in standard continuity loop:
+         !
+         if (store_maximum_waterlevel) then
             !
-         endif      
-         !
-         ! 2. store qmax         
-         if (store_maximum_flux) then
-            !             
-            qmax(nm) = max(qmax(nm), qz)
+            ! Store when the maximum water level changed
             !
-         endif      
+            if (store_t_zsmax) then
+                if (zs(nm) > zsmax(nm)) then
+                    if ( (zs(nm) - subgrid_z_zmin(nm)) > huthresh) then
+                       t_zsmax(nm) = t
+                    endif
+                endif
+            endif
+            !
+            ! Store the maximum water level itself
+            !
+            zsmax(nm) = max(zsmax(nm), zs(nm))
+            !
+         endif
          !
-         ! 3. store Twet
-         if (store_twet) then
-            if (subgrid) then
-              !
-              if ( (zs(nm) - subgrid_z_zmin(nm)) > twet_threshold) then
-                 twet(nm) = twet(nm) + dt
-              endif
-              !
-            else
-              !
-              if ( (zs(nm) - zb(nm)) > twet_threshold) then
-                 !
-                 twet(nm) = twet(nm) + dt
-                 !
-              endif
-              !
-            endif               
-         endif         
+         ! Reset qsrc to zero for the next time step
          !
-      endif   
-   enddo   
-   !$omp end do
-   !$omp end parallel
-   !$acc end parallel
-   !       
+         qsrc(nm) = 0.0
+         !
+      enddo
+      !$omp end do
+      !$omp end parallel
+      !
+      !$acc end parallel
+      !
    end subroutine
-   
+   !
+   !-----------------------------------------------------------------------------------------------------!
+   !
+   subroutine compute_store_variables(dt)
+      !
+      ! Update the optional per-cell running diagnostics vmax, qmax and
+      ! twet from the edge-centred uv / q fields at the current step.
+      ! Cell-centred vmax / qmax are reconstructed as the 2D magnitude
+      ! of the mean of the four surrounding edge values. twet is the
+      ! cumulative time a cell has been wet above twet_threshold. Kept
+      ! in a separate routine to avoid the overhead when unused.
+      !
+      ! Called from: update_continuity (only when any of
+      ! store_maximum_velocity, store_maximum_flux or store_twet is
+      ! enabled).
+      !
+      use sfincs_data
+      !
+      implicit none
+      !
+      real*4           :: dt
+      !
+      integer          :: nm
+      !
+      integer          :: nmu
+      integer          :: nmd
+      integer          :: num
+      integer          :: ndm
+      !
+      real*4           :: quz
+      real*4           :: qvz
+      real*4           :: qz
+      real*4           :: uvz
+      !
+      !$omp parallel &
+      !$omp private ( nmd, nmu, ndm, num, quz, qvz, qz, uvz )
+      !$omp do schedule ( dynamic, 256 )
+      !$acc parallel present( kcs, zs, zb, subgrid_z_zmin, q, uv, vmax, qmax, twet, &
+      !$acc                   z_index_uv_md, z_index_uv_nd, z_index_uv_mu, z_index_uv_nu )
+      !$acc loop gang vector
+      do nm = 1, np
+         !
+         ! And now water level changes due to horizontal fluxes
+         !
+         qz = 0.0
+         uvz = 0.0
+         !
+         if (kcs(nm) == 1 .or. kcs(nm) == 4) then ! TL: kcs(nm)==4 also correct for regular?
+            !
+            ! Regular point with four surrounding cells of the same size
+            !
+            nmd = z_index_uv_md(nm)
+            nmu = z_index_uv_mu(nm)
+            ndm = z_index_uv_nd(nm)
+            num = z_index_uv_nu(nm)
+            !
+            if (store_maximum_velocity) then
+               quz = (uv(nmd) + uv(nmu)) / 2
+               qvz = (uv(ndm) + uv(num)) / 2
+               uvz = sqrt(quz**2 + qvz**2)
+            endif
+            !
+            if (store_maximum_flux) then
+               quz = (q(nmd) + q(nmu)) / 2
+               qvz = (q(ndm) + q(num)) / 2
+               qz = sqrt(quz**2 + qvz**2)
+            endif
+            !
+            ! No continuity update but keeping track of variables
+            ! 1. store vmax
+            if (store_maximum_velocity) then
+               !
+               vmax(nm) = max(vmax(nm), uvz)
+               !
+            endif
+            !
+            ! 2. store qmax
+            if (store_maximum_flux) then
+               !
+               qmax(nm) = max(qmax(nm), qz)
+               !
+            endif
+            !
+            ! 3. store Twet
+            if (store_twet) then
+               if (subgrid) then
+                 !
+                 if ( (zs(nm) - subgrid_z_zmin(nm)) > twet_threshold) then
+                    twet(nm) = twet(nm) + dt
+                 endif
+                 !
+               else
+                 !
+                 if ( (zs(nm) - zb(nm)) > twet_threshold) then
+                    !
+                    twet(nm) = twet(nm) + dt
+                    !
+                 endif
+                 !
+               endif
+            endif
+            !
+         endif
+      enddo
+      !$omp end do
+      !$omp end parallel
+      !$acc end parallel
+      !
+   end subroutine
+   !
 end module

--- a/source/src/sfincs_data.f90
+++ b/source/src/sfincs_data.f90
@@ -645,23 +645,9 @@ module sfincs_data
       real*4, dimension(:),   allocatable :: windv1
       real*4, dimension(:),   allocatable :: windmax
       !
-      real*4, dimension(:),   allocatable :: fwx
-      real*4, dimension(:),   allocatable :: fwy
       real*4, dimension(:),   allocatable :: hm0
       real*4, dimension(:),   allocatable :: hm0_ig
-      real*4, dimension(:),   allocatable :: sw_tp
-      real*4, dimension(:),   allocatable :: sw_tp_ig      
       real*4, dimension(:),   allocatable :: fwuv
-      real*4, dimension(:),   allocatable :: mean_wave_direction
-      real*4, dimension(:),   allocatable :: wave_directional_spreading
-      real*4, dimension(:),   allocatable :: dw
-      real*4, dimension(:),   allocatable :: df      
-      real*4, dimension(:),   allocatable :: dwig
-      real*4, dimension(:),   allocatable :: dfig
-      real*4, dimension(:),   allocatable :: cg    
-      real*4, dimension(:),   allocatable :: betamean
-      real*4, dimension(:),   allocatable :: srcig      
-      real*4, dimension(:),   allocatable :: alphaig      
       !!!
       !!! Boundary data
       !!!

--- a/source/src/sfincs_data.f90
+++ b/source/src/sfincs_data.f90
@@ -125,9 +125,7 @@ module sfincs_data
       character*256 :: obsfile
       character*256 :: crsfile
       character*256 :: rugfile
-      character*256 :: srcfile
-      character*256 :: disfile
-      character*256 :: drnfile
+      character*256 :: urbfile
       character*256 :: zsinifile
       character*256 :: rstfile
       character*256 :: indexfile
@@ -147,7 +145,6 @@ module sfincs_data
       character*256 :: weirfile
       character*256 :: qinffile
       character*256 :: netbndbzsbzifile
-      character*256 :: netsrcdisfile
       character*256 :: netamuamvfile
       character*256 :: netampfile
       character*256 :: netamprfile
@@ -208,6 +205,7 @@ module sfincs_data
       logical       :: store_hsubgrid
       logical       :: store_hmean      
       logical       :: store_qdrain
+      logical       :: store_river_discharge
       logical       :: store_zvolume
       logical       :: store_storagevolume            
       logical       :: store_meteo
@@ -222,6 +220,12 @@ module sfincs_data
       logical       :: write_time_output
       logical       :: bziwaves
       logical       :: infiltration
+      logical       :: discharges
+      logical       :: drainage_structures
+      logical       :: dike_breaching
+      logical       :: urban_drainage
+      logical       :: store_urban_drainage_discharge
+      logical       :: store_cumulative_urban_drainage
       LOGICAL       :: netcdf_infiltration
       logical       :: debug
       logical       :: radstr
@@ -403,6 +407,16 @@ module sfincs_data
       ! Storage volume
       !
       real*4, dimension(:),   allocatable :: storage_volume  ! Storage volume green infra
+      !
+      ! Bucket model - finite capacity reservoir with linear drainage
+      !
+      logical       :: use_bucket_model = .false.
+      real*4, dimension(:),   allocatable :: bucket_volume                     ! current storage (m)
+      real*4, dimension(:),   allocatable :: bucket_capacity                   ! max capacity S_max (m)
+      real*4, dimension(:),   allocatable :: bucket_k                          ! drainage coefficient (1/s)
+      real*4, dimension(:),   allocatable :: bucket_drain_rate                 ! net removal from surface this step (m/s)
+      real*4, dimension(:),   allocatable :: bucket_loss                       ! loss fraction per cell (0-1), ET/deep percolation
+      real*4, dimension(:),   allocatable :: bucket_runoff                     ! bucket drainage returned as surface runoff (m/s)
       !
       ! Wind reduction for spiderweb winds
       !
@@ -791,22 +805,26 @@ module sfincs_data
       !!!
       !!! Discharges and drainage
       !!!
-      integer                               :: nsrc
-      integer                               :: ndrn
-      integer                               :: nsrcdrn
+      ! Cell-wise accumulated discharge used by continuity. Size np. Zeroed
+      ! each step, then both sfincs_discharges and sfincs_src_structures
+      ! accumulate into it.
+      !
+      real*4, dimension(:),     allocatable :: qsrc        ! (np)   cell-wise discharge [m3/s]
+      !
+      ! River point discharges (sfincs_discharges)
+      !
+      ! Identifiers that are read by sfincs_input / sfincs_ncinput stay here;
+      ! the pure discharge-module-only state (itsrclast, nmindsrc, qtsrc,
+      ! src_name, src_name_len) has been moved into sfincs_discharges.
+      !
       integer                               :: ntsrc
-      integer                               :: itsrclast
-      real*4, dimension(:),     allocatable :: tsrc
-      real*4, dimension(:,:),   allocatable :: qsrc
-      real*4, dimension(:),     allocatable :: qtsrc
-      integer*4, dimension(:),  allocatable :: nmindsrc
-      integer*1, dimension(:),  allocatable :: drainage_type
-      real*4, dimension(:,:),   allocatable :: drainage_params
-      real*4, dimension(:),     allocatable :: drainage_distance
-      integer*1, dimension(:),  allocatable :: drainage_status
-      real*4, dimension(:),     allocatable :: drainage_fraction_open
+      real*4, dimension(:),     allocatable :: tsrc        ! (ntsrc) time stamps of river discharge time series
+      real*4, dimension(:,:),   allocatable :: qsrc_ts     ! (nr_discharge_points, ntsrc) river discharge time series matrix
       real*4, dimension(:),     allocatable :: xsrc
       real*4, dimension(:),     allocatable :: ysrc
+      !
+      ! Src-point structures (pumps, culverts, check valves, controlled gates)
+      ! live in module sfincs_src_structures.
       !!!
       !!! Structures
       !!!
@@ -974,7 +992,13 @@ module sfincs_data
     if(allocated(qinffield)) deallocate(qinffield)
     if(allocated(ksfield)) deallocate(ksfield)
     if(allocated(scs_Se)) deallocate(scs_Se)
-    if(allocated(nuvisc)) deallocate(nuvisc)    
+    if(allocated(bucket_volume)) deallocate(bucket_volume)
+    if(allocated(bucket_capacity)) deallocate(bucket_capacity)
+    if(allocated(bucket_k)) deallocate(bucket_k)
+    if(allocated(bucket_drain_rate)) deallocate(bucket_drain_rate)
+    if(allocated(bucket_loss)) deallocate(bucket_loss)
+    if(allocated(bucket_runoff)) deallocate(bucket_runoff)
+    if(allocated(nuvisc)) deallocate(nuvisc)
     !
     ! Boundary velocity points
     !
@@ -1130,10 +1154,15 @@ module sfincs_data
     !!!
     !!! Discharges
     !!!
-    if(allocated(tsrc)) deallocate(tsrc)
     if(allocated(qsrc)) deallocate(qsrc)
-    if(allocated(qtsrc)) deallocate(qtsrc)
-    if(allocated(nmindsrc)) deallocate(nmindsrc)
+    if(allocated(tsrc)) deallocate(tsrc)
+    if(allocated(qsrc_ts)) deallocate(qsrc_ts)
+    !
+    ! River-point-discharge module-private state (qtsrc, nmindsrc, src_name)
+    ! is owned by sfincs_discharges and is deallocated there.
+    !
+    ! Src-point structure state is owned by sfincs_src_structures and is
+    ! deallocated there.
     !!!
     !!! Structures
     !!!

--- a/source/src/sfincs_discharges.f90
+++ b/source/src/sfincs_discharges.f90
@@ -1,164 +1,263 @@
 module sfincs_discharges
-   
+   !
+   ! River point discharges: nr_discharge_points (x,y) locations from srcfile with matching
+   ! time series qsrc_ts(:,:) from disfile, OR from a FEWS-style netCDF input
+   ! via netsrcdisfile. Interpolates to the current model time every step,
+   ! stores the interpolated value in qtsrc(nr_discharge_points) (for his output), and
+   ! accumulates the per-cell discharge into the global qsrc(np) array used
+   ! by sfincs_continuity.
+   !
+   ! Drainage structures (pumps, check valves, culverts, controlled gates)
+   ! live in sfincs_src_structures. The two modules no longer share any
+   ! arrays -- they cooperate only by both writing into qsrc(np).
+   !
+   ! Subroutines:
+   !
+   !   initialize_discharges()
+   !     Read srcfile/disfile (ascii) or netsrcdisfile (netcdf), resolve
+   !     each source to its quadtree cell, and allocate runtime state.
+   !     Called from sfincs_lib at init time.
+   !
+   !   update_discharges(t, dt)
+   !     Zero qsrc(np), interpolate the river discharge time series to the
+   !     current time, and accumulate into qsrc at each source cell.
+   !     Called from update_continuity (sfincs_continuity) once per
+   !     time step, before update_src_structures.
+   !
+   !   count_tokens(line, ntok)
+   !     Count whitespace-separated tokens in a string; used to decide
+   !     between the 2-column (x y) and 3-column (x y name) src formats.
+   !     Called from initialize_discharges (this module).
+   !
    use sfincs_log
    use sfincs_error
    !
-contains
-   !
-   subroutine read_discharges()
-   !
-   ! Reads discharge files
-   !
-   use sfincs_data
-   use sfincs_ncinput
-   use quadtree
-   !
    implicit none
    !
-   real*4, dimension(:),     allocatable :: xsnk
-   real*4, dimension(:),     allocatable :: ysnk
+   ! Module-level runtime state for river point discharges (moved from
+   ! sfincs_data). The count, coordinate arrays, file-path strings, and
+   ! qsrc_ts / tsrc / ntsrc stay in sfincs_data because they are also
+   ! set by sfincs_input (keyword reader) or sfincs_ncinput (which this
+   ! module uses, so a back-reference would be circular).
    !
-   real*4 dummy, xsnk_tmp, ysnk_tmp, xsrc_tmp, ysrc_tmp
+   ! Public so downstream output modules (sfincs_output, sfincs_ncoutput)
+   ! and the openacc bookkeeping module can reference them.
    !
-   integer isrc, itsrc, idrn, nm, m, n, stat, j, iref, nmq, npars
+   ! Input file paths (sfincs.inp keywords 'srcfile' / 'disfile' /
+   ! 'netsrcdisfile'); 'none' when the corresponding input is not supplied.
    !
-   logical :: ok
+   character(len=256), public :: srcfile
+   character(len=256), public :: disfile
+   character(len=256), public :: netsrcdisfile
    !
-   character(len=256) :: drainage_line, message 
+   ! Number of river discharge points resolved from the input files.
    !
-   ! Read discharge points
+   integer, public :: nr_discharge_points
    !
-   nsrc  = 0
-   ndrn  = 0
-   ntsrc = 0
-   itsrclast = 1
+   ! Name length (matches src_struc_name_len from sfincs_src_structures).
    !
-   if (srcfile(1:4) /= 'none') then
+   integer, parameter, public :: src_name_len = 128
+   !
+   ! Per-river-source names
+   !
+   character(len=src_name_len), dimension(:), allocatable, public :: src_name   ! (nr_discharge_points) user-supplied or auto-generated names for river point sources
+   !
+   ! Runtime state
+   !
+   integer,                                   public :: itsrclast   ! last-used bracket index into tsrc, for time-series interpolation
+   real*4,    dimension(:), allocatable,      public :: qtsrc       ! (nr_discharge_points) interpolated discharge at current time, for his output
+   integer*4, dimension(:), allocatable,      public :: nmindsrc    ! (nr_discharge_points) river source cell indices
+   !
+contains
+   !
+   !-----------------------------------------------------------------------------------------------------!
+   !
+   subroutine initialize_discharges()
       !
-      ok = check_file_exists(srcfile, 'Source points file', .true.)
+      ! Read the river-point-discharge input and wire each source up to a grid
+      ! cell. Two mutually-exclusive input paths:
+      !   - srcfile (+ disfile): ascii, 2-column (x y) or 3-column (x y name)
+      !     location file plus a separate time-series file.
+      !   - netsrcdisfile: FEWS-style netcdf with locations and time series
+      !     in one file (no per-point names; auto-generated).
+      ! Allocates nmindsrc(nr_discharge_points) and qtsrc(nr_discharge_points),
+      ! and populates shared tsrc/qsrc_ts arrays in sfincs_data.
       !
-      write(logstr,'(a)')'Info    : reading discharges'
-      call write_log(logstr, 0)
+      ! Called from: sfincs_lib (once, at init time).
       !
-      ok = check_file_exists(srcfile, 'River input locations src file', .true.)      
+      use sfincs_data
+      use sfincs_ncinput
+      use quadtree
       !
-      open(500, file=trim(srcfile))
-      do while(.true.)
-         read(500,*,iostat = stat)dummy
-         if (stat < 0) exit
-         nsrc = nsrc + 1
+      implicit none
+      !
+      real*4    :: dummy
+      integer   :: isrc, itsrc, nmq, n, stat, ntok
+      logical   :: ok
+      character(len=1024) :: line, line_trim
+      character(len=src_name_len) :: name_tmp
+      !
+      discharges          = .false.
+      nr_discharge_points = 0
+      ntsrc               = 0
+      itsrclast           = 1
+      !
+      if (srcfile(1:4) /= 'none') then
          !
-      enddo
-      !
-      rewind(500)
-      !
-   elseif (netsrcdisfile(1:4) /= 'none') then    ! FEWS compatible Netcdf discharge time-series input
-      !
-      ok = check_file_exists(netsrcdisfile, 'Netcdf river input netsrcdis file', .true.)       
-      !
-      call read_netcdf_discharge_data()  ! reads nsrc, ntsrc, xsrc, ysrc, qsrc, and tsrc
-      !
-      if ((tsrc(1) > (t0 + 1.0)) .or. (tsrc(ntsrc) < (t1 - 1.0))) then
+         write(logstr,'(a)') 'Info    : reading discharges'
+         call write_log(logstr, 0)
          !
-         write(logstr,'(a)')' WARNING! Times in discharge file do not cover entire simulation period!'
-         call write_log(logstr, 1)
+         ok = check_file_exists(srcfile, 'River input locations src file', .true.)
          !
-      endif         
-      !
-   endif   
-   !
-   if (drnfile(1:4) /= 'none') then
-      !
-      write(logstr,'(a)')'Info    : reading drainage file'
-      call write_log(logstr, 0)
-      !
-      ok = check_file_exists(drnfile, 'Drainage points drn file', .true.)
-      !
-      open(501, file=trim(drnfile))
-      do while(.true.)
-         read(501,*,iostat = stat)dummy
-         if (stat < 0) exit
-         ndrn = ndrn + 1
-      enddo
-      rewind(501)
-   endif
-   !
-   nsrcdrn = nsrc + 2 * ndrn
-   !
-   if (nsrcdrn > 0) then
-      allocate(nmindsrc(nsrcdrn))
-      allocate(qtsrc(nsrcdrn))
-      nmindsrc = 0
-      qtsrc = 0.0
-   endif
-   !
-   if (srcfile(1:4) /= 'none') then
-      !
-      ! Actually read src and dis files
-      !
-      allocate(xsrc(nsrc))
-      allocate(ysrc(nsrc))
-      !
-      do n = 1, nsrc
-         read(500,*)xsrc(n), ysrc(n)
-      enddo
-      !
-      close(500)
-      !
-      ! Read discharge time series
-      !
-      ok = check_file_exists(disfile, 'River discharge timeseries dis file', .true.)      
-      !      
-      open(502, file=trim(disfile))
-      do while(.true.)
-         read(502,*,iostat = stat)dummy
-         if (stat < 0) exit
-         ntsrc = ntsrc + 1
+         open(500, file=trim(srcfile))
          !
-      enddo
-      !
-      rewind(502)
-      allocate(tsrc(ntsrc))
-      allocate(qsrc(nsrc,ntsrc))
-      do itsrc = 1, ntsrc
-         read(502,*)tsrc(itsrc), (qsrc(isrc, itsrc), isrc = 1, nsrc)
-      enddo
-      close(502)  
-      !
-   endif  
-   !
-   if (nsrc > 0) then
-      !
-      ! Check times at once for either srcfile or netsrcdisfile
-      !
-      if ((tsrc(1) > (t0 + 1.0)) .or. (tsrc(ntsrc) < (t1 - 1.0))) then
-         ! 
-         write(logstr,'(a)')'Warning! Times in discharge file do not cover entire simulation period !'
-         call write_log(logstr, 1)
-         !
-         if (tsrc(1) > (t0 + 1.0)) then
-            ! 
-            write(logstr,'(a)')'Warning! Adjusting first time in discharge time series !'
-            call write_log(logstr, 1)
+         do while (.true.)
             !
-            tsrc(1) = t0 - 1.0
+            read(500, *, iostat=stat) dummy
+            if (stat < 0) exit
+            nr_discharge_points = nr_discharge_points + 1
             !
-         else
-            ! 
-            write(logstr,'(a)')'Warning! Adjusting last time in discharge time series !'
-            call write_log(logstr, 1)
+         enddo
+         !
+         rewind(500)
+         !
+      elseif (netsrcdisfile(1:4) /= 'none') then    ! FEWS-compatible NetCDF discharge time series
+         !
+         ok = check_file_exists(netsrcdisfile, 'Netcdf river input netsrcdis file', .true.)
+         !
+         call read_netcdf_discharge_data(netsrcdisfile, nr_discharge_points)   ! also sets ntsrc, xsrc, ysrc, qsrc_ts, tsrc (in sfincs_data)
+         !
+         ! The netcdf discharge file does not carry per-point names; auto-generate
+         ! the same way as the 2-column srcfile path.
+         !
+         if (nr_discharge_points > 0) then
             !
-            tsrc(ntsrc) = t1 + 1.0
+            allocate(src_name(nr_discharge_points))
+            !
+            src_name = ' '
+            !
+            do n = 1, nr_discharge_points
+               !
+               write(src_name(n), '(a,i4.4)') 'discharge_', n
+               !
+            enddo
             !
          endif
          !
-      endif        
-      ! 
-      ! Determine m and n indices of sources
-      !
-      do isrc = 1, nsrc
+         if ((tsrc(1) > (t0 + 1.0)) .or. (tsrc(ntsrc) < (t1 - 1.0))) then
+            !
+            write(logstr,'(a)') ' WARNING! Times in discharge file do not cover entire simulation period!'
+            call write_log(logstr, 1)
+            !
+         endif
          !
-         ! Find cell in quadtree first
+      endif
+      !
+      if (nr_discharge_points <= 0) return
+      !
+      discharges = .true.
+      !
+      allocate(nmindsrc(nr_discharge_points))
+      allocate(qtsrc(nr_discharge_points))
+      !
+      nmindsrc = 0
+      qtsrc    = 0.0
+      !
+      ! Read src/dis contents for the srcfile case
+      !
+      if (srcfile(1:4) /= 'none') then
+         !
+         allocate(xsrc(nr_discharge_points))
+         allocate(ysrc(nr_discharge_points))
+         allocate(src_name(nr_discharge_points))
+         !
+         src_name = ' '
+         !
+         do n = 1, nr_discharge_points
+            !
+            read(500, '(a)') line
+            line_trim = adjustl(line)
+            !
+            ! Count whitespace-separated tokens on the line.
+            !
+            call count_tokens(line_trim, ntok)
+            !
+            if (ntok == 2) then
+               !
+               read(line_trim, *) xsrc(n), ysrc(n)
+               write(src_name(n), '(a,i4.4)') 'discharge_', n
+               !
+            elseif (ntok == 3) then
+               !
+               read(line_trim, *) xsrc(n), ysrc(n), name_tmp
+               src_name(n) = adjustl(trim(name_tmp))
+               !
+            else
+               !
+               write(logstr,'(a,i0,a,i0,a)') ' Error ! src file line ', n, ' has ', ntok, &
+                  ' tokens -- expected 2 (x y) or 3 (x y name) !'
+               call write_log(logstr, 1)
+               error = 1
+               return
+               !
+            endif
+            !
+         enddo
+         !
+         close(500)
+         !
+         ! Read discharge time series
+         !
+         ok = check_file_exists(disfile, 'River discharge timeseries dis file', .true.)
+         !
+         open(502, file=trim(disfile))
+         !
+         do while (.true.)
+            !
+            read(502, *, iostat=stat) dummy
+            if (stat < 0) exit
+            ntsrc = ntsrc + 1
+            !
+         enddo
+         !
+         rewind(502)
+         allocate(tsrc(ntsrc))
+         allocate(qsrc_ts(nr_discharge_points, ntsrc))
+         !
+         do itsrc = 1, ntsrc
+            !
+            read(502, *) tsrc(itsrc), (qsrc_ts(isrc, itsrc), isrc = 1, nr_discharge_points)
+            !
+         enddo
+         !
+         close(502)
+         !
+         if ((tsrc(1) > (t0 + 1.0)) .or. (tsrc(ntsrc) < (t1 - 1.0))) then
+            !
+            write(logstr,'(a)') 'Warning! Times in discharge file do not cover entire simulation period !'
+            call write_log(logstr, 1)
+            !
+            if (tsrc(1) > (t0 + 1.0)) then
+               !
+               write(logstr,'(a)') 'Warning! Adjusting first time in discharge time series !'
+               call write_log(logstr, 1)
+               tsrc(1) = t0 - 1.0
+               !
+            else
+               !
+               write(logstr,'(a)') 'Warning! Adjusting last time in discharge time series !'
+               call write_log(logstr, 1)
+               tsrc(ntsrc) = t1 + 1.0
+               !
+            endif
+            !
+         endif
+         !
+      endif
+      !
+      ! Map river sources to grid cells
+      !
+      do isrc = 1, nr_discharge_points
          !
          nmq = find_quadtree_cell(xsrc(isrc), ysrc(isrc))
          !
@@ -167,496 +266,142 @@ contains
             nmindsrc(isrc) = index_sfincs_in_quadtree(nmq)
             !
          endif
-         !         
-      enddo
-      !
-      ! Don't need coordinates anymore, and xsrc and ysrc may be used for drainage points as well
-      !
-      deallocate(xsrc)
-      deallocate(ysrc)
-      !
-   endif   
-   !
-   ! And now the drainage points
-   !
-   if (ndrn>0) then
-      !
-      write(logstr,'(a,a,a,i0,a)')' Reading ',trim(drnfile),' (', ndrn, ' drainage points found) ...'
-      call write_log(logstr, 0)
-      !         
-      allocate(xsrc(ndrn))
-      allocate(ysrc(ndrn))
-      allocate(xsnk(ndrn))
-      allocate(ysnk(ndrn))
-      !
-      allocate(drainage_type(ndrn))
-      allocate(drainage_params(ndrn, 6))
-      allocate(drainage_status(ndrn))
-      allocate(drainage_distance(ndrn))
-      allocate(drainage_fraction_open(ndrn))
-      !
-      drainage_params = 0.0
-      drainage_distance = 0.0
-      drainage_fraction_open = 1.0   ! initially fully open (should fix this based on zmin and zmax in params)
-      drainage_status = 1            ! open (0=closed, 1=open, 2=closing, 3=opening)
-      !
-      do idrn = 1, ndrn
-         !
-         read(501, '(a)') drainage_line
-         !
-         ! First find out what type of drainage structure it is (integer 5th item in line)
-         !
-         read(drainage_line,*,iostat=stat)xsnk_tmp, ysnk_tmp, xsrc_tmp, ysrc_tmp, drainage_type(idrn)
-         !
-         npars = 0 ! Default (if npars stays 0, throw error)
-         !
-         if (drainage_type(idrn) == 1 .or. drainage_type(idrn) == 2 .or. drainage_type(idrn) == 3) then
-            !
-            ! Pump, culvert or check valve (1 parameter)
-            !
-            npars = 1
-            !
-         elseif (drainage_type(idrn) == 4 .or. drainage_type(idrn) == 5) then
-            !
-            ! Controlled gate (6 parameters : width, sill elevation, manning, zmin, zmax, closing time)
-            !
-            npars = 6
-            !
-         endif
-         !
-         if (npars == 0) then
-            !
-            write(logstr,'(a,i0,a)')'Drainage type ', drainage_type(idrn), ' not recognized !'
-            call stop_sfincs(logstr, -1)
-            !
-         endif               
-         !
-         if (npars == 1) then
-            !
-            ! Pump, culvert or check valve
-            !
-            read(drainage_line,*,iostat=stat)xsnk(idrn), ysnk(idrn), xsrc(idrn), ysrc(idrn), drainage_type(idrn), drainage_params(idrn,1)
-            !
-         elseif (npars == 6) then
-            !
-            ! Controlled gate, needs 6 parameters
-            !
-            read(drainage_line,*,iostat=stat)xsnk(idrn), ysnk(idrn), xsrc(idrn), ysrc(idrn), drainage_type(idrn), drainage_params(idrn,1), drainage_params(idrn,2), drainage_params(idrn,3), drainage_params(idrn,4), drainage_params(idrn,5), drainage_params(idrn,6)
-            !
-         endif
-         !
-         if (stat /= 0) then
-            !
-            write(logstr,'(a,i0,a,i0,a)')'Drainage type ', drainage_type(idrn), ' requires ', npars, ' parameters !'
-            call stop_sfincs(logstr, -1)
-            !
-         endif
-         !
-      enddo
-      !
-      close(501)
-      !
-      ! Determine nm indices of source and sinks
-      !
-      do idrn = 1, ndrn
-         !
-         ! Determine index of sink first
-         !
-         j = nsrc + idrn*2 - 1
-         !
-         nmq = find_quadtree_cell(xsnk(idrn), ysnk(idrn))
-         !
-         if (nmq > 0) then
-            !
-            nmindsrc(j) = index_sfincs_in_quadtree(nmq)
-            !
-         endif
-         !
-         ! And now the index of the source
-         !
-         j = nsrc + idrn * 2
-         !
-         nmq = find_quadtree_cell(xsrc(idrn), ysrc(idrn))
-         !
-         if (nmq > 0) then
-            !
-            nmindsrc(j) = index_sfincs_in_quadtree(nmq)
-            !
-         endif
-         !
-         ! Get coords of source and sink points, and compute distance between them.
-         ! Only do this when both points were found inside the active grid (nmindsrc > 0);
-         ! if either point is outside, skip to avoid an index-0 array access.
-         !
-         if (nmindsrc(nsrc + idrn * 2 - 1) > 0 .and. nmindsrc(nsrc + idrn * 2) > 0) then
-            !
-            xsnk_tmp = z_xz(nmindsrc(nsrc + idrn * 2 - 1))
-            ysnk_tmp = z_yz(nmindsrc(nsrc + idrn * 2 - 1))
-            xsrc_tmp = z_xz(nmindsrc(nsrc + idrn * 2))
-            ysrc_tmp = z_yz(nmindsrc(nsrc + idrn * 2))
-            !
-            drainage_distance(idrn) = sqrt( (xsrc_tmp - xsnk_tmp)**2 + (ysrc_tmp - ysnk_tmp)**2 )
-            !
-         endif
          !
       enddo
       !
       deallocate(xsrc)
       deallocate(ysrc)
-      deallocate(xsnk)
-      deallocate(ysnk)
       !
-      ! Check if all sink/source points have found an index
-      if (any(nmindsrc == 0)) then
-         !
-         write(logstr,'(a)')'Warning ! For some sink/source drainage points no matching active grid cell was found!'
-         call write_log(logstr, 0)
-         write(logstr,'(a)')'Warning ! These points will be skipped, please check your input!'
-         call write_log(logstr, 0)
-         !
-      endif      
-      !
-   endif
-   !
    end subroutine
    !
+   !-----------------------------------------------------------------------------------------------------!
    !
-   !
-   subroutine update_discharges(t, dt, tloop)
-   !
-   ! Update discharges
-   !
-   use sfincs_data
-   !
-   implicit none
-   !
-   integer  :: count0
-   integer  :: count1
-   integer  :: count_rate
-   integer  :: count_max
-   real     :: tloop
-   !
-   real*8           :: t
-   real*4           :: dt
-   real*4           :: qq
-   real*4           :: qq0
-   !
-   real*4           :: dzds, frac, wdt, zsill, zmin, zmax, mng, hgate, dfrac, tcls, topen, tclose
-   integer          :: idir
-   !
-   integer isrc, itsrc, idrn, jin, jout, nmin, nmout
-   !
-   call system_clock(count0, count_rate, count_max)
-   !
-   ! Compute instantaneous discharges from point sources
-   !
-   if (nsrc > 0) then
+   subroutine update_discharges(t, dt)
+      !
+      ! Zero qsrc(np); interpolate the river discharge time series to t,
+      ! store in qtsrc(1..nr_discharge_points), and accumulate into qsrc(nmindsrc(:)).
+      !
+      ! update_discharges is called BEFORE update_src_structures -- that is
+      ! why it owns the qsrc zeroing. Both routines then additively write
+      ! their contributions.
+      !
+      ! Called from: update_continuity (sfincs_continuity), once per time step.
+      !
+      use sfincs_data
+      !
+      implicit none
+      !
+      real*8  :: t
+      real*4  :: dt
+      !
+      integer :: isrc, itsrc, nm, it_prev, it_next
+      real*4  :: wt
+      !
+      ! qsrc is not zeroed here. The water-level update at the end of the
+      ! previous step clears qsrc(nm) for every active cell, and
+      ! update_meteo_forcing has by now accumulated prcp*area into it for
+      ! the current step. update_discharges and the remaining continuity
+      ! steps just keep adding on top.
+      !
+      if (nr_discharge_points <= 0) return
+      !
+      ! Locate the bracketing interval in tsrc and compute the interpolation
+      ! weight once. Then run a single parallel loop that both interpolates
+      ! qtsrc and accumulates it into qsrc.
+      !
+      it_prev = itsrclast
+      it_next = itsrclast + 1
+      !
       do itsrc = itsrclast, ntsrc
-         ! Find first point in time series large than t
+         !
          if (tsrc(itsrc) > t) then
-            do isrc = 1, nsrc
-               qtsrc(isrc) = qsrc(isrc, itsrc - 1) + (qsrc(isrc, itsrc) - qsrc(isrc, itsrc - 1)) * (t - tsrc(itsrc - 1)) / (tsrc(itsrc) - tsrc(itsrc - 1))
-            enddo
-            itsrclast = itsrc - 1
+            !
+            it_prev = itsrc - 1
+            it_next = itsrc
+            itsrclast = it_prev
             exit
             !
          endif
          !
       enddo
       !
-      !$acc update device(qtsrc)
+      ! Clamp to valid bracket. If t is outside [tsrc(1), tsrc(ntsrc)] (which
+      ! can happen on the netcdf path, where the srcfile pre-padding is not
+      ! applied), hold the endpoint value rather than read out of bounds.
       !
-   endif
-   !
-   if (ndrn > 0) then
+      it_prev = min(max(it_prev, 1), ntsrc - 1)
+      it_next = it_prev + 1
       !
-      !$acc serial, present( z_volume, zs, zb, nmindsrc, qtsrc, drainage_type, drainage_params )
-      do idrn = 1, ndrn
+      wt = (t - tsrc(it_prev)) / (tsrc(it_next) - tsrc(it_prev))
+      !
+      ! Atomic accumulation because two river sources (or a river and a
+      ! structure) can share a cell.
+      !
+      !$acc parallel loop present( qsrc, qtsrc, nmindsrc, qsrc_ts ) private( nm )
+      !$omp parallel do private( nm ) schedule ( static )
+      do isrc = 1, nr_discharge_points
          !
-         jin  = nsrc + idrn * 2 - 1
-         jout = nsrc + idrn * 2
+         qtsrc(isrc) = qsrc_ts(isrc, it_prev) + (qsrc_ts(isrc, it_next) - qsrc_ts(isrc, it_prev)) * wt
+         nm = nmindsrc(isrc)
          !
-         nmin  = nmindsrc(jin)
-         nmout = nmindsrc(jout)
-         !
-         if (nmin > 0 .and. nmout > 0) then
+         if (nm > 0) then
             !
-            select case(drainage_type(idrn))
-               !
-               case(1)
-                  !
-                  ! Pump
-                  !
-                  qq = drainage_params(idrn, 1)
-                  !
-               case(2)
-                  !
-                  ! Culvert
-                  !
-                  if (zs(nmin)>zs(nmout)) then
-                     !
-                     qq  = drainage_params(idrn, 1) * sqrt(zs(nmin) - zs(nmout))
-                     !
-                  else
-                     !
-                     qq  = -drainage_params(idrn, 1) * sqrt(zs(nmout) - zs(nmin))
-                     !
-                  endif
-                  !
-               case(3)
-                  !
-                  ! Check valve (same as culvert, but only works in one direction)
-                  !
-                  if (zs(nmin) > zs(nmout)) then
-                     !
-                     qq = drainage_params(idrn, 1) * sqrt(zs(nmin) - zs(nmout))
-                     !
-                  else
-                     !
-                     qq = -drainage_params(idrn, 1) * sqrt(zs(nmout) - zs(nmin))
-                     !
-                  endif
-                  !
-                  ! Make sure it can only flow from intake to outfall point
-                  !
-                  qq = max(qq, 0.0)
-                  !
-               case(4)
-                  !
-                  ! Controlled gate. Gate opens when water level at intake point is between zmin and zmax.
-                  !
-                  wdt   = drainage_params(idrn, 1)                        ! width
-                  zsill = drainage_params(idrn, 2)                        ! sill elevation
-                  mng   = drainage_params(idrn, 3)                        ! Manning's n
-                  zmin  = drainage_params(idrn, 4)                        ! min water level for open
-                  zmax  = drainage_params(idrn, 5)                        ! max water level for open
-                  tcls  = drainage_params(idrn, 6)                        ! closing time (seconds)
-                  !
-                  dzds = (zs(nmout) - zs(nmin)) / drainage_distance(idrn) ! water level slope
-                  frac = drainage_fraction_open(idrn)                     ! fraction open (from previous time step)
-                  hgate = max(max(zs(nmin), zs(nmout)) - zsill, 0.0)      ! water depth
-                  dfrac = dt / tcls                                       ! change in fraction open per time step
-                  !
-                  qq0 = -qtsrc(jin) / (wdt * max(frac, 0.001))            ! discharge (in m2/s) from previous time step, excluding fraction open
-                  !
-                  ! Get status of gate
-                  !
-                  if (drainage_status(idrn) == 0) then
-                     !
-                     ! Gate fully closed
-                     !
-                     if (zs(nmin) > zmin .and. zs(nmin) < zmax) then
-                        !
-                        ! Water level is in allowable range, so need to open the gate
-                        !
-                        drainage_status(idrn) = 3
-                        !
-                        ! Lines below only work with Windows intel compiler, can be used for debugging
-                        !
-                        ! Actual discharges through drainage structure can always be checked if 'storeqdrain=1' in sfincs.inp
-                        !
-                        !write(logstr,'(a,i0,a,f0.1)')'INFO Gates - Opening structure ',idrn,' at t= ',t
-                        !call write_log(logstr, 0)            
-                        !
-                     endif
-                     !
-                  elseif (drainage_status(idrn) == 1) then
-                     !
-                     ! Gate fully open
-                     !
-                     if (zs(nmin) <= zmin .or. zs(nmin) >= zmax) then
-                        !
-                        ! Water level is NOT in allowable range, so need to close the gate
-                        !
-                        drainage_status(idrn) = 2
-                        !                                        
-                        !write(logstr,'(a,i0,a,f0.1)')'INFO Gates - Closing structure ',idrn,' at t= ',t
-                        !call write_log(logstr, 0)
-                        !                        
-                     endif
-                     !
-                  endif                        
-                  !
-                  ! Update fraction open
-                  !
-                  if (drainage_status(idrn) == 2) then
-                     !
-                     ! Gate is closing
-                     !
-                     frac = frac - dfrac
-                     !
-                     if (frac < 0.0) then
-                        !
-                        ! Gate is now fully closed
-                        !
-                        frac = 0.0
-                        drainage_status(idrn) = 0
-                        !
-                     endif
-                     !
-                  elseif (drainage_status(idrn) == 3) then
-                     !
-                     ! Gate is opening
-                     !
-                     frac = frac + dfrac
-                     !
-                     if (frac > 1.0) then
-                        !
-                        ! Gate is now fully open
-                        !
-                        frac = 1.0
-                        drainage_status(idrn) = 1
-                        !
-                     endif
-                     !
-                  endif
-                  !
-                  drainage_fraction_open(idrn) = frac
-                  !
-                  ! Use Bates et al. (2010) formulation to include inertia effects
-                  !
-                  qq = (qq0 - g * hgate * dzds * dt) / (1.0 + g * mng**2 * dt * abs(qq0) / hgate**(7.0 / 3.0))
-                  !
-                  ! Multiply with width and fraction open to get discharge in m3/s
-                  !
-                  qq = qq * wdt * frac
-                  !
-               case(5)
-                  !
-                  ! Controlled gate. Gate opens and closes at set user input times (only, and once), still using closing time.
-                  !
-                  wdt   = drainage_params(idrn, 1)                        ! width
-                  zsill = drainage_params(idrn, 2)                        ! sill elevation
-                  mng   = drainage_params(idrn, 3)                        ! Manning's n
-                  tclose = drainage_params(idrn, 4)                       ! time wrt tref for closing gate
-                  topen  = drainage_params(idrn, 5)                       ! time wrt tref for opening gate
-                  tcls  = drainage_params(idrn, 6)                        ! closing time (seconds)
-                  !
-                  dzds = (zs(nmout) - zs(nmin)) / drainage_distance(idrn) ! water level slope
-                  frac = drainage_fraction_open(idrn)                     ! fraction open (from previous time step)
-                  hgate = max(max(zs(nmin), zs(nmout)) - zsill, 0.0)      ! water depth
-                  dfrac = dt / tcls                                       ! change in fraction open per time step
-                  !
-                  qq0 = -qtsrc(jin) / (wdt * max(frac, 0.001))            ! discharge (in m2/s) from previous time step, excluding fraction open
-                  !
-                  ! Get status of gate
-                  !
-                  if (drainage_status(idrn) == 0) then
-                     !
-                     ! Gate fully closed
-                     !
-                     if (t >= topen) then
-                        !
-                        ! Time has passed 'topen', so need to open the gate
-                        !
-                        drainage_status(idrn) = 3
-                        !
-                        !write(logstr,'(a,i0,a,f0.1)')'INFO Gates - Opening structure ',idrn,' at t= ',t
-                        !call write_log(logstr, 0)                        
-                        !
-                     endif
-                     !
-                  elseif (drainage_status(idrn) == 1) then
-                     !
-                     ! Gate fully open
-                     !
-                     if (t >= tclose .and. t < topen) then
-                        !
-                        ! Time has passed 'tclose', so need to close the gate
-                        !
-                        drainage_status(idrn) = 2
-                        !
-                        !write(logstr,'(a,i0,a,f0.1)')'INFO Gates - Closing structure ',idrn,' at t= ',t
-                        !call write_log(logstr, 0)
-                        !                        
-                     endif
-                     !
-                  endif                        
-                  !
-                  ! Update fraction open
-                  !
-                  if (drainage_status(idrn) == 2) then
-                     !
-                     ! Gate is closing
-                     !
-                     frac = frac - dfrac
-                     !
-                     if (frac < 0.0) then
-                        !
-                        ! Gate is now fully closed
-                        !
-                        frac = 0.0
-                        drainage_status(idrn) = 0
-                        !
-                     endif
-                     !
-                  elseif (drainage_status(idrn) == 3) then
-                     !
-                     ! Gate is opening
-                     !
-                     frac = frac + dfrac
-                     !
-                     if (frac > 1.0) then
-                        !
-                        ! Gate is now fully open
-                        !
-                        frac = 1.0
-                        drainage_status(idrn) = 1
-                        !
-                     endif
-                     !
-                  endif
-                  !
-                  drainage_fraction_open(idrn) = frac
-                  !
-                  ! Use Bates et al. (2010) formulation to include inertia effects
-                  !
-                  qq = (qq0 - g * hgate * dzds * dt) / (1.0 + g * mng**2 * dt * abs(qq0) / hgate**(7.0 / 3.0))
-                  !
-                  ! Multiply with width and fraction open to get discharge in m3/s
-                  !
-                  qq = qq * wdt * frac
-                  !                  
-            end select
-            !
-            ! Add some relaxation
-            ! structure_relax in seconds => gives ratio between new and old discharge (default 10s)
-            !   
-            qq = 1.0 / (structure_relax / dt) * qq + (1.0 - (1.0 / (structure_relax / dt))) * -qtsrc(jin)
-            !   
-            ! Limit discharge based on available volume in cell (regular or subgrid)
-            !    
-            if (subgrid) then
-               !
-               if (qq > 0.0) then
-                  qq = min(qq, max(z_volume(nmin), 0.0) / dt)
-               else
-                  qq = max(qq, -max(z_volume(nmout), 0.0) / dt)
-               endif
-               !
-            else
-               !
-               if (qq > 0.0) then
-                  qq = min(qq, max((zs(nmin) - zb(nmin)) * cell_area(z_flags_iref(nmin)), 0.0) / dt)
-               else
-                  qq = max(qq, -max((zs(nmout) - zb(nmout)) * cell_area(z_flags_iref(nmout)), 0.0) / dt)
-               endif
-               !
-            endif
-            !      
-            qtsrc(jin)  = -qq 
-            qtsrc(jout) = qq
+            !$acc atomic update
+            !$omp atomic
+            qsrc(nm) = qsrc(nm) + qtsrc(isrc)
             !
          endif
          !
       enddo
-      !$acc end serial
+      !$omp end parallel do
+      !$acc end parallel loop
       !
-   endif
-   !
-   call system_clock(count1, count_rate, count_max)
-   tloop = tloop + 1.0 * (count1 - count0) / count_rate
-   !
    end subroutine
-
+   !
+   !-----------------------------------------------------------------------------------------------------!
+   !
+   subroutine count_tokens(line, ntok)
+      !
+      ! Count the number of whitespace-separated tokens in a string.
+      ! Whitespace = spaces and tabs. Empty string returns 0.
+      !
+      ! Called from: initialize_discharges (this module) to disambiguate the
+      ! 2-column vs 3-column srcfile layout.
+      !
+      implicit none
+      !
+      character(len=*), intent(in)  :: line
+      integer,          intent(out) :: ntok
+      !
+      integer :: i, n
+      logical :: in_tok
+      character(len=1) :: c
+      !
+      ntok   = 0
+      in_tok = .false.
+      n      = len_trim(line)
+      !
+      do i = 1, n
+         !
+         c = line(i:i)
+         !
+         if (c == ' ' .or. c == char(9)) then
+            !
+            in_tok = .false.
+            !
+         else
+            !
+            if (.not. in_tok) then
+               !
+               ntok   = ntok + 1
+               in_tok = .true.
+               !
+            endif
+            !
+         endif
+         !
+      enddo
+      !
+   end subroutine
+   !
 end module

--- a/source/src/sfincs_domain.f90
+++ b/source/src/sfincs_domain.f90
@@ -25,8 +25,6 @@ contains
    !
    call initialize_roughness()
    !
-   call initialize_infiltration() ! see: sfincs_infiltration.f90
-   !
    call initialize_storage_volume()
    !
    call initialize_vegetation()
@@ -2202,12 +2200,18 @@ contains
    allocate(uv0(npuv + ncuv + 1))
    !
    allocate(kfuv(npuv))
-   ! 
-   zs  = 0.0
-   q   = 0.0
-   q0  = 0.0
-   uv  = 0.0
-   uv0 = 0.0
+   !
+   ! Cell-wise discharge accumulator (point sources + drainage structures),
+   ! read by sfincs_continuity.
+   !
+   allocate(qsrc(np))
+   !
+   zs   = 0.0
+   q    = 0.0
+   q0   = 0.0
+   uv   = 0.0
+   uv0  = 0.0
+   qsrc = 0.0
    !
    kfuv = 0 
    !

--- a/source/src/sfincs_domain.f90
+++ b/source/src/sfincs_domain.f90
@@ -2228,47 +2228,13 @@ contains
       !
       allocate(hm0(np))
       allocate(hm0_ig(np))
-      allocate(sw_tp(np))
-      allocate(sw_tp_ig(np))      
       allocate(fwuv(npuv))
       !
       hm0    = 0.0
       hm0_ig = 0.0
-      sw_tp     = 0.0
-      sw_tp_ig  = 0.0      
       fwuv   = 0.0
       !
-      if (store_wave_forces) then
-         allocate(fwx(np))
-         allocate(fwy(np))
-         fwx = 0.0
-         fwy = 0.0
-         allocate(dw(np))
-         allocate(df(np))
-         dw = 0.0
-         df = 0.0
-         allocate(dwig(np))
-         allocate(dfig(np))
-         dwig = 0.0
-         dfig = 0.0   
-         allocate(cg(np))
-         cg = 0.0
-         allocate(betamean(np))
-         betamean = 0.0     
-         allocate(srcig(np))
-         srcig = 0.0           
-         allocate(alphaig(np))
-         alphaig = 0.0            
-      endif
-      !
-      if (store_wave_direction) then
-         allocate(mean_wave_direction(np))
-         allocate(wave_directional_spreading(np))
-         mean_wave_direction        = 0.0
-         wave_directional_spreading = 0.0
-      endif   
-      !
-   endif   
+   endif
    !
    if (wavemaker .or. snapwave) then !TL: zsm also used in sfincs_continuity if 'snapwave=true' > todo: check if needed, or only for wavemaker 
       allocate(zsm(np))

--- a/source/src/sfincs_infiltration.f90
+++ b/source/src/sfincs_infiltration.f90
@@ -18,8 +18,8 @@ contains
    !
    character*256 :: varname
    !
-   character(len=3), parameter :: allowed_types(5) = &
-        ['c2d', 'cna', 'cnb', 'gai', 'hor']   
+   character(len=3), parameter :: allowed_types(6) = &
+        ['c2d', 'cna', 'cnb', 'gai', 'hor', 'bkt']   
 
    logical :: inftype_exists   
    !
@@ -32,20 +32,22 @@ contains
    infiltration   = .false.
    netcdf_infiltration   = .false.   
    !
-   ! Four options for infiltration:
+   ! Seven infiltration flavors (inftype):
    !
-   ! 1) Spatially-uniform constant infiltration
-   !    Requires: -
-   ! 2) Spatially-varying constant infiltration
-   !    Requires: qinfmap (does not require qinffield !)
-   ! 3) Spatially-varying infiltration with CN numbers (old)
-   !    Requires: cumprcp, cuminf, qinfmap, qinffield
-   ! 4) Spatially-varying infiltration with CN numbers (new)
-   !    Requires: qinfmap, qinffield, qinffield, ksfield, scs_P1, scs_F1, scs_Se and scs_rain (but not necessarily cuminf and cumprcp)
-   ! 5) Spatially-varying infiltration with the Green-Ampt (GA) model
-   !    Requires: qinfmap, qinffield, ksfield, GA_head, GA_sigma_max, GA_Lu
-   ! 6) Spatially-varying infiltration with the modified Horton Equation 
-   !    Requires: qinfmap, qinffield, horton_fc, horton_f0     
+   ! 1) 'con' - Spatially-uniform constant infiltration
+   !    Requires: qinf (mm/hr in sfincs.inp)
+   ! 2) 'c2d' - Spatially-varying constant infiltration
+   !    Requires: qinffile or infiltrationfile
+   ! 3) 'cna' - SCS Curve Number (old, no recovery)
+   !    Requires: scsfile or infiltrationfile
+   ! 4) 'cnb' - SCS Curve Number (new, with recovery)
+   !    Requires: sefffile or infiltrationfile
+   ! 5) 'gai' - Green-Ampt infiltration
+   !    Requires: psifile or infiltrationfile
+   ! 6) 'hor' - Modified Horton equation
+   !    Requires: f0file or infiltrationfile
+   ! 7) 'bkt' - Bucket model (linear reservoir, HBV/wflow style)
+   !    Requires: infiltrationfile with bucket_smax, bucket_k and bucket_loss
    !
    ! cumprcp and cuminf are stored in the netcdf output if store_cumulative_precipitation == .true. which is the default
    !
@@ -61,6 +63,12 @@ contains
    ! 1) First we determine infiltration type
    !
    if (precip) then
+      !
+      if (inftype == 'bkt' .and. infiltrationfile == 'none') then
+         !
+         call stop_sfincs('Error ! Bucket model requires infiltrationfile together with infiltrationtype = bkt !', 1)
+         !
+      endif
       !
       if (infiltrationfile  /= 'none') then
          !
@@ -83,7 +91,7 @@ contains
             !
          else
             !
-            write(logstr,*)'Error    : infiltration input type ',trim(inftype),' is not part of supported types c2d cna cnb gai hor !'
+            write(logstr,*)'Error    : infiltration input type ',trim(inftype),' is not part of supported types c2d cna cnb gai hor bkt !'
             call stop_sfincs(trim(logstr), 1)   
             !
          end if        
@@ -124,7 +132,7 @@ contains
          inftype = 'gai'
          infiltration = .true.      
          !
-      elseif (f0file /= 'none') then  
+      elseif (f0file /= 'none') then
          !
          ! The Horton Equation model for infiltration
          !
@@ -168,22 +176,19 @@ contains
       ! 5) Check whether infiltration input type (orignal vs netcdf) are correctly matched to grid type (regular vs quadtree)
       !
       if (infiltration .and. inftype /= 'con') then !constant uniform works for both options
-         ! 
-         if (netcdf_infiltration) then
-            !            
-            if (use_quadtree .eqv. .false.) then
-               ! 
-               call stop_sfincs('Error ! Netcdf infiltration input format can only be specified for quadtree mesh model !', 1)              
+         !
+         ! Netcdf infiltration works for both regular and quadtree grids
+         ! (regular grids populate quadtree_nr_points and index_sfincs_in_quadtree
+         !  via make_quadtree_from_indices)
+         !
+         if (.not. netcdf_infiltration) then
+            !
+            if (use_quadtree .eqv. .true.) then
+               !
+               call stop_sfincs('Error ! Infiltration input for quadtree mesh model can only be specified using the infiltrationfile Netcdf format! !', 1)
                !
             endif
             !
-         else ! Original
-            ! 
-            if (use_quadtree .eqv. .true.) then
-               ! 
-               call stop_sfincs('Error ! Infiltration input for quadtree mesh model can only be specified using the infiltrationfile Netcdf format! !', 1)                       
-            endif 
-             ! 
          endif
          !
       endif      
@@ -498,7 +503,7 @@ contains
          ! Allocate support variables:
          !
          allocate(qinffield(np))
-         qinffield(nm) = 0.0
+         qinffield = 0.0
          !
       elseif (inftype == 'hor') then  
          !
@@ -591,6 +596,14 @@ contains
          allocate(rain_T1(np))
          rain_T1 = 0.0
          !
+      elseif (inftype == 'bkt') then
+         !
+         ! Bucket model (linear reservoir) - mimics hydrology models like wflow/HBV
+         !
+         call write_log('Info    : turning on process infiltration (via bucket model)', 0)
+         !
+         call initialize_bucket_model()
+         !
       endif
       !
    else
@@ -604,7 +617,7 @@ contains
    end subroutine
    
    
-   subroutine update_infiltration_map(dt, tloop)
+   subroutine update_infiltration_map(dt)
    !
    ! Update infiltration rates in each grid cell
    !
@@ -617,15 +630,7 @@ contains
    real*4  :: Qq
    real*4  :: I
    real*4  :: hh_local, a
-   real*4  :: dt   
-   !
-   integer   :: count0
-   integer   :: count1
-   integer   :: count_rate
-   integer   :: count_max
-   real      :: tloop
-   !
-   call system_clock(count0, count_rate, count_max)
+   real*4  :: dt
    !
    if (inftype == 'con' .or. inftype == 'c2d') then
       !
@@ -634,7 +639,7 @@ contains
       !$omp parallel &
       !$omp private ( nm )
       !$omp do
-      !$acc parallel present( qinfmap, qinffield, z_volume, zs, zb, netprcp, cuminf )
+      !$acc parallel present( qinfmap, qinffield, z_volume, zs, zb, cuminf )
       !$acc loop independent gang vector
       do nm = 1, np
          !
@@ -656,17 +661,13 @@ contains
             !
          endif
          !
-         ! Compute nett precip
-         !
-         netprcp(nm) = netprcp(nm) - qinfmap(nm)
-         !
          if (store_cumulative_precipitation) then
             !
             ! Compute cumulative infiltration
             !
             cuminf(nm) = cuminf(nm) + qinfmap(nm) * dt
             !
-         endif   
+         endif
          !
       enddo
       !$omp end do
@@ -680,7 +681,7 @@ contains
       !$omp parallel &
       !$omp private ( Qq,I,nm )
       !$omp do
-      !$acc parallel present( qinfmap, qinffield, prcp, netprcp, cumprcp, cuminf )
+      !$acc parallel present( qinfmap, qinffield, prcp, cumprcp, cuminf )
       !$acc loop independent gang vector
       do nm = 1, np
          !
@@ -702,10 +703,6 @@ contains
             !
          endif   
          !
-         ! Compute nett precip
-         !
-         netprcp(nm) = netprcp(nm) - qinfmap(nm)
-         ! 
          if (store_cumulative_precipitation) then
             !
             ! Compute cumulative infiltration
@@ -726,7 +723,7 @@ contains
       !$omp parallel &
       !$omp private ( Qq,I,nm )       
       !$omp do       
-      !$acc parallel present( qinfmap, prcp, netprcp, cuminf, scs_rain, scs_Se, scs_P1, scs_F1, scs_S1, rain_T1, qinffield, inf_kr )
+      !$acc parallel present( qinfmap, prcp, cuminf, scs_rain, scs_Se, scs_P1, scs_F1, scs_S1, rain_T1, qinffield, inf_kr )
       !$acc loop independent gang vector
       do nm = 1, np
          !
@@ -808,10 +805,6 @@ contains
             !
          endif
          !
-         ! Compute nett precip
-         !
-         netprcp(nm) = netprcp(nm) - qinfmap(nm)
-         !
          if (store_cumulative_precipitation) then
             !
             ! Compute cumulative infiltration
@@ -822,7 +815,7 @@ contains
          !
       enddo
       !$omp end do
-      !$omp end parallel 
+      !$omp end parallel
       !$acc end parallel
       !
    elseif (inftype == 'gai') then
@@ -832,7 +825,7 @@ contains
       !$omp parallel &
       !$omp private ( nm )
       !$omp do              
-      !$acc parallel present( qinfmap, prcp, netprcp, cuminf, rain_T1,  &
+      !$acc parallel present( qinfmap, prcp, cuminf, rain_T1,  &
       !$acc                  ksfield, GA_head, GA_sigma, GA_sigma_max, GA_F, GA_Lu, inf_kr )
       !$acc loop independent gang vector
       do nm = 1, np
@@ -853,8 +846,18 @@ contains
                !
                ! Larger amounts of rainfall - Equation 4-27 from SWMM manual
                !
-               qinfmap(nm) = (ksfield(nm) * (1.0 + (GA_head(np) * GA_sigma(np)) / GA_F(nm)))
-               qinfmap(nm) = max(min(qinfmap(nm), prcp(nm)), 0.0)     ! never more than rainfall and and never negative
+               if (GA_F(nm) < 1.0e-10) then
+                  !
+                  ! No cumulative infiltration yet (first timestep) - all rainfall infiltrates
+                  !
+                  qinfmap(nm) = prcp(nm)
+                  !
+               else
+                  !
+                  qinfmap(nm) = (ksfield(nm) * (1.0 + (GA_head(nm) * GA_sigma(nm)) / GA_F(nm)))
+                  qinfmap(nm) = max(min(qinfmap(nm), prcp(nm)), 0.0)     ! never more than rainfall and never negative
+                  !
+               endif
                !
             endif
             !
@@ -891,11 +894,6 @@ contains
             endif
          endif
          ! 
-         ! Compute nett precip
-         !
-         !qinffield(nm)  = qinfmap(nm) ! Really ? Why ?
-         netprcp(nm)    = netprcp(nm) - qinfmap(nm)
-         !
          if (store_cumulative_precipitation) then
             !
             ! Compute cumulative infiltration
@@ -906,7 +904,7 @@ contains
          !
       enddo
       !$omp end do
-      !$omp end parallel       
+      !$omp end parallel
       !$acc end parallel
       !
    elseif (inftype == 'hor') then
@@ -916,7 +914,7 @@ contains
       !$omp parallel &
       !$omp private  ( nm, Qq, I, a, hh_local )
       !$omp do              
-      !$acc parallel present( qinfmap, prcp, netprcp, cuminf, cell_area_m2, cell_area, z_flags_iref, z_volume, zs, zb, rain_T1,  &
+      !$acc parallel present( qinfmap, prcp, cuminf, cell_area_m2, cell_area, z_flags_iref, z_volume, zs, zb, rain_T1,  &
       !$acc                  horton_kd, horton_fc, horton_f0 )
       !$acc loop independent gang vector
       do nm = 1, np
@@ -1012,10 +1010,6 @@ contains
             !
          endif
          !
-         ! Compute nett precip
-         !
-         netprcp(nm)    = netprcp(nm) - qinfmap(nm)
-         !
          if (store_cumulative_precipitation) then
             !
             ! Compute cumulative infiltration
@@ -1026,14 +1020,216 @@ contains
          !
       enddo
       !$omp end do
-      !$omp end parallel 
+      !$omp end parallel
       !$acc end parallel
+      !
+   elseif (inftype == 'bkt') then
+      !
+      ! Bucket model (linear reservoir)
+      !
+      call compute_bucket_drainage(dt)
       !
    endif
    !
-   call system_clock(count1, count_rate, count_max)
-   tloop = tloop + 1.0 * (count1 - count0) / count_rate
+   ! Apply the resulting infiltration-rate field to the point-source field
+   ! qsrc (m3/s). qinfmap is m/s, so multiply by cell area and subtract.
+   ! qsrc already holds this step's prcp*area contribution (from
+   ! update_meteo_forcing) plus any discharges / src-structures updates
+   ! done earlier in update_continuity.
    !
-   end subroutine   
+   !$acc parallel loop present( qsrc, qinfmap, cell_area, cell_area_m2, z_flags_iref )
+   !$omp parallel do default(shared) private(nm) schedule(static)
+   do nm = 1, np
+      !
+      if (crsgeo) then
+         qsrc(nm) = qsrc(nm) - qinfmap(nm) * cell_area_m2(nm)
+      else
+         qsrc(nm) = qsrc(nm) - qinfmap(nm) * cell_area(z_flags_iref(nm))
+      endif
+      !
+   enddo
+   !$omp end parallel do
+   !
+   end subroutine
+
+
+   subroutine initialize_bucket_model()
+   !
+   use netcdf
+   use sfincs_data
+   use sfincs_ncinput
+   !
+   implicit none
+   !
+   integer :: status, ncid, varid
+   character*256 :: varname
+   !
+   if (netcdf_infiltration) then
+      !
+      use_bucket_model = .true.
+      !
+      write(logstr,'(a)')'Info    : turning on bucket model (linear reservoir)'
+      call write_log(logstr, 0)
+      !
+      allocate(bucket_capacity(np))
+      allocate(bucket_k(np))
+      allocate(bucket_volume(np))
+      allocate(bucket_drain_rate(np))
+      allocate(bucket_loss(np))
+      allocate(bucket_runoff(np))
+      !
+      bucket_capacity   = 0.0
+      bucket_k          = 0.0
+      bucket_volume     = 0.0
+      bucket_drain_rate = 0.0
+      bucket_loss       = 0.0
+      bucket_runoff     = 0.0
+      !
+      !
+      ! Read from infiltrationfile (netcdf) - works for both regular and quadtree grids
+      !
+      varname = 'bucket_smax'
+      call read_netcdf_quadtree_to_sfincs(infiltrationfile, varname, bucket_capacity)
+      bucket_capacity = bucket_capacity / 1000.0   ! mm to m
+      !
+      varname = 'bucket_k'
+      call read_netcdf_quadtree_to_sfincs(infiltrationfile, varname, bucket_k)
+      bucket_k = bucket_k / 3600.0   ! 1/hr to 1/s
+      !
+      status = nf90_open(trim(infiltrationfile), NF90_NOWRITE, ncid)
+      if (status /= nf90_noerr) then
+         call stop_sfincs('Error ! Cannot open infiltrationfile for bucket model input !', 1)
+      endif
+      !
+      status = nf90_inq_varid(ncid, 'bucket_loss', varid)
+      if (nf90_close(ncid) /= nf90_noerr) then
+         call stop_sfincs('Error ! Cannot close infiltrationfile after checking bucket model variables !', 1)
+      endif
+      !
+      if (status /= nf90_noerr) then
+         call stop_sfincs('Error ! Bucket model requires variable bucket_loss in infiltrationfile !', 1)
+      endif
+      !
+      varname = 'bucket_loss'
+      call read_netcdf_quadtree_to_sfincs(infiltrationfile, varname, bucket_loss)
+      call write_log('Info    : read spatially-varying bucket_loss from infiltrationfile', 0)
+      !
+      write(logstr,'(a,f10.4,a)')'Info    : bucket max capacity = ', maxval(bucket_capacity) * 1000.0, ' mm'
+      call write_log(logstr, 0)
+      write(logstr,'(a,f6.3)')'Info    : bucket loss fraction = ', maxval(bucket_loss)
+      call write_log(logstr, 0)
+      !
+   else
+      !
+      ! Allocate minimal arrays for OpenACC compatibility
+      !
+      allocate(bucket_capacity(1))
+      allocate(bucket_k(1))
+      allocate(bucket_volume(1))
+      allocate(bucket_drain_rate(1))
+      allocate(bucket_loss(1))
+      allocate(bucket_runoff(1))
+      bucket_capacity   = 0.0
+      bucket_k          = 0.0
+      bucket_volume     = 0.0
+      bucket_drain_rate = 0.0
+      bucket_loss       = 0.0
+      bucket_runoff     = 0.0
+      !
+   endif
+   !
+   end subroutine
+
+
+   subroutine compute_bucket_drainage(dt)
+   !
+   ! Bucket model with loss: linear reservoir + loss fraction (HBV/wflow style)
+   !
+   ! Steps per cell:
+   !   1. P_eff = P * (1 - loss)       -- fraction lost to ET/deep percolation
+   !   2. Fill bucket with P_eff (up to Smax capacity)
+   !   3. Drain bucket: S(t+dt) = S(t)*exp(-k*dt), drainage returned as runoff
+   !   4. qinfmap = P - runoff         -- net removal from surface
+   !
+   ! In continuity: zs += prcp*dt - qinfmap*dt = bucket_runoff*dt
+   ! => Only bucket drainage reaches the surface water level
+   !
+   ! Literature: Linear reservoir (Nash, 1957), HBV soil moisture bucket (Bergstrom, 1995)
+   !
+   use sfincs_data
+   !
+   implicit none
+   !
+   real*4           :: dt
+   integer          :: nm
+   real*4           :: exp_factor
+   real*4           :: drain_vol
+   real*4           :: P_eff
+   real*4           :: available_cap
+   real*4           :: actual_inflow
+   real*4           :: precip_rate
+   !
+   !$omp parallel do private(nm, exp_factor, drain_vol, P_eff, available_cap, actual_inflow, precip_rate)
+   !$acc parallel present( kcs, prcp, qinfmap, cuminf, bucket_volume, bucket_capacity, bucket_k, &
+   !$acc                   bucket_drain_rate, bucket_loss, bucket_runoff )
+   !$acc loop independent gang vector
+   do nm = 1, np
+      !
+      if (kcs(nm) == 1 .and. bucket_k(nm) > 0.0) then
+         !
+         ! Step 1: Compute effective precipitation (after loss)
+         !
+         precip_rate = max(prcp(nm), 0.0)
+         P_eff = precip_rate * (1.0 - bucket_loss(nm))             ! m/s after loss
+         !
+         ! Step 2: Fill bucket with effective precip (up to capacity)
+         !
+         if (bucket_capacity(nm) > 0.0) then
+            available_cap = bucket_capacity(nm) - bucket_volume(nm)
+            actual_inflow = min(P_eff * dt, available_cap)          ! m
+         else
+            ! No capacity limit (Smax = 0 means infinite)
+            actual_inflow = P_eff * dt                              ! m
+         endif
+         bucket_volume(nm) = bucket_volume(nm) + actual_inflow
+         !
+         ! Step 3: Drain bucket (analytical linear reservoir)
+         ! S(t+dt) = S(t) * exp(-k*dt), drainage = S(t) - S(t+dt)
+         !
+         exp_factor = exp(-bucket_k(nm) * dt)
+         drain_vol = bucket_volume(nm) * (1.0 - exp_factor)        ! m drained this step
+         bucket_volume(nm) = bucket_volume(nm) * exp_factor
+         !
+         ! Step 4: Bucket drainage becomes runoff returned to surface
+         !
+         bucket_runoff(nm) = drain_vol / dt                         ! m/s
+         !
+         ! Step 5: Set qinfmap = loss + what entered bucket - what drained back
+         ! In continuity: zs += prcp*dt - qinfmap*dt
+         ! Water balance: qinfmap = prcp*loss + actual_inflow/dt - bucket_runoff
+         ! When bucket has room:  actual_inflow = P_eff*dt => qinfmap = prcp - bucket_runoff
+         ! When bucket is full:   actual_inflow = 0       => qinfmap can be negative (drainage > inflow)
+         !
+         qinfmap(nm) = precip_rate * bucket_loss(nm) + actual_inflow / dt - bucket_runoff(nm)
+         !
+         bucket_drain_rate(nm) = bucket_runoff(nm)
+         !
+         if (store_cumulative_precipitation) then
+            cuminf(nm) = cuminf(nm) + qinfmap(nm) * dt
+         endif
+         !
+      else
+         !
+         qinfmap(nm) = 0.0
+         bucket_drain_rate(nm) = 0.0
+         bucket_runoff(nm) = 0.0
+         !
+      endif
+      !
+   enddo
+   !$acc end parallel
+   !$omp end parallel do
+   !
+   end subroutine
 
 end module

--- a/source/src/sfincs_input.f90
+++ b/source/src/sfincs_input.f90
@@ -10,7 +10,9 @@ contains
    use sfincs_date
    use sfincs_log
    use sfincs_error
-   use sfincs_read   
+   use sfincs_read
+   use sfincs_discharges,     only: srcfile, disfile, netsrcdisfile
+   use sfincs_src_structures, only: drnfile, dkbfile
    !
    implicit none
    !
@@ -220,6 +222,8 @@ contains
    call read_char_input(500,'weirfile',weirfile,'none')
    call read_char_input(500,'manningfile',manningfile,'none')   
    call read_char_input(500,'drnfile',drnfile,'none')
+   call read_char_input(500,'dkbfile',dkbfile,'none')
+   call read_char_input(500,'urbfile',urbfile,'none')
    call read_char_input(500,'volfile',volfile,'none')
    call read_char_input(500,'vegetationfile',veggiefile,'none')
    call read_char_input(500,'vegetationtype_toml',veggietype_toml,'none')   ! companion TOML lookup table; if set, veggiefile holds only vegetation_type integers
@@ -297,6 +301,9 @@ contains
    call read_int_input(500,'storewavdir', istorewavdir, 0)
    call read_logical_input(500,'regular_output_on_mesh',use_quadtree_output,.false.)
    call read_logical_input(500, 'store_dynamic_bed_level', store_dynamic_bed_level, .false.)
+   call read_logical_input(500,'store_river_discharge',store_river_discharge,.false.)
+   call read_logical_input(500,'store_urban_drainage_discharge',store_urban_drainage_discharge,.false.)
+   call read_logical_input(500,'store_cumulative_urban_drainage',store_cumulative_urban_drainage,.false.)
    call read_logical_input(500,'snapwave_use_nearest',snapwave_use_nearest,.true.)   
    call read_int_input(500,'percentage_done',percdoneval,5)
    ! Limit to range (0,100)
@@ -722,8 +729,12 @@ contains
       !
       ! Turn off some processes not needed for bathtub flooding
       !
-      nsrc = 0
-      ndrn = 0
+      srcfile       = 'none'
+      disfile       = 'none'
+      netsrcdisfile = 'none'
+      drnfile       = 'none'
+      dkbfile       = 'none'
+      urbfile       = 'none'
       !
       meteo3d = .false.
       wind = .false.

--- a/source/src/sfincs_lib.f90
+++ b/source/src/sfincs_lib.f90
@@ -96,8 +96,8 @@ module sfincs_lib
    !
    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
    !
-   build_revision = "$Rev: v2.4.0 Galibier Release"
-   build_date     = "$Date: 2026-06-11"
+   build_revision = "$Rev: v2.4.0 Galibier+"
+   build_date     = "$Date: 2026-07-13"
    !
    call write_log('', 1)
    call write_log('------------ Welcome to SFINCS ------------', 1)

--- a/source/src/sfincs_lib.f90
+++ b/source/src/sfincs_lib.f90
@@ -11,6 +11,8 @@ module sfincs_lib
    use sfincs_crosssections
    use sfincs_runup_gauges
    use sfincs_discharges
+   use sfincs_src_structures
+   use sfincs_urban_drainage
    use sfincs_meteo
    use sfincs_infiltration
    use sfincs_data
@@ -75,7 +77,7 @@ module sfincs_lib
    logical  :: update_meteo
    logical  :: update_waves
    !
-   real :: tstart, tfinish, tloopflux, tloopcont, tloopstruc, tloopbnd, tloopsrc, tloopwnd1, tloopwnd2, tloopinf, tloopoutput, tloopsnapwave, tloopwavemaker, tloopnonh
+   real :: tstart, tfinish, tloopflux, tloopcont, tloopstruc, tloopbnd, tloopwnd1, tloopwnd2, tloopoutput, tloopsnapwave, tloopwavemaker, tloopnonh
    real :: time_per_timestep
    real :: tinput
    real :: percdone,percdonenext,trun,trem
@@ -165,7 +167,13 @@ module sfincs_lib
    !
    call read_rug_file()         ! Read runup gauge file
    !
-   call read_discharges()       ! Reads dis and src file
+   call initialize_infiltration()     ! Reads qinf / scs / gai / horton / bucket infiltration inputs
+   !
+   call initialize_discharges()       ! Reads dis and src file (river point discharges)
+   !
+   call initialize_src_structures()   ! Reads drn file (pumps / culverts / check valves / gates)
+   !
+   call initialize_urban_drainage()   ! Reads urb file (per-zone polygon drainage + outfall)
    !
    if (nonhydrostatic) then
       !
@@ -302,10 +310,8 @@ module sfincs_lib
    tloopcont      = 0.0
    tloopstruc     = 0.0
    tloopbnd       = 0.0
-   tloopsrc       = 0.0
    tloopwnd1      = 0.0
    tloopwnd2      = 0.0
-   tloopinf       = 0.0
    tloopsnapwave  = 0.0
    tloopwavemaker = 0.0
    tloopnonh      = 0.0
@@ -529,25 +535,11 @@ module sfincs_lib
          !
          call update_meteo_forcing(t, dt, tloopwnd2)
          !
-         ! Update infiltration
-         !
-         if (infiltration) then
-             !
-             ! Compute infiltration rates
-             !
-             call update_infiltration_map(dt, tloopinf)
-             !
-         endif
-         !
-      endif   
+      endif
       !
       ! Update boundary conditions
       !
       call update_boundaries(t, dt, tloopbnd)
-      !
-      ! Update discharges
-      !
-      call update_discharges(t, dt, tloopsrc)
       !
       if (snapwave .and. update_waves) then
          !
@@ -613,9 +605,9 @@ module sfincs_lib
             !
          endif
          !      
-         ! Update water levels
+         ! Update water levels (also adds discharges, drainage structures, infiltration and urban drainage to qsrc)
          !
-         call compute_water_levels(t, dt, tloopcont)
+         call update_continuity(t, dt, tloopcont)
          !
       endif   
       !
@@ -720,11 +712,6 @@ module sfincs_lib
       call write_log(logstr, 1)
    endif   
    !
-   if (nsrc>0 .or. ndrn>0) then
-      write(logstr,'(a,f10.3,a,f5.1,a)') ' Time in discharges     : ', tloopsrc, ' (', 100 * tloopsrc / (tfinish_all - tstart_all), '%)'
-      call write_log(logstr, 1)
-   endif   
-   !
    if (meteo3d)  then
       write(logstr,'(a,f10.3,a,f5.1,a)') ' Time in meteo fields   : ', tloopwnd1, ' (', 100 * tloopwnd1 / (tfinish_all - tstart_all), '%)'
       call write_log(logstr, 1)
@@ -734,11 +721,6 @@ module sfincs_lib
       write(logstr,'(a,f10.3,a,f5.1,a)') ' Time in meteo forcing  : ', tloopwnd2, ' (', 100 * tloopwnd2 / (tfinish_all - tstart_all), '%)'
       call write_log(logstr, 1)
    endif   
-   !
-   if (infiltration) then
-      write(logstr,'(a,f10.3,a,f5.1,a)') ' Time in infiltration   : ', tloopinf, ' (', 100 * tloopinf / (tfinish_all - tstart_all), '%)'
-      call write_log(logstr, 1)
-   endif
    !
    write(logstr,'(a,f10.3,a,f5.1,a)')    ' Time in momentum       : ', tloopflux, ' (', 100 * tloopflux / (tfinish_all - tstart_all), '%)'
    call write_log(logstr, 1)
@@ -787,10 +769,8 @@ module sfincs_lib
       write(123,'(f10.3,a)')tfinish_all - tstart_all,' % total'
       write(123,'(f10.3,a)')tinput,' % input'
       write(123,'(f10.3,a)')tloopbnd,' % boundaries'
-      write(123,'(f10.3,a)')tloopsrc,' % discharges'
       write(123,'(f10.3,a)')tloopwnd1,' % meteo1'
       write(123,'(f10.3,a)')tloopwnd2,' % meteo2'
-      write(123,'(f10.3,a)')tloopinf,' % infiltration'
       write(123,'(f10.3,a)')tloopflux,' % momentum'
       write(123,'(f10.3,a)')tloopstruc,' % structures'
       write(123,'(f10.3,a)')tloopcont,' % continuity'

--- a/source/src/sfincs_log.f90
+++ b/source/src/sfincs_log.f90
@@ -37,4 +37,41 @@ contains
    !
    end subroutine
 
+   function fmt_real(val, decimals) result(s)
+      !
+      ! Format a real with minimum width and a guaranteed leading zero
+      ! for |val| < 1. ifx's "f0.d" descriptor drops the leading zero in
+      ! that range, which is not standard-conforming; this helper rewrites
+      ! the result so the log output always reads "0.6670" rather than
+      ! ".6670".
+      !
+      ! Called from: write_src_structures_log_summary (sfincs_src_structures),
+      ! urban_drainage log summary (sfincs_urban_drainage), and anywhere
+      ! else a real needs to be embedded in a log line with the smallest
+      ! reasonable field width.
+      !
+      implicit none
+      !
+      real,    intent(in) :: val
+      integer, intent(in) :: decimals
+      character(len=32)   :: s
+      !
+      character(len=16)   :: fmt
+      !
+      write(fmt,'(a,i0,a)') '(f0.', decimals, ')'
+      write(s,fmt) val
+      s = adjustl(s)
+      !
+      if (s(1:1) == '.') then
+         !
+         s = '0' // s(1:len_trim(s))
+         !
+      else if (s(1:2) == '-.') then
+         !
+         s = '-0' // trim(s(2:))
+         !
+      endif
+      !
+   end function fmt_real
+
 end module

--- a/source/src/sfincs_meteo.f90
+++ b/source/src/sfincs_meteo.f90
@@ -1237,20 +1237,20 @@ contains
    use sfincs_data
    !
    implicit none
-   !   
-   integer  :: count0
-   integer  :: count1
-   integer  :: count_rate
-   integer  :: count_max
-   real     :: tloop
    !
    real*8                           :: t
    real*4                           :: dt
+   real                             :: tloop
    real*4                           :: twfact
    real*4                           :: onemintwfact
    real*4                           :: smfac
    real*4                           :: oneminsmfac
    integer                          :: nm, ib
+   !
+   integer                          :: count0
+   integer                          :: count1
+   integer                          :: count_rate
+   integer                          :: count_max
    !
    call system_clock(count0, count_rate, count_max)
    !
@@ -1265,7 +1265,7 @@ contains
       !$acc parallel, present( tauwu, tauwv,  tauwu0, tauwv0, tauwu1, tauwv1, &
       !$acc                    windu, windv, windu0, windv0, windu1, windv1, windmax, &
       !$acc                    patm, patm0, patm1, &
-      !$acc                    prcp, prcp0, prcp1, cumprcp, netprcp, &
+      !$acc                    prcp, prcp0, prcp1, cumprcp, &
       !$acc                    zs, zb, z_volume )
       !$acc loop independent gang vector
       do nm = 1, np
@@ -1341,40 +1341,38 @@ contains
          !$omp parallel &
          !$omp private ( nm )
          !$omp do
-         !$acc parallel, present( tauwu, tauwv, patm, prcp, netprcp, zs, zb, z_volume )
-         !$acc loop independent gang vector
+         !$acc parallel, present( tauwu, tauwv, patm, prcp, zs, zb, z_volume )
+         !$acc loop gang vector
          do nm = 1, np
             !
             if (wind) then
                tauwu(nm) = tauwu(nm) * smfac
                tauwv(nm) = tauwv(nm) * smfac
-            endif   
+            endif
             !
             if (patmos) then
                patm(nm)  = patm(nm) * smfac + gapres * oneminsmfac
             endif   
             !
             if (precip) then
-               !  
-               netprcp(nm) = netprcp(nm) * smfac
-               !  
-               ! Don't allow negative netprcp during spinup (e.g. hardfixing infiltration/evaporation on model when forcing effective rainfall) when there's no water in the cell (same as check for constant infiltration)
-               !  
-               if (netprcp(nm) < 0.0) then
-                  !  
-                  ! No effective infiltration if there is no water
-                  !  
+               !
+               prcp(nm) = prcp(nm) * smfac
+               !
+               ! Don't allow negative precip during spinup when there's no water in the cell
+               !
+               if (prcp(nm) < 0.0) then
+                  !
                   if (subgrid) then
                      if (z_volume(nm) <= 0.0) then
-                        netprcp(nm) = 0.0
+                        prcp(nm) = 0.0
                      endif
                   else
                      if (zs(nm) <= zb(nm)) then
-                        netprcp(nm) = 0.0
+                        prcp(nm) = 0.0
                      endif
-                  endif            
-                  !  
-               endif               
+                  endif
+                  !
+               endif
             endif   
             !
          enddo   
@@ -1419,13 +1417,35 @@ contains
    !
    if (prcpfile(1:4) /= 'none') then
       !
-      call update_precipitation_from_timeseries(t, dt) 
+      call update_precipitation_from_timeseries(t, dt)
+      !
+   endif
+   !
+   ! Apply rainfall to the point-source field qsrc (m3/s). prcp is m/s,
+   ! so multiply by cell area. qsrc was zeroed at the end of the previous
+   ! step inside the water-level update loops, so this is the first
+   ! accumulation into qsrc for the current step.
+   !
+   if (precip) then
+      !
+      !$acc parallel loop present( qsrc, prcp, cell_area, cell_area_m2, z_flags_iref )
+      !$omp parallel do default(shared) private(nm) schedule(static)
+      do nm = 1, np
+         !
+         if (crsgeo) then
+            qsrc(nm) = qsrc(nm) + prcp(nm) * cell_area_m2(nm)
+         else
+            qsrc(nm) = qsrc(nm) + prcp(nm) * cell_area(z_flags_iref(nm))
+         endif
+         !
+      enddo
+      !$omp end parallel do
       !
    endif
    !
    call system_clock(count1, count_rate, count_max)
-   tloop = tloop + 1.0 * (count1 - count0) / count_rate
-   !         
+   tloop = tloop + 1.0*(count1 - count0)/count_rate
+   !
    end subroutine
 
 
@@ -1524,12 +1544,11 @@ contains
    !$omp parallel &
    !$omp private ( nm )
    !$omp do
-   !$acc parallel present( prcp, cumprcp, netprcp )
-   !$acc loop independent gang vector
+   !$acc parallel present( prcp, cumprcp )
+   !$acc loop gang vector
    do nm = 1, np
       !
       prcp(nm)    = ptmp
-      netprcp(nm) = ptmp
       !
       if (store_cumulative_precipitation) then
          cumprcp(nm) = cumprcp(nm) + ptmp * dt
@@ -1553,15 +1572,15 @@ contains
    !
    implicit none
    !
+   integer  :: nm
+   !
+   real*8   :: t
+   real     :: tloop
+   !
    integer  :: count0
    integer  :: count1
    integer  :: count_rate
    integer  :: count_max
-   real     :: tloop
-   !
-   integer  :: nm
-   !
-   real*8   :: t
    !
    call system_clock(count0, count_rate, count_max)
    !
@@ -1607,7 +1626,7 @@ contains
    !
    call system_clock(count1, count_rate, count_max)
    tloop = tloop + 1.0*(count1 - count0)/count_rate
-   !         
-   end subroutine   
+   !
+   end subroutine
 
 end module

--- a/source/src/sfincs_ncinput.F90
+++ b/source/src/sfincs_ncinput.F90
@@ -170,13 +170,21 @@ module sfincs_ncinput
 
    
    
-   subroutine read_netcdf_discharge_data()
+   subroutine read_netcdf_discharge_data(netsrcdisfile, nr_discharge_points)
    !
-   use sfincs_date   
+   ! Read FEWS-compatible netCDF river-discharge input. netsrcdisfile is
+   ! passed in rather than pulled from a module to avoid a circular
+   ! dependency (the owning module sfincs_discharges `use`s this module
+   ! for the procedure).
+   !
+   use sfincs_date
    use netcdf
-   use sfincs_data   
+   use sfincs_data
    !
-   implicit none   
+   implicit none
+   !
+   character(len=*), intent(in)  :: netsrcdisfile
+   integer,          intent(out) :: nr_discharge_points
    !
    ! Variable names for Fews compatible netcdf input
    !
@@ -206,7 +214,7 @@ module sfincs_ncinput
    !
    ! Get dimensions sizes: time, stations      
    NF90(nf90_inquire_dimension(net_file_srcdis%ncid, net_file_srcdis%time_dimid,   len = ntsrc))   !nr of timesteps in file
-   NF90(nf90_inquire_dimension(net_file_srcdis%ncid, net_file_srcdis%points_dimid, len = nsrc))  !nr of discharge points     
+   NF90(nf90_inquire_dimension(net_file_srcdis%ncid, net_file_srcdis%points_dimid, len = nr_discharge_points))  !nr of discharge points
    !
    ! Get variable id's
    NF90(nf90_inq_varid(net_file_srcdis%ncid, x_varname,    net_file_srcdis%x_varid) )  ! Has to be in the same UTM zone as SFINCS grid
@@ -215,16 +223,16 @@ module sfincs_ncinput
    NF90(nf90_inq_varid(net_file_srcdis%ncid, q_varname,    net_file_srcdis%q_varid) )    
    !
    ! Allocate variables   
-   allocate(xsrc(nsrc))
-   allocate(ysrc(nsrc)) 
+   allocate(xsrc(nr_discharge_points))
+   allocate(ysrc(nr_discharge_points))
    allocate(tsrc(ntsrc))
-   allocate(qsrc(nsrc,ntsrc))
+   allocate(qsrc_ts(nr_discharge_points,ntsrc))
    !
    ! Read values
    NF90(nf90_get_var(net_file_srcdis%ncid, net_file_srcdis%x_varid,    xsrc(:)) )
    NF90(nf90_get_var(net_file_srcdis%ncid, net_file_srcdis%y_varid,    ysrc(:)) )
-   NF90(nf90_get_var(net_file_srcdis%ncid, net_file_srcdis%time_varid, tsrc(:)) ) 
-   NF90(nf90_get_var(net_file_srcdis%ncid, net_file_srcdis%q_varid,    qsrc(:,:)) )   
+   NF90(nf90_get_var(net_file_srcdis%ncid, net_file_srcdis%time_varid, tsrc(:)) )
+   NF90(nf90_get_var(net_file_srcdis%ncid, net_file_srcdis%q_varid,    qsrc_ts(:,:)) )
    !   
    ! Read time attibute
    !

--- a/source/src/sfincs_ncoutput.F90
+++ b/source/src/sfincs_ncoutput.F90
@@ -18,6 +18,7 @@ module sfincs_ncoutput
       integer :: zs_varid, zsmax_varid, h_varid, u_varid, v_varid, tmax_varid, Seff_varid, t_zsmax_varid
       integer :: zvolume_varid, storagevolume_varid
       integer :: hmax_varid, vmax_varid, qmax_varid, cumprcp_varid, cuminf_varid, windmax_varid
+      integer :: cumulative_urbdrain_varid
       integer :: patm_varid, wind_u_varid, wind_v_varid, precip_varid        
       integer :: hm0_varid, hm0ig_varid, snapwavemsk_varid, tp_varid, tpig_varid, wavdir_varid, dirspr_varid
       integer :: fwx_varid, fwy_varid, beta_varid, snapwavedepth_varid
@@ -45,14 +46,17 @@ module sfincs_ncoutput
       integer :: ncid   
       integer :: time_dimid 
       integer :: points_dimid, pointnamelength_dimid
-      integer :: crosssections_dimid, structures_dimid, thindams_dimid, drain_dimid, runup_gauges_dimid
+      integer :: crosssections_dimid, structures_dimid, thindams_dimid, drain_dimid, runup_gauges_dimid, river_dimid
+      integer :: urbdrain_dimid
       integer :: runtime_dimid
       integer :: point_x_varid, point_y_varid, station_x_varid, station_y_varid, crs_varid, qinf_varid, S_varid  
       integer :: station_id_varid, station_name_varid
       integer :: crosssection_name_varid
       integer :: structure_height_varid, structure_x_varid, structure_y_varid
       integer :: thindam_x_varid, thindam_y_varid      
-      integer :: drain_varid, drain_name_varid
+      integer :: drain_varid, drain_name_varid, breach_width_varid, drain_fraction_open_varid
+      integer :: river_varid, river_name_varid
+      integer :: urbdrain_varid, urbdrain_name_varid
       integer :: zb_varid
       integer :: time_varid
       integer :: zs_varid, h_varid, u_varid, v_varid, prcp_varid, cumprcp_varid, discharge_varid, uvmag_varid, uvdir_varid
@@ -218,12 +222,16 @@ contains
            NF90(nf90_put_att(map_file%ncid, map_file%qinf_varid, 'long_name', 'suction head at the wetting front - Green and Ampt')) 
            NF90(nf90_put_att(map_file%ncid, map_file%qinf_varid, 'units', 'm'))
        elseif (inftype == 'hor') then
-           NF90(nf90_put_att(map_file%ncid, map_file%qinf_varid, 'standard_name', 'f0')) 
-           NF90(nf90_put_att(map_file%ncid, map_file%qinf_varid, 'long_name', 'initial infiltration rate - Horton')) 
+           NF90(nf90_put_att(map_file%ncid, map_file%qinf_varid, 'standard_name', 'f0'))
+           NF90(nf90_put_att(map_file%ncid, map_file%qinf_varid, 'long_name', 'initial infiltration rate - Horton'))
            NF90(nf90_put_att(map_file%ncid, map_file%qinf_varid, 'units', 'm'))
+       elseif (inftype == 'bkt') then
+           NF90(nf90_put_att(map_file%ncid, map_file%qinf_varid, 'standard_name', 'bucket_capacity'))
+           NF90(nf90_put_att(map_file%ncid, map_file%qinf_varid, 'long_name', 'maximum bucket storage capacity'))
+           NF90(nf90_put_att(map_file%ncid, map_file%qinf_varid, 'units', 'mm'))
        else
-           NF90(nf90_put_att(map_file%ncid, map_file%qinf_varid, 'standard_name', 'qinf')) 
-           NF90(nf90_put_att(map_file%ncid, map_file%qinf_varid, 'long_name', 'infiltration rate - constant in time')) 
+           NF90(nf90_put_att(map_file%ncid, map_file%qinf_varid, 'standard_name', 'qinf'))
+           NF90(nf90_put_att(map_file%ncid, map_file%qinf_varid, 'long_name', 'infiltration rate - constant in time'))
            NF90(nf90_put_att(map_file%ncid, map_file%qinf_varid, 'units', 'mm h-1'))
        endif
    endif
@@ -374,14 +382,25 @@ contains
       NF90(nf90_put_att(map_file%ncid, map_file%Seff_varid, 'coordinates', 'corner_x corner_y'))
    endif
    !
-   ! Store current infiltration (only for Horton)
+   ! Store current infiltration capacity (only for Horton)
    !
    if (inftype == 'hor') then
-      NF90(nf90_def_var(map_file%ncid, 'f', NF90_FLOAT, (/map_file%m_dimid, map_file%n_dimid, map_file%time_dimid/), map_file%Seff_varid)) ! time-varying sigma
-      NF90(nf90_put_att(map_file%ncid, map_file%Seff_varid, '_FillValue', FILL_VALUE))   
+      NF90(nf90_def_var(map_file%ncid, 'f', NF90_FLOAT, (/map_file%m_dimid, map_file%n_dimid, map_file%time_dimid/), map_file%Seff_varid)) ! time-varying f
+      NF90(nf90_put_att(map_file%ncid, map_file%Seff_varid, '_FillValue', FILL_VALUE))
       NF90(nf90_put_att(map_file%ncid, map_file%Seff_varid, 'units', 'mm h-1'))
-      NF90(nf90_put_att(map_file%ncid, map_file%Seff_varid, 'standard_name', 'sigma')) 
-      NF90(nf90_put_att(map_file%ncid, map_file%Seff_varid, 'long_name', 'current infiltration capacity'))     
+      NF90(nf90_put_att(map_file%ncid, map_file%Seff_varid, 'standard_name', 'f'))
+      NF90(nf90_put_att(map_file%ncid, map_file%Seff_varid, 'long_name', 'current infiltration capacity'))
+      NF90(nf90_put_att(map_file%ncid, map_file%Seff_varid, 'coordinates', 'corner_x corner_y'))
+   endif
+   !
+   ! Store current bucket storage (only for Bucket model)
+   !
+   if (inftype == 'bkt') then
+      NF90(nf90_def_var(map_file%ncid, 'bucket_volume', NF90_FLOAT, (/map_file%m_dimid, map_file%n_dimid, map_file%time_dimid/), map_file%Seff_varid)) ! time-varying bucket volume
+      NF90(nf90_put_att(map_file%ncid, map_file%Seff_varid, '_FillValue', FILL_VALUE))
+      NF90(nf90_put_att(map_file%ncid, map_file%Seff_varid, 'units', 'm'))
+      NF90(nf90_put_att(map_file%ncid, map_file%Seff_varid, 'standard_name', 'bucket_volume'))
+      NF90(nf90_put_att(map_file%ncid, map_file%Seff_varid, 'long_name', 'current bucket storage'))
       NF90(nf90_put_att(map_file%ncid, map_file%Seff_varid, 'coordinates', 'corner_x corner_y'))
    endif
    !
@@ -407,12 +426,22 @@ contains
    if (store_cumulative_precipitation) then
       NF90(nf90_def_var(map_file%ncid, 'cumprcp', NF90_FLOAT, (/map_file%m_dimid, map_file%n_dimid, map_file%timemax_dimid/), map_file%cumprcp_varid)) ! time-varying maximum water level map
       NF90(nf90_def_var_deflate(map_file%ncid, map_file%cumprcp_varid, 1, 1, nc_deflate_level)) ! deflate
-      NF90(nf90_put_att(map_file%ncid, map_file%cumprcp_varid, '_FillValue', FILL_VALUE))          
+      NF90(nf90_put_att(map_file%ncid, map_file%cumprcp_varid, '_FillValue', FILL_VALUE))
       NF90(nf90_put_att(map_file%ncid, map_file%cumprcp_varid, 'units', 'm'))
       NF90(nf90_put_att(map_file%ncid, map_file%cumprcp_varid, 'long_name', 'cumulative_precipitation_depth')) 
       NF90(nf90_put_att(map_file%ncid, map_file%cumprcp_varid, 'standard_name', 'Cumulative precipitation depth')) 
       NF90(nf90_put_att(map_file%ncid, map_file%cumprcp_varid, 'cell_methods', 'time: sum'))       
       NF90(nf90_put_att(map_file%ncid, map_file%cumprcp_varid, 'coordinates', 'x y'))
+   endif
+   !
+   if (store_cumulative_urban_drainage .and. urban_drainage) then
+      NF90(nf90_def_var(map_file%ncid, 'urban_drainage_cumulative_depth', NF90_FLOAT, (/map_file%m_dimid, map_file%n_dimid, map_file%timemax_dimid/), map_file%cumulative_urbdrain_varid))
+      NF90(nf90_def_var_deflate(map_file%ncid, map_file%cumulative_urbdrain_varid, 1, 1, nc_deflate_level))
+      NF90(nf90_put_att(map_file%ncid, map_file%cumulative_urbdrain_varid, '_FillValue', FILL_VALUE))
+      NF90(nf90_put_att(map_file%ncid, map_file%cumulative_urbdrain_varid, 'units', 'm'))
+      NF90(nf90_put_att(map_file%ncid, map_file%cumulative_urbdrain_varid, 'long_name', 'cumulative_urban_drainage_depth'))
+      NF90(nf90_put_att(map_file%ncid, map_file%cumulative_urbdrain_varid, 'cell_methods', 'time: sum'))
+      NF90(nf90_put_att(map_file%ncid, map_file%cumulative_urbdrain_varid, 'coordinates', 'x y'))
    endif
    !
    if (store_twet) then
@@ -830,9 +859,9 @@ contains
    !
    ! Write infiltration map
    !
-   if (infiltration) then
+   if (infiltration .and. allocated(qinffield)) then
       !
-      zsg = FILL_VALUE       
+      zsg = FILL_VALUE
       !
       do nm = 1, np
          !
@@ -848,10 +877,26 @@ contains
             zsg(m, n) = qinffield(nm)
             !
          endif
-         ! 
+         !
       enddo
       !
       NF90(nf90_put_var(map_file%ncid, map_file%qinf_varid, zsg, (/1, 1/))) ! write infiltration map
+      !
+   endif
+   !
+   ! Write bucket capacity map (static)
+   !
+   if (inftype == 'bkt' .and. allocated(bucket_capacity)) then
+      !
+      zsg = FILL_VALUE
+      !
+      do nm = 1, np
+         n    = z_index_z_n(nm)
+         m    = z_index_z_m(nm)
+         zsg(m, n) = bucket_capacity(nm) * 1000.0 ! m to mm
+      enddo
+      !
+      NF90(nf90_put_var(map_file%ncid, map_file%qinf_varid, zsg, (/1, 1/))) ! write bucket capacity map
       !
    endif
    !
@@ -1320,10 +1365,21 @@ contains
       !
       NF90(nf90_def_var(map_file%ncid, 'cuminf', NF90_FLOAT, (/map_file%nmesh2d_face_dimid, map_file%timemax_dimid/), map_file%cuminf_varid)) ! cumulative infiltration map
       NF90(nf90_def_var_deflate(map_file%ncid, map_file%cuminf_varid, 1, 1, nc_deflate_level))
-      NF90(nf90_put_att(map_file%ncid, map_file%cuminf_varid, '_FillValue', FILL_VALUE))          
+      NF90(nf90_put_att(map_file%ncid, map_file%cuminf_varid, '_FillValue', FILL_VALUE))
       NF90(nf90_put_att(map_file%ncid, map_file%cuminf_varid, 'units', 'm'))
       NF90(nf90_put_att(map_file%ncid, map_file%cuminf_varid, 'long_name', 'Cumulative infiltration depth')) 
       NF90(nf90_put_att(map_file%ncid, map_file%cuminf_varid, 'cell_methods', 'time: sum'))     
+      !
+   endif
+   !
+   if (store_cumulative_urban_drainage .and. urban_drainage) then
+      !
+      NF90(nf90_def_var(map_file%ncid, 'urban_drainage_cumulative_depth', NF90_FLOAT, (/map_file%nmesh2d_face_dimid, map_file%timemax_dimid/), map_file%cumulative_urbdrain_varid))
+      NF90(nf90_def_var_deflate(map_file%ncid, map_file%cumulative_urbdrain_varid, 1, 1, nc_deflate_level))
+      NF90(nf90_put_att(map_file%ncid, map_file%cumulative_urbdrain_varid, '_FillValue', FILL_VALUE))
+      NF90(nf90_put_att(map_file%ncid, map_file%cumulative_urbdrain_varid, 'units', 'm'))
+      NF90(nf90_put_att(map_file%ncid, map_file%cumulative_urbdrain_varid, 'long_name', 'cumulative_urban_drainage_depth'))
+      NF90(nf90_put_att(map_file%ncid, map_file%cumulative_urbdrain_varid, 'cell_methods', 'time: sum'))
       !
    endif
    !
@@ -1498,12 +1554,16 @@ contains
            NF90(nf90_put_att(map_file%ncid, map_file%qinf_varid, 'long_name', 'suction head at the wetting front - Green and Ampt')) 
            NF90(nf90_put_att(map_file%ncid, map_file%qinf_varid, 'units', 'm'))
        elseif (inftype == 'hor') then
-           NF90(nf90_put_att(map_file%ncid, map_file%qinf_varid, 'standard_name', 'f0')) 
-           NF90(nf90_put_att(map_file%ncid, map_file%qinf_varid, 'long_name', 'initial infiltration rate - Horton')) 
+           NF90(nf90_put_att(map_file%ncid, map_file%qinf_varid, 'standard_name', 'f0'))
+           NF90(nf90_put_att(map_file%ncid, map_file%qinf_varid, 'long_name', 'initial infiltration rate - Horton'))
            NF90(nf90_put_att(map_file%ncid, map_file%qinf_varid, 'units', 'mm h-1'))
+       elseif (inftype == 'bkt') then
+           NF90(nf90_put_att(map_file%ncid, map_file%qinf_varid, 'standard_name', 'bucket_capacity'))
+           NF90(nf90_put_att(map_file%ncid, map_file%qinf_varid, 'long_name', 'maximum bucket storage capacity'))
+           NF90(nf90_put_att(map_file%ncid, map_file%qinf_varid, 'units', 'mm'))
        else
-           NF90(nf90_put_att(map_file%ncid, map_file%qinf_varid, 'standard_name', 'qinf')) 
-           NF90(nf90_put_att(map_file%ncid, map_file%qinf_varid, 'long_name', 'infiltration rate - constant in time')) 
+           NF90(nf90_put_att(map_file%ncid, map_file%qinf_varid, 'standard_name', 'qinf'))
+           NF90(nf90_put_att(map_file%ncid, map_file%qinf_varid, 'long_name', 'infiltration rate - constant in time'))
            NF90(nf90_put_att(map_file%ncid, map_file%qinf_varid, 'units', 'mm h-1'))
        endif
    endif
@@ -1682,7 +1742,7 @@ contains
    !   
    vtmp = FILL_VALUE
    !
-   if (infiltration) then
+   if (infiltration .and. allocated(qinffield)) then
       !
       if (inftype == 'con' .or. inftype == 'c2d') then
          do nmq = 1, quadtree_nr_points
@@ -1690,17 +1750,34 @@ contains
             if (nm>0) then
                vtmp(nmq) = qinffield(nm) * 3600 * 1000
             endif
-         enddo 
+         enddo
       else
          do nmq = 1, quadtree_nr_points
             nm = index_sfincs_in_quadtree(nmq)
             if (nm>0) then
                vtmp(nmq) = qinffield(nm)
             endif
-         enddo 
+         enddo
       endif
       !
       NF90(nf90_put_var(map_file%ncid, map_file%qinf_varid, vtmp)) ! write infiltration map
+      !
+   endif
+   !
+   ! Write bucket capacity map (static)
+   !
+   if (inftype == 'bkt' .and. allocated(bucket_capacity)) then
+      !
+      vtmp = FILL_VALUE
+      !
+      do nmq = 1, quadtree_nr_points
+         nm = index_sfincs_in_quadtree(nmq)
+         if (nm>0) then
+            vtmp(nmq) = bucket_capacity(nm) * 1000.0 ! m to mm
+         endif
+      enddo
+      !
+      NF90(nf90_put_var(map_file%ncid, map_file%qinf_varid, vtmp)) ! write bucket capacity map
       !
    endif
    !
@@ -1771,13 +1848,16 @@ contains
    ! 2. write grid/msk/zb to file
    !
    use sfincs_date
-   use sfincs_data   
+   use sfincs_data
    use sfincs_structures
+   use sfincs_src_structures, only: nr_src_structures, src_struc_name, src_struc_type, structure_dike_breach
+   use sfincs_discharges,     only: src_name, nr_discharge_points
+   use sfincs_urban_drainage, only: nr_urban_drainage_zones, urb_zone_name
    !
-   implicit none   
+   implicit none
    !
-   integer                      :: istruc   
-   !  
+   integer                      :: istruc
+   !
    real*4, dimension(:,:), allocatable :: struc_info
    real*4, dimension(:), allocatable :: struc_x
    real*4, dimension(:), allocatable :: struc_y
@@ -1785,9 +1865,13 @@ contains
    !
    real*4, dimension(:,:), allocatable :: thindam_info
    real*4, dimension(:), allocatable :: thindam_x
-   real*4, dimension(:), allocatable :: thindam_y   
+   real*4, dimension(:), allocatable :: thindam_y
    !
-   if (nobs==0 .and. nrcrosssections==0 .and. nrstructures==0 .and. ndrn==0 .and. nr_runup_gauges==0) then ! If no observation points, cross-sections, structures, drains or run-up gauges; his file is not created        
+   character*256, dimension(:), allocatable :: drain_name_buf
+   character*256, dimension(:), allocatable :: river_name_buf
+   character*256, dimension(:), allocatable :: urbdrain_name_buf
+   !
+   if (nobs==0 .and. nrcrosssections==0 .and. nrstructures==0 .and. nr_src_structures==0 .and. .not. (nr_discharge_points>0 .and. store_river_discharge) .and. .not. (nr_urban_drainage_zones>0 .and. store_urban_drainage_discharge) .and. nr_runup_gauges==0) then ! If no observation points, cross-sections, structures, drains, river sources, urban drainage zones or run-up gauges; his file is not created
       return
    endif
    !
@@ -1807,11 +1891,19 @@ contains
       NF90(nf90_def_dim(his_file%ncid, 'crosssections', nrcrosssections, his_file%crosssections_dimid)) ! nr of crosssections
    endif
    !
-   if (ndrn>0) then   
-      NF90(nf90_def_dim(his_file%ncid, 'drainage', ndrn, his_file%drain_dimid)) ! nr of drainage structures
+   if (nr_src_structures>0) then
+      NF90(nf90_def_dim(his_file%ncid, 'drainage', nr_src_structures, his_file%drain_dimid)) ! nr of drainage structures
    endif
    !
-   if (nrstructures>0) then   
+   if (nr_discharge_points>0 .and. store_river_discharge) then
+      NF90(nf90_def_dim(his_file%ncid, 'rivers', nr_discharge_points, his_file%river_dimid)) ! nr of river point sources
+   endif
+   !
+   if (nr_urban_drainage_zones > 0 .and. store_urban_drainage_discharge) then
+      NF90(nf90_def_dim(his_file%ncid, 'urban_drainage_zones', nr_urban_drainage_zones, his_file%urbdrain_dimid)) ! nr of urban drainage zones
+   endif
+   !
+   if (nrstructures>0) then
       NF90(nf90_def_dim(his_file%ncid, 'structures', nrstructures, his_file%structures_dimid)) ! nr of structures (weir)
    endif   
    !
@@ -1852,9 +1944,21 @@ contains
    !
    if (nr_runup_gauges > 0) then
       NF90(nf90_def_var(his_file%ncid, 'runup_gauge_name', NF90_CHAR, (/his_file%pointnamelength_dimid, his_file%runup_gauges_dimid/), his_file%runup_gauge_name_varid))
-   endif      
+   endif
    !
-   !NF90(nf90_put_att(his_file%ncid, his_file%station_name_varid, 'units', '-')) !not wanted in fews   
+   if (nr_src_structures > 0) then
+      NF90(nf90_def_var(his_file%ncid, 'drainage_name', NF90_CHAR, (/his_file%pointnamelength_dimid, his_file%drain_dimid/), his_file%drain_name_varid))
+   endif
+   !
+   if (nr_discharge_points > 0 .and. store_river_discharge) then
+      NF90(nf90_def_var(his_file%ncid, 'river_name', NF90_CHAR, (/his_file%pointnamelength_dimid, his_file%river_dimid/), his_file%river_name_varid))
+   endif
+   !
+   if (nr_urban_drainage_zones > 0 .and. store_urban_drainage_discharge) then
+      NF90(nf90_def_var(his_file%ncid, 'urban_drainage_zone_name', NF90_CHAR, (/his_file%pointnamelength_dimid, his_file%urbdrain_dimid/), his_file%urbdrain_name_varid))
+   endif
+   !
+   !NF90(nf90_put_att(his_file%ncid, his_file%station_name_varid, 'units', '-')) !not wanted in fews
    !
    ! Domain
    NF90(nf90_def_var(his_file%ncid, 'station_x', NF90_FLOAT, (/his_file%points_dimid/), his_file%station_x_varid))   ! non snapped input coordinate 
@@ -2017,9 +2121,29 @@ contains
    !
    if (inftype == 'gai') then
       NF90(nf90_def_var(his_file%ncid, 'point_S', NF90_FLOAT, (/his_file%points_dimid, his_file%time_dimid/), his_file%S_varid)) ! time-varying S
-      NF90(nf90_put_att(his_file%ncid, his_file%S_varid, '_FillValue', FILL_VALUE))   
+      NF90(nf90_put_att(his_file%ncid, his_file%S_varid, '_FillValue', FILL_VALUE))
       NF90(nf90_put_att(his_file%ncid, his_file%S_varid, 'units', 'm'))
-      NF90(nf90_put_att(his_file%ncid, his_file%S_varid, 'long_name', 'maximum soil moisture deficit')) 
+      NF90(nf90_put_att(his_file%ncid, his_file%S_varid, 'long_name', 'maximum soil moisture deficit'))
+      NF90(nf90_put_att(his_file%ncid, his_file%S_varid, 'coordinates', 'station_id station_name point_x point_y'))
+   endif
+   !
+   ! More output for Horton method
+   !
+   if (inftype == 'hor') then
+      NF90(nf90_def_var(his_file%ncid, 'point_S', NF90_FLOAT, (/his_file%points_dimid, his_file%time_dimid/), his_file%S_varid)) ! time-varying f
+      NF90(nf90_put_att(his_file%ncid, his_file%S_varid, '_FillValue', FILL_VALUE))
+      NF90(nf90_put_att(his_file%ncid, his_file%S_varid, 'units', 'mm hr-1'))
+      NF90(nf90_put_att(his_file%ncid, his_file%S_varid, 'long_name', 'current infiltration capacity'))
+      NF90(nf90_put_att(his_file%ncid, his_file%S_varid, 'coordinates', 'station_id station_name point_x point_y'))
+   endif
+   !
+   ! More output for Bucket model
+   !
+   if (inftype == 'bkt') then
+      NF90(nf90_def_var(his_file%ncid, 'point_S', NF90_FLOAT, (/his_file%points_dimid, his_file%time_dimid/), his_file%S_varid)) ! time-varying bucket volume
+      NF90(nf90_put_att(his_file%ncid, his_file%S_varid, '_FillValue', FILL_VALUE))
+      NF90(nf90_put_att(his_file%ncid, his_file%S_varid, 'units', 'm'))
+      NF90(nf90_put_att(his_file%ncid, his_file%S_varid, 'long_name', 'current bucket storage'))
       NF90(nf90_put_att(his_file%ncid, his_file%S_varid, 'coordinates', 'station_id station_name point_x point_y'))
    endif
    !
@@ -2203,15 +2327,49 @@ contains
       !
    endif
    !   
-   if (ndrn>0) then
+   if (nr_src_structures>0) then
       !
       NF90(nf90_def_var(his_file%ncid, 'drainage_discharge', NF90_FLOAT, (/his_file%drain_dimid, his_file%time_dimid/), his_file%drain_varid)) ! time-varying discharge through drainage structure
-      NF90(nf90_put_att(his_file%ncid, his_file%drain_varid, '_FillValue', FILL_VALUE))   
+      NF90(nf90_put_att(his_file%ncid, his_file%drain_varid, '_FillValue', FILL_VALUE))
       NF90(nf90_put_att(his_file%ncid, his_file%drain_varid, 'units', 'm3 s-1'))
       NF90(nf90_put_att(his_file%ncid, his_file%drain_varid, 'long_name', 'discharge through drainage structure'))
       NF90(nf90_put_att(his_file%ncid, his_file%drain_varid, 'coordinates', 'drainage_name'))
       !
-   endif   
+      if (any(src_struc_type == structure_dike_breach)) then
+         NF90(nf90_def_var(his_file%ncid, 'breach_width', NF90_FLOAT, (/his_file%drain_dimid, his_file%time_dimid/), his_file%breach_width_varid))
+         NF90(nf90_put_att(his_file%ncid, his_file%breach_width_varid, '_FillValue', FILL_VALUE))
+         NF90(nf90_put_att(his_file%ncid, his_file%breach_width_varid, 'units', 'm'))
+         NF90(nf90_put_att(his_file%ncid, his_file%breach_width_varid, 'long_name', 'dike breach width'))
+         NF90(nf90_put_att(his_file%ncid, his_file%breach_width_varid, 'coordinates', 'drainage_name'))
+      endif
+      !
+      NF90(nf90_def_var(his_file%ncid, 'drainage_fraction_open', NF90_FLOAT, (/his_file%drain_dimid, his_file%time_dimid/), his_file%drain_fraction_open_varid)) ! time-varying gate open fraction (1=open, 0=closed)
+      NF90(nf90_put_att(his_file%ncid, his_file%drain_fraction_open_varid, '_FillValue', FILL_VALUE))
+      NF90(nf90_put_att(his_file%ncid, his_file%drain_fraction_open_varid, 'units', '1'))
+      NF90(nf90_put_att(his_file%ncid, his_file%drain_fraction_open_varid, 'long_name', 'gate open fraction (1 = fully open, 0 = fully closed)'))
+      NF90(nf90_put_att(his_file%ncid, his_file%drain_fraction_open_varid, 'coordinates', 'drainage_name'))
+      !
+   endif
+   !
+   if (nr_discharge_points>0 .and. store_river_discharge) then
+      !
+      NF90(nf90_def_var(his_file%ncid, 'river_discharge', NF90_FLOAT, (/his_file%river_dimid, his_file%time_dimid/), his_file%river_varid)) ! time-varying river point discharge
+      NF90(nf90_put_att(his_file%ncid, his_file%river_varid, '_FillValue', FILL_VALUE))
+      NF90(nf90_put_att(his_file%ncid, his_file%river_varid, 'units', 'm3 s-1'))
+      NF90(nf90_put_att(his_file%ncid, his_file%river_varid, 'long_name', 'river point discharge'))
+      NF90(nf90_put_att(his_file%ncid, his_file%river_varid, 'coordinates', 'river_name'))
+      !
+   endif
+   !
+   if (nr_urban_drainage_zones > 0 .and. store_urban_drainage_discharge) then
+      !
+      NF90(nf90_def_var(his_file%ncid, 'urban_drainage_discharge', NF90_FLOAT, (/his_file%urbdrain_dimid, his_file%time_dimid/), his_file%urbdrain_varid)) ! per-zone outfall discharge
+      NF90(nf90_put_att(his_file%ncid, his_file%urbdrain_varid, '_FillValue', FILL_VALUE))
+      NF90(nf90_put_att(his_file%ncid, his_file%urbdrain_varid, 'units', 'm3 s-1'))
+      NF90(nf90_put_att(his_file%ncid, his_file%urbdrain_varid, 'long_name', 'urban drainage zone net outfall discharge'))
+      NF90(nf90_put_att(his_file%ncid, his_file%urbdrain_varid, 'coordinates', 'urban_drainage_zone_name'))
+      !
+   endif
    !   
    if (nr_runup_gauges > 0) then
       !
@@ -2251,7 +2409,62 @@ contains
    !
    if (nr_runup_gauges > 0) then
       NF90(nf90_put_var(his_file%ncid, his_file%runup_gauge_name_varid, runup_gauge_name))  ! write rug name
-   endif   
+   endif
+   !
+   if (nr_src_structures > 0) then
+      !
+      ! Copy src_struc_name (length src_struc_name_len = 128) into a length-256 buffer
+      ! to match the pointnamelength netCDF dimension used for all his_file name
+      ! variables.
+      !
+      allocate(drain_name_buf(nr_src_structures))
+      !
+      do istruc = 1, nr_src_structures
+         !
+         drain_name_buf(istruc) = src_struc_name(istruc)
+         !
+      enddo
+      !
+      NF90(nf90_put_var(his_file%ncid, his_file%drain_name_varid, drain_name_buf))  ! write drainage_name
+      !
+      deallocate(drain_name_buf)
+      !
+   endif
+   !
+   if (nr_discharge_points > 0 .and. store_river_discharge) then
+      !
+      ! Copy src_name (length src_name_len) into a length-256 buffer to match
+      ! the pointnamelength netCDF dimension.
+      !
+      allocate(river_name_buf(nr_discharge_points))
+      !
+      do istruc = 1, nr_discharge_points
+         !
+         river_name_buf(istruc) = src_name(istruc)
+         !
+      enddo
+      !
+      NF90(nf90_put_var(his_file%ncid, his_file%river_name_varid, river_name_buf))  ! write river_name
+      !
+      deallocate(river_name_buf)
+      !
+   endif
+   !
+   if (nr_urban_drainage_zones > 0 .and. store_urban_drainage_discharge) then
+      !
+      allocate(urbdrain_name_buf(nr_urban_drainage_zones))
+      !
+      do istruc = 1, nr_urban_drainage_zones
+         !
+         urbdrain_name_buf(istruc) = urb_zone_name(istruc)
+         !
+      enddo
+      !
+      NF90(nf90_put_var(his_file%ncid, his_file%urbdrain_name_varid, urbdrain_name_buf))  ! write urban_drainage_zone_name
+      !
+      deallocate(urbdrain_name_buf)
+      !
+   endif
    !
    if (nrstructures>0) then
       !
@@ -2521,8 +2734,25 @@ contains
          !
          n    = z_index_z_n(nm)
          m    = z_index_z_m(nm)
-         !      
+         !
          zsg(m, n) = qinfmap(nm)
+         !
+      enddo
+      !
+      NF90(nf90_put_var(map_file%ncid, map_file%Seff_varid, zsg, (/1, 1, ntmapout/)))
+      !
+   elseif (inftype == 'bkt') then
+      !
+      ! Store current bucket volume
+      !
+      zsg = FILL_VALUE
+      !
+      do nm = 1, np
+         !
+         n    = z_index_z_n(nm)
+         m    = z_index_z_m(nm)
+         !
+         zsg(m, n) = bucket_volume(nm)
          !
       enddo
       !
@@ -2808,8 +3038,16 @@ contains
       enddo
       !
       NF90(nf90_put_var(map_file%ncid, map_file%zs_varid, vtmp, (/1, ntmapout/))) ! write zs
-      ! 
-      ! Water depth 
+      !
+            endif
+            !
+         enddo
+         !
+         NF90(nf90_put_var(map_file%ncid, map_file%zb_varid, vtmp, (/1, ntmapout/))) ! write zb (subgrid_z_zmin for subgrid runs)
+         !
+      endif
+      !
+      ! Water depth
       !
       if (subgrid .eqv. .false. .or. store_hsubgrid .eqv. .true.) then   
          ! 
@@ -3159,14 +3397,17 @@ contains
    subroutine ncoutput_update_his(t,nthisout)
    ! Write time, zs, u, v, prcp of points 
    !
-   use sfincs_data   
+   use sfincs_data
    use sfincs_crosssections
    use sfincs_runup_gauges
    use sfincs_snapwave
+   use sfincs_src_structures, only: nr_src_structures, src_struc_q_now, src_struc_breach_width, src_struc_type, structure_dike_breach, src_struc_fraction_open
+   use sfincs_discharges,     only: qtsrc, nr_discharge_points
+   use sfincs_urban_drainage, only: nr_urban_drainage_zones, urban_drainage_q_total
    !
-   implicit none   
+   implicit none
    !
-   integer :: iobs, nm, idrn
+   integer :: iobs, nm, istruc
    !
    integer :: nthisout      
    integer :: nmd1, nmu1, ndm1, num1
@@ -3192,7 +3433,6 @@ contains
    real*4, dimension(nobs) :: tpigobs   
    real*4, dimension(nobs) :: wavdirobs
    real*4, dimension(nobs) :: dirsprobs
-   real*4, dimension(ndrn) :: q_drain   
    real*4, dimension(nobs) :: dwobs
    real*4, dimension(nobs) :: dfobs
    real*4, dimension(nobs) :: dwigobs
@@ -3218,7 +3458,6 @@ contains
    tpatm        = FILL_VALUE
    twndmag      = FILL_VALUE
    twnddir      = FILL_VALUE
-   q_drain      = FILL_VALUE
    dwobs        = FILL_VALUE
    dfobs        = FILL_VALUE
    cgobs        = FILL_VALUE
@@ -3271,10 +3510,12 @@ contains
             elseif (inftype == 'gai') then
                !
                tS_effective(iobs) = GA_sigma(nm)
-               !
+            elseif (inftype == 'hor') then
+               tS_effective(iobs) = qinfmap(nm)*3.6e3*1.0e3 ! current f in mm/hr
+            elseif (inftype == 'bkt') then
+               tS_effective(iobs) = bucket_volume(nm)        ! current bucket storage in m
             endif
-            !
-         endif  
+         endif
          !
          if (store_meteo) then
             !
@@ -3359,9 +3600,7 @@ contains
       !
       NF90(nf90_put_var(his_file%ncid, his_file%qinf_varid, tqinf, (/1, nthisout/))) ! write qinf
       !
-      if (inftype == 'cnb') then
-         NF90(nf90_put_var(his_file%ncid, his_file%S_varid, tS_effective, (/1, nthisout/))) ! write S
-      elseif (inftype == 'gai') then
+      if (inftype == 'cnb' .or. inftype == 'gai' .or. inftype == 'hor' .or. inftype == 'bkt') then
          NF90(nf90_put_var(his_file%ncid, his_file%S_varid, tS_effective, (/1, nthisout/))) ! write S
       endif
       !
@@ -3456,19 +3695,32 @@ contains
       !
    endif
    !
-   if (ndrn>0) then
+   if (nr_src_structures>0) then
+      !
+      !$acc update host(src_struc_q_now, src_struc_fraction_open)
+      !
+      NF90(nf90_put_var(his_file%ncid, his_file%drain_varid, src_struc_q_now, (/1, nthisout/))) ! write per-structure discharge
+      NF90(nf90_put_var(his_file%ncid, his_file%drain_fraction_open_varid, src_struc_fraction_open, (/1, nthisout/))) ! write per-structure gate open fraction
+      !
+      if (any(src_struc_type == structure_dike_breach)) then
+         !$acc update host(src_struc_breach_width)
+         NF90(nf90_put_var(his_file%ncid, his_file%breach_width_varid, src_struc_breach_width, (/1, nthisout/))) ! write breach width
+      endif
+      !
+   endif
+   !
+   if (nr_discharge_points>0 .and. store_river_discharge) then
       !
       !$acc update host(qtsrc)
-      ! Get fluxes through drainage structure             
       !
-      idrn = 0
-      do iobs = nsrc + 1, nsrcdrn, 2 !TL: as in sfincs_output.f90
-         idrn = idrn + 1
-         q_drain(idrn) = qtsrc(iobs)
-      enddo      
+      NF90(nf90_put_var(his_file%ncid, his_file%river_varid, qtsrc, (/1, nthisout/))) ! write per-river-source discharge
       !
-      NF90(nf90_put_var(his_file%ncid, his_file%drain_varid, q_drain, (/1, nthisout/))) ! write discharge of sink point
-      !         
+   endif
+   !
+   if (nr_urban_drainage_zones > 0 .and. store_urban_drainage_discharge) then
+      !
+      NF90(nf90_put_var(his_file%ncid, his_file%urbdrain_varid, urban_drainage_q_total, (/1, nthisout/))) ! write per-zone total discharge
+      !
    endif
    !
    if (store_velocity) then
@@ -3490,9 +3742,10 @@ contains
    !
    ! write zsmax per dtmaxout
    !
-   use sfincs_data   
+   use sfincs_data
+   use sfincs_urban_drainage, only: urban_drainage_cumulative_volume
    !
-   implicit none   
+   implicit none
    !
    integer :: nm, n, m
    !
@@ -3614,7 +3867,30 @@ contains
          zstmp(m, n)    = cuminf(nm) 
       enddo
       !
-      NF90(nf90_put_var(map_file%ncid, map_file%cuminf_varid, zstmp, (/1, 1, ntmaxout/))) ! write cuminf   
+      NF90(nf90_put_var(map_file%ncid, map_file%cuminf_varid, zstmp, (/1, 1, ntmaxout/))) ! write cuminf
+      !
+   endif
+   !
+   ! Cumulative urban drainage depth (volume / cell_area)
+   !
+   if (store_cumulative_urban_drainage .and. urban_drainage) then
+      !
+      zstmp = FILL_VALUE
+      !
+      do nm = 1, np
+         !
+         n = z_index_z_n(nm)
+         m = z_index_z_m(nm)
+         !
+         if (crsgeo) then
+            zstmp(m, n) = urban_drainage_cumulative_volume(nm) / cell_area_m2(nm)
+         else
+            zstmp(m, n) = urban_drainage_cumulative_volume(nm) / cell_area(z_flags_iref(nm))
+         endif
+         !
+      enddo
+      !
+      NF90(nf90_put_var(map_file%ncid, map_file%cumulative_urbdrain_varid, zstmp, (/1, 1, ntmaxout/))) ! write cumulative urban drainage depth
       !
    endif
    !
@@ -3687,11 +3963,12 @@ contains
    !
    ! write zsmax per dtmaxout
    !
-   use sfincs_data  
+   use sfincs_data
    !use sfincs_snapwave
    use quadtree
+   use sfincs_urban_drainage, only: urban_drainage_cumulative_volume
    !
-   implicit none   
+   implicit none
    !
    integer                              :: nmq, nm, ntmaxout
    real*8                               :: t  
@@ -3815,9 +4092,32 @@ contains
                endif
            endif           
        enddo
-       NF90(nf90_put_var(map_file%ncid, map_file%cuminf_varid, zstmp, (/1, ntmaxout/))) ! write cuminf      
-       !       
-   endif      
+       NF90(nf90_put_var(map_file%ncid, map_file%cuminf_varid, zstmp, (/1, ntmaxout/))) ! write cuminf
+       !
+   endif
+   !
+   ! Cumulative urban drainage depth (volume / cell_area)
+   !
+   if (store_cumulative_urban_drainage .and. urban_drainage) then
+       !
+       zstmp = FILL_VALUE
+       !
+       do nmq = 1, quadtree_nr_points
+           nm = index_sfincs_in_quadtree(nmq)
+           if (nm > 0) then
+               if (kcs(nm) > 0) then
+                   if (crsgeo) then
+                       zstmp(nmq) = urban_drainage_cumulative_volume(nm) / cell_area_m2(nm)
+                   else
+                       zstmp(nmq) = urban_drainage_cumulative_volume(nm) / cell_area(z_flags_iref(nm))
+                   endif
+               endif
+           endif
+       enddo
+       !
+       NF90(nf90_put_var(map_file%ncid, map_file%cumulative_urbdrain_varid, zstmp, (/1, ntmaxout/))) ! write cumulative urban drainage depth
+       !
+   endif
    !
    ! Maximum flow velocity
    if (store_maximum_velocity) then
@@ -3893,13 +4193,13 @@ contains
    !
    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!   
    !
-   subroutine ncoutput_map_finalize() 
+   subroutine ncoutput_map_finalize()
    !
    ! Add total runtime, dtavg to file and close
    !
    use sfincs_data
-   !   
-   implicit none   
+   !
+   implicit none
    !
    if (store_tsunami_arrival_time) then
       !
@@ -3911,7 +4211,7 @@ contains
        !
        call ncoutput_write_timestep_analysis()
        !
-   endif   
+   endif
    !
    NF90(nf90_put_var(map_file%ncid, map_file%total_runtime_varid, tfinish_all - tstart_all))
    NF90(nf90_put_var(map_file%ncid, map_file%average_dt_varid,  dtavg))
@@ -4051,14 +4351,17 @@ contains
    ! Add total runtime, dtavg to file and close
    !
    use sfincs_data
-   !   
-   implicit none   
-   !   
-   if (nobs==0 .and. nrcrosssections==0 .and. nrstructures==0 .and. nrthindams==0 .and. ndrn==0) then ! If no observation points, cross-sections, structures 9weir or thin dam), or drains; hisfile        
-        return
-   endif   
+   use sfincs_src_structures, only: nr_src_structures
+   use sfincs_discharges,     only: nr_discharge_points
+   use sfincs_urban_drainage, only: nr_urban_drainage_zones
    !
-   NF90(nf90_put_var(his_file%ncid, his_file%total_runtime_varid, tfinish_all - tstart_all)) 
+   implicit none
+   !
+   if (nobs==0 .and. nrcrosssections==0 .and. nrstructures==0 .and. nrthindams==0 .and. nr_src_structures==0 .and. .not. (nr_discharge_points>0 .and. store_river_discharge) .and. .not. (nr_urban_drainage_zones>0 .and. store_urban_drainage_discharge)) then ! If no observation points, cross-sections, structures (weir or thin dam), drains, river sources or urban drainage zones; hisfile
+        return
+   endif
+   !
+   NF90(nf90_put_var(his_file%ncid, his_file%total_runtime_varid, tfinish_all - tstart_all))
    NF90(nf90_put_var(his_file%ncid, his_file%average_dt_varid,  dtavg)) 
    NF90(nf90_put_var(his_file%ncid, his_file%status_varid,  error))       
    !   
@@ -4071,6 +4374,8 @@ contains
    subroutine ncoutput_add_params(ncid, varid)
    ! Add user params to netcdf file (both map & his)
    use sfincs_data
+   use sfincs_src_structures, only: drnfile
+   use sfincs_discharges,     only: srcfile, disfile, netsrcdisfile
    !
    ! Because of overlapping names, only important specific values from snapwave_data
    use snapwave_data, only: gamma, gammax, alpha, hmin, fw0, fw0_ig, dt, tol, dtheta, crit, nr_sweeps, baldock_exponent, baldock_ratio, &
@@ -4206,13 +4511,18 @@ contains
         NF90(nf90_put_att(ncid, varid, 'amvfile',amvfile))  
         NF90(nf90_put_att(ncid, varid, 'ampfile',ampfile))              
         NF90(nf90_put_att(ncid, varid, 'amprfile',amprfile))  
-        NF90(nf90_put_att(ncid, varid, 'qinffile',qinffile))   
+        NF90(nf90_put_att(ncid, varid, 'infiltrationfile',infiltrationfile))
+        NF90(nf90_put_att(ncid, varid, 'infiltrationtype',inftype))
+        NF90(nf90_put_att(ncid, varid, 'qinffile',qinffile))
         NF90(nf90_put_att(ncid, varid, 'scsfile',scsfile)) 
         NF90(nf90_put_att(ncid, varid, 'smaxfile',smaxfile)) 
         NF90(nf90_put_att(ncid, varid, 'sefffile',sefffile)) 
         NF90(nf90_put_att(ncid, varid, 'ksfile',ksfile)) 
         NF90(nf90_put_att(ncid, varid, 'psifile',psifile)) 
         NF90(nf90_put_att(ncid, varid, 'sigmafile',sigmafile)) 
+        NF90(nf90_put_att(ncid, varid, 'f0file',f0file))
+        NF90(nf90_put_att(ncid, varid, 'fcfile',fcfile))
+        NF90(nf90_put_att(ncid, varid, 'kdfile',kdfile))
         NF90(nf90_put_att(ncid, varid, 'z0lfile',z0lfile)) 
         NF90(nf90_put_att(ncid, varid, 'wavemaker_wvmfile',wavemaker_wvmfile)) 
         !
@@ -4230,20 +4540,20 @@ contains
         NF90(nf90_put_att(ncid, varid, 'nobs',nobs))                    
         NF90(nf90_put_att(ncid, varid, 'crsfile',crsfile))   
         !
-        NF90(nf90_put_att(ncid, varid, 'storevelmax',storevelmax)) 
-        NF90(nf90_put_att(ncid, varid, 'storefluxmax',storefluxmax))        
-        NF90(nf90_put_att(ncid, varid, 'storevel',storevel)) 
-        NF90(nf90_put_att(ncid, varid, 'storecumprcp',storecumprcp)) 
-        NF90(nf90_put_att(ncid, varid, 'storetwet',storetwet)) 
-        NF90(nf90_put_att(ncid, varid, 'storehsubgrid',storehsubgrid)) 
-        NF90(nf90_put_att(ncid, varid, 'twet_threshold',twet_threshold)) 
-        NF90(nf90_put_att(ncid, varid, 'store_tsunami_arrival_time',logical2int(store_tsunami_arrival_time))) 
-        NF90(nf90_put_att(ncid, varid, 'tsunami_arrival_threshold',tsunami_arrival_threshold)) 
-        NF90(nf90_put_att(ncid, varid, 'storeqdrain',storeqdrain)) 
-        NF90(nf90_put_att(ncid, varid, 'storezvolume',storezvolume)) 
-        NF90(nf90_put_att(ncid, varid, 'writeruntime',wrttimeoutput)) 
-        NF90(nf90_put_att(ncid, varid, 'debug',logical2int(debug))) 
-        NF90(nf90_put_att(ncid, varid, 'storemeteo',storemeteo)) 
+        NF90(nf90_put_att(ncid, varid, 'storevelmax',logical2int(store_maximum_velocity)))
+        NF90(nf90_put_att(ncid, varid, 'storefluxmax',logical2int(store_maximum_flux)))
+        NF90(nf90_put_att(ncid, varid, 'storevel',logical2int(store_velocity)))
+        NF90(nf90_put_att(ncid, varid, 'storecumprcp',logical2int(store_cumulative_precipitation)))
+        NF90(nf90_put_att(ncid, varid, 'storetwet',logical2int(store_twet)))
+        NF90(nf90_put_att(ncid, varid, 'storehsubgrid',logical2int(store_hsubgrid)))
+        NF90(nf90_put_att(ncid, varid, 'twet_threshold',twet_threshold))
+        NF90(nf90_put_att(ncid, varid, 'store_tsunami_arrival_time',logical2int(store_tsunami_arrival_time)))
+        NF90(nf90_put_att(ncid, varid, 'tsunami_arrival_threshold',tsunami_arrival_threshold))
+        NF90(nf90_put_att(ncid, varid, 'storeqdrain',logical2int(store_qdrain)))
+        NF90(nf90_put_att(ncid, varid, 'storezvolume',logical2int(store_zvolume)))
+        NF90(nf90_put_att(ncid, varid, 'writeruntime',logical2int(write_time_output)))
+        NF90(nf90_put_att(ncid, varid, 'debug',logical2int(debug)))
+        NF90(nf90_put_att(ncid, varid, 'storemeteo',logical2int(store_meteo)))
         NF90(nf90_put_att(ncid, varid, 'storemaxwind',logical2int(store_wind_max))) 
         NF90(nf90_put_att(ncid, varid, 'storefw',logical2int(store_wave_forces)))         
         NF90(nf90_put_att(ncid, varid, 'storewavdir', logical2int(store_wave_direction))) 

--- a/source/src/sfincs_ncoutput.F90
+++ b/source/src/sfincs_ncoutput.F90
@@ -1,1847 +1,781 @@
-#define NF90(nf90call) call handle_err(nf90call,__FILE__,__LINE__)     
+#define NF90(nf90call) call handle_err(nf90call,__FILE__,__LINE__)
+!
+! ============================================================================
+! sfincs_ncoutput — NetCDF output for the SFINCS map file (sfincs_map.nc)
+!                   and the his point file (sfincs_his.nc).
+!
+! Handles regular and quadtree grids through a single set of helpers.
+! Caller code does not need separate `if (use_quadtree) … else …` branches
+! for standard cell-centered or point-station outputs.
+!
+! ----------------------------------------------------------------------------
+! HOW TO ADD A NEW OUTPUT VARIABLE
+! ----------------------------------------------------------------------------
+!
+! In the recipes below, 'waterlevel' is just a placeholder — replace it with
+! the real name of the variable you are adding.
+!
+! Map-file (cell-centered) output, time-varying — e.g. a new field 'waterlevel':
+!   1. Add `integer :: waterlevel_varid` to `map_type` below.
+!   2. In ncoutput_map_init, define the var:
+!         call def_time_cell_float('waterlevel', map_file%waterlevel_varid, &
+!              'units', 'long_name', standard_name='cf_standard_name')
+!   3. In ncoutput_update_map, write it each timestep:
+!         call write_cell_var(map_file%ncid, map_file%waterlevel_varid, &
+!              waterlevel, ntmapout)
+!
+! Map-file output, max-aggregated — e.g. 'waterlevel_max' (zsmax / hmax / vmax style):
+!   1. Add `integer :: waterlevel_max_varid` to `map_type`.
+!   2. In ncoutput_map_init:
+!         call def_maxtime_cell_float('waterlevel_max', map_file%waterlevel_max_varid, &
+!              'units', 'long_name', cell_methods='time: maximum')
+!   3. In ncoutput_update_max:
+!         call write_cell_var(map_file%ncid, map_file%waterlevel_max_varid, &
+!              waterlevel_max, ntmaxout, check_kcs=.true.)
+!
+! Map-file output, static (single value per cell, written once) — e.g. 'soil':
+!   1. Add `integer :: soil_varid` to `map_type`.
+!   2. In ncoutput_map_init:
+!         call def_static_cell_float('soil', map_file%soil_varid, 'units', &
+!              'long_name', standard_name='...')
+!   3. In ncoutput_map_init's static-write block (after nf90_enddef):
+!         call put_static_cell_float(map_file%ncid, map_file%soil_varid, soil, FILL_VALUE)
+!
+! Map-file output, static integer mask (stored as integer on quadtree,
+! float on regular grid) — e.g. a 'valid_cell' flag:
+!   1. Add `integer :: valid_cell_varid` to `map_type`.
+!   2. In ncoutput_map_init:
+!         call def_static_cell_int('valid_cell', map_file%valid_cell_varid, &
+!              'long_name', units='1', standard_name='valid_cell_mask', &
+!              description='inactive=0, active=1')
+!   3. In ncoutput_map_init's static-write block:
+!         call put_static_cell_mask(map_file%ncid, map_file%valid_cell_varid, &
+!              real(valid_cell, 4))    ! cast int*1/int*4 source to real*4
+!
+! His-file (point/station) output, time-varying — e.g. 'point_waterlevel':
+!   1. Add `integer :: waterlevel_varid` to `his_type`.
+!   2. In ncoutput_his_init:
+!         call def_time_point_float('point_waterlevel', his_file%waterlevel_varid, &
+!              'units', 'long_name', standard_name='...')
+!   3. In ncoutput_update_his: call write_point_var(his_file%waterlevel_varid,
+!      source_array, nthisout) — it gathers nmindobs and writes for you.
+!      Use optional scale= for unit conversion (e.g. scale=3600000.0 for mm/hr).
+!
+! Conditions (subgrid, snapwave, infiltration, etc.) belong in the caller's
+! `if (...)` guard around the def + write pair, not inside helpers.
+!
+! GPU note: when running on GPU (OpenACC), the source array of any new
+! time-varying output must be synced back to the host before the write call
+! using `!$acc update host(<source>)`.  The helpers themselves run on the
+! host; they only read host-resident data.
+!
+! ----------------------------------------------------------------------------
+! HELPER INVENTORY
+! ----------------------------------------------------------------------------
+!
+! Generic NetCDF (bottom of helpers file):
+!   ncdef_float_var, ncdef_int_var          one-call var-def + attribute set
+!   logical2int(lgc)                        returns 1/.true. or 0/.false.
+!   handle_err                              NF90 macro error handler
+!
+! Module-level static-cell writers:
+!   put_static_cell_float(ncid, varid, source, fill, [scale, sw_index, min_value])
+!   put_static_cell_mask (ncid, varid, source, [sw_index])
+!
+! Module-level time-varying cell writers:
+!   write_cell_var      (ncid, varid, source, nt, [use_sw_index, check_kcs,
+!                                                  scale, min_value])
+!   write_cell_var_wet  (ncid, varid, source, zref, nt, [check_wet])
+!   write_cell_var_depth(ncid, varid, water_level, bed_level, nt, [check_wet])
+!
+! Definition wrappers used inside ncoutput_map_init (these reuse the
+! enclosing scope's dims_* / coord_str / crsgeo / nc_deflate_level so call
+! sites stay one-liners):
+!   def_static_cell_float / def_static_cell_int    static cell variables
+!   def_time_cell_float                            time-varying cell variables
+!   def_maxtime_cell_float                         max-aggregated cell variables
+!   add_ugrid_face_attrs      attach mesh2d_face_face_link attrs to a varid
+!   def_mesh2d_node_coord     UGRID node coord (float for geographic, double for projected)
+!   def_grid_axis_coord       SGRID face/corner coord (always float)
+!   put_2d                    nf90_put_var with (/1, 1/) start
+!
+! Definition wrappers used inside ncoutput_his_init:
+!   def_time_point_float                           (points × time)
+!   def_his_point_coord                            station coordinate variable
+!
+! His-update writer (gathers nmindobs internally):
+!   write_point_var(varid, source, nt, [scale])
+!
+! Precompute helpers used inside ncoutput_update_his:
+!   compute_uv_at_obs_points   face-averaged, rotated (u,v), magnitude, direction
+!   compute_wind_at_obs_points speed + meteorological direction (270 convention)
+!
+! Precompute helpers used inside ncoutput_update_map (return arrays
+! indexed by SFINCS cell number):
+!   compute_uv_at_cell_centers
+!   compute_pnh_unwrapped
+!   compute_subgrid_mean_depth  (also used by ncoutput_update_max)
+!
+! Finalize helpers (write once at end of simulation):
+!   ncoutput_write_timestep_analysis
+!   ncoutput_write_tsunami_arrival_time
+!
+! ----------------------------------------------------------------------------
+! GRID-TYPE BRANCH STILL NEEDED WHEN
+! ----------------------------------------------------------------------------
+!
+! - the variable is grid-specific topology (UGRID mesh2d / face_node_connectivity
+!   on quadtree vs SGRID face_x / corner_x / sfincsgrid on regular) and the
+!   Conventions string that goes with it;
+! - the variable itself is grid-agnostic (SnapWave output now reads the
+!   snapwave_* node arrays via use_sw_index on both quadtree and regular).
+!
+! Model-physics asymmetries that propagate into output (not a netCDF concern):
+! - dynamic bed level (`store_dynamic_bed_level`) only updates on regular
+!   non-subgrid runs, so zb is time-varying there and static everywhere else.
+!
+! ============================================================================
 module sfincs_ncoutput
    !
-   use netcdf 
+   use netcdf
+   use sfincs_ncoutput_helpers
    !
    implicit none
    !
-   type map_type
-      !
-      integer :: ncid   
-      integer :: n_dimid, m_dimid, corner_n_dimid, corner_m_dimid
-      integer :: time_dimid 
-      integer :: timemax_dimid 
-      integer :: runtime_dimid
-      integer :: corner_x_varid, corner_y_varid, face_x_varid, face_y_varid, crs_varid, grid_varid 
-      integer :: zb_varid, msk_varid, qinf_varid
-      integer :: time_varid, timemax_varid
-      integer :: zs_varid, zsmax_varid, h_varid, u_varid, v_varid, tmax_varid, Seff_varid, t_zsmax_varid
-      integer :: zvolume_varid, storagevolume_varid
-      integer :: hmax_varid, vmax_varid, qmax_varid, cumprcp_varid, cuminf_varid, windmax_varid
-      integer :: cumulative_urbdrain_varid
-      integer :: patm_varid, wind_u_varid, wind_v_varid, precip_varid        
-      integer :: hm0_varid, hm0ig_varid, snapwavemsk_varid, tp_varid, tpig_varid, wavdir_varid, dirspr_varid
-      integer :: fwx_varid, fwy_varid, beta_varid, snapwavedepth_varid
-      integer :: zsm_varid, tsunami_arrival_time_varid, average_required_timestep_varid, percentage_limiting_varid
-      integer :: inp_varid, total_runtime_varid, average_dt_varid, status_varid
-      integer :: manning_varid
-      integer :: pnonh_varid
-      integer :: subgridslope_varid
-      ! Vegetation
-      integer :: nsec_dimid
-      integer :: veg_cd_varid, veg_ah_varid, veg_bstems_varid, veg_Nstems_varid
-      !
-         integer :: mesh2d_varid
-         integer :: mesh2d_node_x_varid, mesh2d_node_y_varid
-         integer :: mesh2d_face_x_varid, mesh2d_face_y_varid
-         integer :: mesh2d_face_nodes_varid
-         integer :: nmesh2d_node_dimid
-         integer :: nmesh2d_face_dimid
-         integer :: max_nmesh2d_face_nodes_dimid
-         !
-      end type
-   !
-   type his_type
-      !
-      integer :: ncid   
-      integer :: time_dimid 
-      integer :: points_dimid, pointnamelength_dimid
-      integer :: crosssections_dimid, structures_dimid, thindams_dimid, drain_dimid, runup_gauges_dimid, river_dimid
-      integer :: urbdrain_dimid
-      integer :: runtime_dimid
-      integer :: point_x_varid, point_y_varid, station_x_varid, station_y_varid, crs_varid, qinf_varid, S_varid  
-      integer :: station_id_varid, station_name_varid
-      integer :: crosssection_name_varid
-      integer :: structure_height_varid, structure_x_varid, structure_y_varid
-      integer :: thindam_x_varid, thindam_y_varid      
-      integer :: drain_varid, drain_name_varid, breach_width_varid, drain_fraction_open_varid
-      integer :: river_varid, river_name_varid
-      integer :: urbdrain_varid, urbdrain_name_varid
-      integer :: zb_varid
-      integer :: time_varid
-      integer :: zs_varid, h_varid, u_varid, v_varid, prcp_varid, cumprcp_varid, discharge_varid, uvmag_varid, uvdir_varid
-      integer :: patm_varid, wind_speed_varid, wind_dir_varid
-      integer :: inp_varid, total_runtime_varid, average_dt_varid, status_varid  
-      integer :: hm0_varid, hm0ig_varid, zsm_varid, tp_varid, tpig_varid, wavdir_varid, dirspr_varid
-      integer :: dw_varid, df_varid, dwig_varid, dfig_varid, cg_varid, beta_varid, srcig_varid, alphaig_varid
-      integer :: runup_gauge_name_varid, runup_gauge_zs_varid
-      !
-   end type
-   !
-   type(map_type) :: map_file
-   type(his_type) :: his_file
-   !
-   real*4, parameter :: FILL_VALUE = -99999.0
 
 contains
 
-   subroutine ncoutput_regular_map_init()
+   subroutine ncoutput_map_init()
    !
+   ! Merged init for both regular and quadtree grids.
    ! 1. Initialise dimensions/variables/attributes
-   ! 2. write grid/msk/zb to file
+   ! 2. Write grid/msk/zb to file
    !
    use sfincs_date
    use sfincs_data
-   use sfincs_snapwave   
-   !
-   implicit none   
-   !   
-   integer                      :: nm, n, m, ntmx
-   !
-   real*4, dimension(:,:), allocatable :: zsg
-   real*4, dimension(:,:), allocatable :: xz
-   real*4, dimension(:,:), allocatable :: yz
-   real*4, dimension(:,:), allocatable :: xg
-   real*4, dimension(:,:), allocatable :: yg
-   !
-   NF90(nf90_create('sfincs_map.nc', ior(NF90_CLOBBER,NF90_NETCDF4), map_file%ncid))
-   !
-   ! Create dimensions
-   ! grid, time, points
-   ! do mmax/nmax-2 to not write away dummy cells
-   NF90(nf90_def_dim(map_file%ncid, 'n', nmax, map_file%n_dimid)) ! rows 
-   NF90(nf90_def_dim(map_file%ncid, 'm', mmax, map_file%m_dimid)) ! columns
-   NF90(nf90_def_dim(map_file%ncid, 'corner_n', nmax + 1, map_file%corner_n_dimid)) ! rows of corners
-   NF90(nf90_def_dim(map_file%ncid, 'corner_m', mmax + 1, map_file%corner_m_dimid)) ! columns of corners   
-   NF90(nf90_def_dim(map_file%ncid, 'time', NF90_UNLIMITED, map_file%time_dimid)) ! time
-   ntmx = max(ceiling((t1out - t0out)/dtmaxout), 1)
-   NF90(nf90_def_dim(map_file%ncid, 'timemax', ntmx, map_file%timemax_dimid)) ! time
-   NF90(nf90_def_dim(map_file%ncid, 'runtime', 1, map_file%runtime_dimid)) ! total_runtime, average_dt       
-   !
-   ! Some metadata attributes 
-   NF90(nf90_put_att(map_file%ncid,nf90_global, "Conventions", "CF-1.8 UGRID-1.0 Deltares-0.10"))
-   NF90(nf90_put_att(map_file%ncid,nf90_global, "Build-Revision-Date-Netcdf-library", trim(nf90_inq_libvers()))) ! version of netcdf library
-   NF90(nf90_put_att(map_file%ncid,nf90_global, "Producer", "SFINCS model: Super-Fast INundation of CoastS"))
-   NF90(nf90_put_att(map_file%ncid,nf90_global, "Build-Revision", trim(build_revision))) 
-   NF90(nf90_put_att(map_file%ncid,nf90_global, "Build-Date", trim(build_date)))
-   NF90(nf90_put_att(map_file%ncid,nf90_global, "title", "SFINCS map netcdf output"))   
-   !
-   ! add input params for reproducability
-   !
-   call ncoutput_add_params(map_file%ncid,map_file%inp_varid)   
-   !
-   !! Create variables
-   !
-   ! Domain
-   !
-   NF90(nf90_def_var(map_file%ncid, 'x', NF90_FLOAT, (/map_file%m_dimid, map_file%n_dimid/), map_file%face_x_varid)) ! location of zb, zs etc. in cell centre   
-   NF90(nf90_def_var_deflate(map_file%ncid, map_file%face_x_varid, 1, 1, nc_deflate_level)) ! deflate
-   NF90(nf90_put_att(map_file%ncid, map_file%face_x_varid, '_FillValue', FILL_VALUE))         
-   if (crsgeo) then
-      NF90(nf90_put_att(map_file%ncid, map_file%face_x_varid, 'units', 'degrees'))
-      NF90(nf90_put_att(map_file%ncid, map_file%face_x_varid, 'standard_name', 'longitude'))
-   else
-      NF90(nf90_put_att(map_file%ncid, map_file%face_x_varid, 'units', 'm'))
-      NF90(nf90_put_att(map_file%ncid, map_file%face_x_varid, 'standard_name', 'projection_x_coordinate'))
-   endif
-   NF90(nf90_put_att(map_file%ncid, map_file%face_x_varid, 'long_name', 'face_x'))   
-   NF90(nf90_put_att(map_file%ncid, map_file%face_x_varid, 'grid_mapping', 'crs'))   
-   NF90(nf90_put_att(map_file%ncid, map_file%face_x_varid, 'grid', 'sfincsgrid'))   
-   !
-   NF90(nf90_def_var(map_file%ncid, 'y', NF90_FLOAT, (/map_file%m_dimid, map_file%n_dimid/), map_file%face_y_varid)) ! location of zb, zs etc. in cell centre
-   NF90(nf90_def_var_deflate(map_file%ncid, map_file%face_y_varid, 1, 1, nc_deflate_level)) ! deflate
-   NF90(nf90_put_att(map_file%ncid, map_file%face_y_varid, '_FillValue', FILL_VALUE))            
-   if (crsgeo) then
-      NF90(nf90_put_att(map_file%ncid, map_file%face_y_varid, 'units', 'degrees'))
-      NF90(nf90_put_att(map_file%ncid, map_file%face_y_varid, 'standard_name', 'latitude'))
-   else
-      NF90(nf90_put_att(map_file%ncid, map_file%face_y_varid, 'units', 'm'))
-      NF90(nf90_put_att(map_file%ncid, map_file%face_y_varid, 'standard_name', 'projection_y_coordinate'))
-   endif
-   NF90(nf90_put_att(map_file%ncid, map_file%face_y_varid, 'long_name', 'face_y'))
-   NF90(nf90_put_att(map_file%ncid, map_file%face_y_varid, 'grid_mapping', 'crs'))   
-   NF90(nf90_put_att(map_file%ncid, map_file%face_y_varid, 'grid', 'sfincsgrid'))      
-   !
-   NF90(nf90_def_var(map_file%ncid, 'corner_x', NF90_FLOAT, (/map_file%corner_m_dimid, map_file%corner_n_dimid/), map_file%corner_x_varid)) ! location of u points in cell corner
-   NF90(nf90_def_var_deflate(map_file%ncid, map_file%corner_x_varid, 1, 1, nc_deflate_level)) ! deflate
-   NF90(nf90_put_att(map_file%ncid, map_file%corner_x_varid, '_FillValue', FILL_VALUE))         
-   if (crsgeo) then
-      NF90(nf90_put_att(map_file%ncid, map_file%corner_x_varid, 'units', 'degrees'))
-      NF90(nf90_put_att(map_file%ncid, map_file%corner_x_varid, 'standard_name', 'longitude'))
-   else
-      NF90(nf90_put_att(map_file%ncid, map_file%corner_x_varid, 'units', 'm'))
-      NF90(nf90_put_att(map_file%ncid, map_file%corner_x_varid, 'standard_name', 'projection_x_coordinate'))
-   endif
-   NF90(nf90_put_att(map_file%ncid, map_file%corner_x_varid, 'long_name', 'corner_x'))
-   NF90(nf90_put_att(map_file%ncid, map_file%corner_x_varid, 'grid_mapping', 'crs'))   
-   NF90(nf90_put_att(map_file%ncid, map_file%corner_x_varid, 'grid', 'sfincsgrid'))     
-   !
-   NF90(nf90_def_var(map_file%ncid, 'corner_y', NF90_FLOAT, (/map_file%corner_m_dimid, map_file%corner_n_dimid/), map_file%corner_y_varid)) ! location of v points in cell corner
-   NF90(nf90_def_var_deflate(map_file%ncid, map_file%corner_y_varid, 1, 1, nc_deflate_level)) ! deflate
-   NF90(nf90_put_att(map_file%ncid, map_file%corner_y_varid, '_FillValue', FILL_VALUE))         
-   if (crsgeo) then
-      NF90(nf90_put_att(map_file%ncid, map_file%corner_y_varid, 'units', 'degrees'))
-      NF90(nf90_put_att(map_file%ncid, map_file%corner_y_varid, 'standard_name', 'latitude'))
-   else
-      NF90(nf90_put_att(map_file%ncid, map_file%corner_y_varid, 'units', 'm'))
-      NF90(nf90_put_att(map_file%ncid, map_file%corner_y_varid, 'standard_name', 'projection_y_coordinate'))
-   endif
-   NF90(nf90_put_att(map_file%ncid, map_file%corner_y_varid, 'long_name', 'corner_y'))
-   NF90(nf90_put_att(map_file%ncid, map_file%corner_y_varid, 'grid_mapping', 'crs'))   
-   NF90(nf90_put_att(map_file%ncid, map_file%corner_y_varid, 'grid', 'sfincsgrid'))   
-   !
-   NF90(nf90_def_var(map_file%ncid, 'crs', NF90_INT, map_file%crs_varid)) ! For EPSG code   
-   NF90(nf90_put_att(map_file%ncid, map_file%crs_varid, 'epsg', epsg))
-   NF90(nf90_put_att(map_file%ncid, map_file%crs_varid, 'epsg_code', 'EPSG:' // trim(epsg_code) ))   !--> add epsg_code like FEWS wants
-   !
-   NF90(nf90_def_var(map_file%ncid, 'sfincsgrid', NF90_INT, map_file%grid_varid)) ! For neat grid clarification
-   NF90(nf90_put_att(map_file%ncid, map_file%grid_varid, 'cf_role', 'grid_topology'))
-   NF90(nf90_put_att(map_file%ncid, map_file%grid_varid, 'topology_dimension', 2))
-   NF90(nf90_put_att(map_file%ncid, map_file%grid_varid, 'node_dimensions', 'n m')) !or n m?   
-   NF90(nf90_put_att(map_file%ncid, map_file%grid_varid, 'face_dimensions', 'n: m:')) 
-   NF90(nf90_put_att(map_file%ncid, map_file%grid_varid, 'corner_dimensions', 'corner_n: corner_m:'))   
-   NF90(nf90_put_att(map_file%ncid, map_file%grid_varid, 'face_coordinates', 'x y'))
-   NF90(nf90_put_att(map_file%ncid, map_file%grid_varid, 'corner_coordinates', 'corner_x corner_y'))   
-   !
-   NF90(nf90_def_var(map_file%ncid, 'msk', NF90_FLOAT, (/map_file%m_dimid, map_file%n_dimid/), map_file%msk_varid)) ! input msk value in cell centre   
-   NF90(nf90_put_att(map_file%ncid, map_file%msk_varid, '_FillValue', FILL_VALUE))      
-   NF90(nf90_put_att(map_file%ncid, map_file%msk_varid, 'units', '-'))
-   NF90(nf90_put_att(map_file%ncid, map_file%msk_varid, 'standard_name', 'land_binary_mask')) ! land_binary_mask but with added boundary=2
-   NF90(nf90_put_att(map_file%ncid, map_file%msk_varid, 'long_name', 'Active cells mask')) 
-   NF90(nf90_put_att(map_file%ncid, map_file%msk_varid, 'description', 'inactive=0, active=1, normal_boundary=2, outflow_boundary=3'))    
-   NF90(nf90_put_att(map_file%ncid, map_file%msk_varid, 'coordinates', 'x y'))   
-   NF90(nf90_def_var_deflate(map_file%ncid, map_file%msk_varid, 1, 1, nc_deflate_level)) ! deflate
-   !
-   ! Infiltration map
-   !
-   if (infiltration) then
-       NF90(nf90_def_var(map_file%ncid, 'qinf', NF90_FLOAT, (/map_file%m_dimid, map_file%n_dimid/), map_file%qinf_varid))       
-       NF90(nf90_def_var_deflate(map_file%ncid, map_file%qinf_varid, 1, 1, nc_deflate_level)) ! deflate
-       NF90(nf90_put_att(map_file%ncid, map_file%qinf_varid, '_FillValue', FILL_VALUE))
-       NF90(nf90_put_att(map_file%ncid, map_file%qinf_varid, 'coordinates', 'x y'))
-       if (inftype == 'cna') then
-           NF90(nf90_put_att(map_file%ncid, map_file%qinf_varid, 'standard_name', 'S')) 
-           NF90(nf90_put_att(map_file%ncid, map_file%qinf_varid, 'long_name', 'moisture storage (S) capacity - Curve number')) 
-           NF90(nf90_put_att(map_file%ncid, map_file%qinf_varid, 'units', 'm'))
-       elseif (inftype == 'cnb') then
-           NF90(nf90_put_att(map_file%ncid, map_file%qinf_varid, 'standard_name', 'Smax')) 
-           NF90(nf90_put_att(map_file%ncid, map_file%qinf_varid, 'long_name', 'maximum moisture storage (Smax) capacity - Curve number')) 
-           NF90(nf90_put_att(map_file%ncid, map_file%qinf_varid, 'units', 'm'))
-       elseif (inftype == 'gai') then
-           NF90(nf90_put_att(map_file%ncid, map_file%qinf_varid, 'standard_name', 'psi')) 
-           NF90(nf90_put_att(map_file%ncid, map_file%qinf_varid, 'long_name', 'suction head at the wetting front - Green and Ampt')) 
-           NF90(nf90_put_att(map_file%ncid, map_file%qinf_varid, 'units', 'm'))
-       elseif (inftype == 'hor') then
-           NF90(nf90_put_att(map_file%ncid, map_file%qinf_varid, 'standard_name', 'f0'))
-           NF90(nf90_put_att(map_file%ncid, map_file%qinf_varid, 'long_name', 'initial infiltration rate - Horton'))
-           NF90(nf90_put_att(map_file%ncid, map_file%qinf_varid, 'units', 'm'))
-       elseif (inftype == 'bkt') then
-           NF90(nf90_put_att(map_file%ncid, map_file%qinf_varid, 'standard_name', 'bucket_capacity'))
-           NF90(nf90_put_att(map_file%ncid, map_file%qinf_varid, 'long_name', 'maximum bucket storage capacity'))
-           NF90(nf90_put_att(map_file%ncid, map_file%qinf_varid, 'units', 'mm'))
-       else
-           NF90(nf90_put_att(map_file%ncid, map_file%qinf_varid, 'standard_name', 'qinf'))
-           NF90(nf90_put_att(map_file%ncid, map_file%qinf_varid, 'long_name', 'infiltration rate - constant in time'))
-           NF90(nf90_put_att(map_file%ncid, map_file%qinf_varid, 'units', 'mm h-1'))
-       endif
-   endif
-   !
-   if (store_dynamic_bed_level) then
-      NF90(nf90_def_var(map_file%ncid, 'zb', NF90_FLOAT, (/map_file%m_dimid, map_file%n_dimid, map_file%time_dimid/), map_file%zb_varid)) ! bed level in cell centre
-      NF90(nf90_def_var_deflate(map_file%ncid, map_file%zb_varid, 1, 1, nc_deflate_level)) ! deflate
-      NF90(nf90_put_att(map_file%ncid, map_file%zb_varid, '_FillValue', FILL_VALUE))   
-      NF90(nf90_put_att(map_file%ncid, map_file%zb_varid, 'units', 'm'))
-      NF90(nf90_put_att(map_file%ncid, map_file%zb_varid, 'standard_name', 'altitude'))
-      NF90(nf90_put_att(map_file%ncid, map_file%zb_varid, 'long_name', 'Bed level above reference level'))   
-      NF90(nf90_put_att(map_file%ncid, map_file%zb_varid, 'coordinates', 'x y'))   
-   else      
-      NF90(nf90_def_var(map_file%ncid, 'zb', NF90_FLOAT, (/map_file%m_dimid, map_file%n_dimid/), map_file%zb_varid)) ! bed level in cell centre
-      NF90(nf90_def_var_deflate(map_file%ncid, map_file%zb_varid, 1, 1, nc_deflate_level)) ! deflate
-      NF90(nf90_put_att(map_file%ncid, map_file%zb_varid, '_FillValue', FILL_VALUE))   
-      NF90(nf90_put_att(map_file%ncid, map_file%zb_varid, 'units', 'm'))
-      NF90(nf90_put_att(map_file%ncid, map_file%zb_varid, 'standard_name', 'altitude'))
-      NF90(nf90_put_att(map_file%ncid, map_file%zb_varid, 'long_name', 'Bed level above reference level'))   
-      NF90(nf90_put_att(map_file%ncid, map_file%zb_varid, 'coordinates', 'x y'))   
-   endif
-   !
-   if (.not. subgrid) then
-      NF90(nf90_def_var(map_file%ncid, 'manning', NF90_FLOAT, (/map_file%m_dimid, map_file%n_dimid/), map_file%manning_varid)) ! bed level in cell centre
-      NF90(nf90_def_var_deflate(map_file%ncid, map_file%manning_varid, 1, 1, nc_deflate_level)) ! deflate
-      NF90(nf90_put_att(map_file%ncid, map_file%manning_varid, '_FillValue', FILL_VALUE))   
-      NF90(nf90_put_att(map_file%ncid, map_file%manning_varid, 'units', 's/m^1/3'))
-      NF90(nf90_put_att(map_file%ncid, map_file%manning_varid, 'standard_name', 'manning'))
-      NF90(nf90_put_att(map_file%ncid, map_file%manning_varid, 'long_name', 'manning_roughness'))   
-      NF90(nf90_put_att(map_file%ncid, map_file%manning_varid, 'coordinates', 'x y'))                               
-   endif
-   !
-   if (subgrid .and. store_hsubgrid .and. store_hmean) then
-      !
-      ! The subgrid slope (zmax - zmin) / sqrt(A) is used for making high-res flood maps
-      ! If the subgrid slope is lower than a threshold, the mean water depth in a cell
-      ! can be used instead of difference between the cell water level and the pixel heights
-      !
-      NF90(nf90_def_var(map_file%ncid, 'subgridslope', NF90_FLOAT, (/map_file%m_dimid, map_file%n_dimid/), map_file%subgridslope_varid)) ! (zmax - zmin) / dx      
-      NF90(nf90_def_var_deflate(map_file%ncid, map_file%subgridslope_varid, 1, 1, nc_deflate_level))
-      NF90(nf90_put_att(map_file%ncid, map_file%subgridslope_varid, '_FillValue', FILL_VALUE))   
-      NF90(nf90_put_att(map_file%ncid, map_file%subgridslope_varid, 'units', '-'))
-      NF90(nf90_put_att(map_file%ncid, map_file%subgridslope_varid, 'standard_name', 'subgrid_slope'))
-      NF90(nf90_put_att(map_file%ncid, map_file%subgridslope_varid, 'long_name', 'subgrid_slope'))
-      NF90(nf90_put_att(map_file%ncid, map_file%subgridslope_varid, 'coordinates', 'x y'))      
-      !
-   endif
-   !
-   ! Time variables   
-   !
-   trefstr_iso8601 = date_to_iso8601(trefstr)
-   NF90(nf90_def_var(map_file%ncid, 'time', NF90_FLOAT, (/map_file%time_dimid/), map_file%time_varid)) ! time
-   NF90(nf90_put_att(map_file%ncid, map_file%time_varid, 'units', 'seconds since ' // trim(trefstr_iso8601) ))  ! time stamp following ISO 8601
-   NF90(nf90_put_att(map_file%ncid, map_file%time_varid, 'standard_name', 'time'))     
-   NF90(nf90_put_att(map_file%ncid, map_file%time_varid, 'long_name', 'time_in_seconds_since_' // trim(trefstr_iso8601) ))  
-   !
-   ! Time varying map output
-   !
-   NF90(nf90_def_var(map_file%ncid, 'zs', NF90_FLOAT, (/map_file%m_dimid, map_file%n_dimid, map_file%time_dimid/), map_file%zs_varid)) ! time-varying water level map
-   NF90(nf90_def_var_deflate(map_file%ncid, map_file%zs_varid, 1, 1, nc_deflate_level)) ! deflate
-   NF90(nf90_put_att(map_file%ncid, map_file%zs_varid, '_FillValue', FILL_VALUE))
-   NF90(nf90_put_att(map_file%ncid, map_file%zs_varid, 'units', 'm'))
-   NF90(nf90_put_att(map_file%ncid, map_file%zs_varid, 'standard_name', 'sea_surface_height_above_reference_level')) 
-   NF90(nf90_put_att(map_file%ncid, map_file%zs_varid, 'long_name', 'Water level above reference level'))  
-   NF90(nf90_put_att(map_file%ncid, map_file%zs_varid, 'coordinates', 'x y'))
-   !
-   if (subgrid .eqv. .false. .or. store_hsubgrid .eqv. .true.) then   
-      NF90(nf90_def_var(map_file%ncid, 'h', NF90_FLOAT, (/map_file%m_dimid, map_file%n_dimid, map_file%time_dimid/), map_file%h_varid)) ! time-varying water depth map
-      NF90(nf90_def_var_deflate(map_file%ncid, map_file%h_varid, 1, 1, nc_deflate_level)) ! deflate
-      NF90(nf90_put_att(map_file%ncid, map_file%h_varid, '_FillValue', FILL_VALUE))
-      NF90(nf90_put_att(map_file%ncid, map_file%h_varid, 'units', 'm'))
-      NF90(nf90_put_att(map_file%ncid, map_file%h_varid, 'standard_name', 'water_depth')) 
-      NF90(nf90_put_att(map_file%ncid, map_file%h_varid, 'long_name', 'Water depth'))     
-      NF90(nf90_put_att(map_file%ncid, map_file%h_varid, 'coordinates', 'x y'))
-   endif
-   !
-   ! Velocity is optional
-   !
-   if (store_velocity) then
-      !
-      NF90(nf90_def_var(map_file%ncid, 'u', NF90_FLOAT, (/map_file%m_dimid, map_file%n_dimid, map_file%time_dimid/), map_file%u_varid)) ! time-varying u map
-      NF90(nf90_def_var_deflate(map_file%ncid, map_file%u_varid, 1, 1, nc_deflate_level)) ! deflate
-      NF90(nf90_put_att(map_file%ncid, map_file%u_varid, '_FillValue', FILL_VALUE))   
-      NF90(nf90_put_att(map_file%ncid, map_file%u_varid, 'units', 'm s-1'))
-      NF90(nf90_put_att(map_file%ncid, map_file%u_varid, 'standard_name', 'eastward_sea_water_velocity')) ! not truly eastward when rotated, eastward_sea_water_velocity
-      NF90(nf90_put_att(map_file%ncid, map_file%u_varid, 'long_name', 'Flow velocity x-component'))
-      NF90(nf90_put_att(map_file%ncid, map_file%u_varid, 'coordinates', 'x y'))
-      !
-      NF90(nf90_def_var(map_file%ncid, 'v', NF90_FLOAT, (/map_file%m_dimid, map_file%n_dimid, map_file%time_dimid/), map_file%v_varid)) ! time-varying u map 
-      NF90(nf90_def_var_deflate(map_file%ncid, map_file%v_varid, 1, 1, nc_deflate_level)) ! deflate
-      NF90(nf90_put_att(map_file%ncid, map_file%v_varid, '_FillValue', FILL_VALUE))   
-      NF90(nf90_put_att(map_file%ncid, map_file%v_varid, 'units', 'm s-1'))
-      NF90(nf90_put_att(map_file%ncid, map_file%v_varid, 'standard_name', 'northward_sea_water_velocity')) ! not truly eastward when rotated, eastward_sea_water_velocity
-      NF90(nf90_put_att(map_file%ncid, map_file%v_varid, 'long_name', 'Flow velocity y-component'))
-      NF90(nf90_put_att(map_file%ncid, map_file%v_varid, 'coordinates', 'x y'))
-   endif
-   !
-   ! Volume in subgrid cell and storage volume
-   !
-   if (subgrid) then
-      !
-      if (store_zvolume) then
-         !
-         NF90(nf90_def_var(map_file%ncid, 'subgrid_volume', NF90_FLOAT, (/map_file%m_dimid, map_file%n_dimid, map_file%time_dimid/), map_file%zvolume_varid)) ! time-varying z_volume map
-         NF90(nf90_def_var_deflate(map_file%ncid, map_file%zvolume_varid, 1, 1, nc_deflate_level)) ! deflate
-         NF90(nf90_put_att(map_file%ncid, map_file%zvolume_varid, '_FillValue', FILL_VALUE))
-         NF90(nf90_put_att(map_file%ncid, map_file%zvolume_varid, 'units', 'm3'))
-         NF90(nf90_put_att(map_file%ncid, map_file%zvolume_varid, 'standard_name', 'subgrid_volume_in_cell')) 
-         NF90(nf90_put_att(map_file%ncid, map_file%zvolume_varid, 'long_name', 'Subgrid volume in cell'))  
-         NF90(nf90_put_att(map_file%ncid, map_file%zvolume_varid, 'coordinates', 'x y'))
-         ! 
-      endif
-      !
-      if (store_storagevolume) then
-         !
-         NF90(nf90_def_var(map_file%ncid, 'storage_volume', NF90_FLOAT, (/map_file%m_dimid, map_file%n_dimid, map_file%time_dimid/), map_file%storagevolume_varid)) ! time-varying storage_volume map
-         NF90(nf90_def_var_deflate(map_file%ncid, map_file%storagevolume_varid, 1, 1, nc_deflate_level)) ! deflate
-         NF90(nf90_put_att(map_file%ncid, map_file%storagevolume_varid, '_FillValue', FILL_VALUE))
-         NF90(nf90_put_att(map_file%ncid, map_file%storagevolume_varid, 'units', 'm3'))
-         NF90(nf90_put_att(map_file%ncid, map_file%storagevolume_varid, 'standard_name', 'storage_volume_in_cell')) 
-         NF90(nf90_put_att(map_file%ncid, map_file%storagevolume_varid, 'long_name', 'Storage volume in cell'))  
-         NF90(nf90_put_att(map_file%ncid, map_file%storagevolume_varid, 'coordinates', 'x y'))
-         !           
-      endif
-      !      
-   endif
-   !
-   ! Store S_effective (only for CN method with recovery)
-   !
-   if (inftype == 'cnb') then
-      NF90(nf90_def_var(map_file%ncid, 'Seff', NF90_FLOAT, (/map_file%m_dimid, map_file%n_dimid, map_file%time_dimid/), map_file%Seff_varid)) ! time-varying S
-      NF90(nf90_def_var_deflate(map_file%ncid, map_file%Seff_varid, 1, 1, nc_deflate_level)) ! deflate
-      NF90(nf90_put_att(map_file%ncid, map_file%Seff_varid, '_FillValue', FILL_VALUE))   
-      NF90(nf90_put_att(map_file%ncid, map_file%Seff_varid, 'units', 'm'))
-      NF90(nf90_put_att(map_file%ncid, map_file%Seff_varid, 'standard_name', 'Se')) 
-      NF90(nf90_put_att(map_file%ncid, map_file%Seff_varid, 'long_name', 'current moisture storage (Se) capacity'))     
-      NF90(nf90_put_att(map_file%ncid, map_file%Seff_varid, 'coordinates', 'corner_x corner_y'))
-   endif
-   !
-   ! Store sigma (only for Green-Ampt)
-   !
-   if (inftype == 'gai') then
-      NF90(nf90_def_var(map_file%ncid, 'sigma', NF90_FLOAT, (/map_file%m_dimid, map_file%n_dimid, map_file%time_dimid/), map_file%Seff_varid)) ! time-varying sigma
-      NF90(nf90_put_att(map_file%ncid, map_file%Seff_varid, '_FillValue', FILL_VALUE))   
-      NF90(nf90_put_att(map_file%ncid, map_file%Seff_varid, 'units', '-'))
-      NF90(nf90_put_att(map_file%ncid, map_file%Seff_varid, 'standard_name', 'sigma')) 
-      NF90(nf90_put_att(map_file%ncid, map_file%Seff_varid, 'long_name', 'maximum soil moisture deficit'))     
-      NF90(nf90_put_att(map_file%ncid, map_file%Seff_varid, 'coordinates', 'corner_x corner_y'))
-   endif
-   !
-   ! Store current infiltration capacity (only for Horton)
-   !
-   if (inftype == 'hor') then
-      NF90(nf90_def_var(map_file%ncid, 'f', NF90_FLOAT, (/map_file%m_dimid, map_file%n_dimid, map_file%time_dimid/), map_file%Seff_varid)) ! time-varying f
-      NF90(nf90_put_att(map_file%ncid, map_file%Seff_varid, '_FillValue', FILL_VALUE))
-      NF90(nf90_put_att(map_file%ncid, map_file%Seff_varid, 'units', 'mm h-1'))
-      NF90(nf90_put_att(map_file%ncid, map_file%Seff_varid, 'standard_name', 'f'))
-      NF90(nf90_put_att(map_file%ncid, map_file%Seff_varid, 'long_name', 'current infiltration capacity'))
-      NF90(nf90_put_att(map_file%ncid, map_file%Seff_varid, 'coordinates', 'corner_x corner_y'))
-   endif
-   !
-   ! Store current bucket storage (only for Bucket model)
-   !
-   if (inftype == 'bkt') then
-      NF90(nf90_def_var(map_file%ncid, 'bucket_volume', NF90_FLOAT, (/map_file%m_dimid, map_file%n_dimid, map_file%time_dimid/), map_file%Seff_varid)) ! time-varying bucket volume
-      NF90(nf90_put_att(map_file%ncid, map_file%Seff_varid, '_FillValue', FILL_VALUE))
-      NF90(nf90_put_att(map_file%ncid, map_file%Seff_varid, 'units', 'm'))
-      NF90(nf90_put_att(map_file%ncid, map_file%Seff_varid, 'standard_name', 'bucket_volume'))
-      NF90(nf90_put_att(map_file%ncid, map_file%Seff_varid, 'long_name', 'current bucket storage'))
-      NF90(nf90_put_att(map_file%ncid, map_file%Seff_varid, 'coordinates', 'corner_x corner_y'))
-   endif
-   !
-   ! Time varying spatial output max
-   !
-   if (store_maximum_waterlevel) then
-      NF90(nf90_def_var(map_file%ncid, 'timemax', NF90_FLOAT, (/map_file%timemax_dimid/), map_file%timemax_varid)) ! time
-      NF90(nf90_put_att(map_file%ncid, map_file%timemax_varid, 'units', 'seconds since ' // trim(trefstr_iso8601) ))  ! time stamp following ISO 8601
-      NF90(nf90_put_att(map_file%ncid, map_file%timemax_varid, 'standard_name', 'time'))     
-      NF90(nf90_put_att(map_file%ncid, map_file%timemax_varid, 'long_name', 'time_in_seconds_since_' // trim(trefstr_iso8601) ))  
-   endif
-   !
-   if (store_maximum_waterlevel) then
-      NF90(nf90_def_var(map_file%ncid, 'zsmax', NF90_FLOAT, (/map_file%m_dimid, map_file%n_dimid, map_file%timemax_dimid/), map_file%zsmax_varid)) ! time-varying maximum water level map
-      NF90(nf90_def_var_deflate(map_file%ncid, map_file%zsmax_varid, 1, 1, nc_deflate_level)) ! deflate
-      NF90(nf90_put_att(map_file%ncid, map_file%zsmax_varid, '_FillValue', FILL_VALUE))
-      NF90(nf90_put_att(map_file%ncid, map_file%zsmax_varid, 'units', 'm'))
-      NF90(nf90_put_att(map_file%ncid, map_file%zsmax_varid, 'standard_name', 'maximum_sea_surface_height_above_reference_level')) 
-      NF90(nf90_put_att(map_file%ncid, map_file%zsmax_varid, 'long_name', 'Maximum water level'))
-      NF90(nf90_put_att(map_file%ncid, map_file%zsmax_varid, 'coordinates', 'x y'))
-   endif
-   !
-   if (store_cumulative_precipitation) then
-      NF90(nf90_def_var(map_file%ncid, 'cumprcp', NF90_FLOAT, (/map_file%m_dimid, map_file%n_dimid, map_file%timemax_dimid/), map_file%cumprcp_varid)) ! time-varying maximum water level map
-      NF90(nf90_def_var_deflate(map_file%ncid, map_file%cumprcp_varid, 1, 1, nc_deflate_level)) ! deflate
-      NF90(nf90_put_att(map_file%ncid, map_file%cumprcp_varid, '_FillValue', FILL_VALUE))
-      NF90(nf90_put_att(map_file%ncid, map_file%cumprcp_varid, 'units', 'm'))
-      NF90(nf90_put_att(map_file%ncid, map_file%cumprcp_varid, 'long_name', 'cumulative_precipitation_depth')) 
-      NF90(nf90_put_att(map_file%ncid, map_file%cumprcp_varid, 'standard_name', 'Cumulative precipitation depth')) 
-      NF90(nf90_put_att(map_file%ncid, map_file%cumprcp_varid, 'cell_methods', 'time: sum'))       
-      NF90(nf90_put_att(map_file%ncid, map_file%cumprcp_varid, 'coordinates', 'x y'))
-   endif
-   !
-   if (store_cumulative_urban_drainage .and. urban_drainage) then
-      NF90(nf90_def_var(map_file%ncid, 'urban_drainage_cumulative_depth', NF90_FLOAT, (/map_file%m_dimid, map_file%n_dimid, map_file%timemax_dimid/), map_file%cumulative_urbdrain_varid))
-      NF90(nf90_def_var_deflate(map_file%ncid, map_file%cumulative_urbdrain_varid, 1, 1, nc_deflate_level))
-      NF90(nf90_put_att(map_file%ncid, map_file%cumulative_urbdrain_varid, '_FillValue', FILL_VALUE))
-      NF90(nf90_put_att(map_file%ncid, map_file%cumulative_urbdrain_varid, 'units', 'm'))
-      NF90(nf90_put_att(map_file%ncid, map_file%cumulative_urbdrain_varid, 'long_name', 'cumulative_urban_drainage_depth'))
-      NF90(nf90_put_att(map_file%ncid, map_file%cumulative_urbdrain_varid, 'cell_methods', 'time: sum'))
-      NF90(nf90_put_att(map_file%ncid, map_file%cumulative_urbdrain_varid, 'coordinates', 'x y'))
-   endif
-   !
-   if (store_twet) then
-      NF90(nf90_def_var(map_file%ncid, 'tmax', NF90_FLOAT, (/map_file%m_dimid, map_file%n_dimid, map_file%timemax_dimid/), map_file%tmax_varid)) ! time-varying duration wet cell
-      NF90(nf90_def_var_deflate(map_file%ncid, map_file%tmax_varid, 1, 1, nc_deflate_level)) ! deflate
-      NF90(nf90_put_att(map_file%ncid, map_file%tmax_varid, '_FillValue', FILL_VALUE))
-      NF90(nf90_put_att(map_file%ncid, map_file%tmax_varid, 'units', 'seconds'))
-      NF90(nf90_put_att(map_file%ncid, map_file%tmax_varid, 'standard_name', 'duration_wet_cell')) 
-      NF90(nf90_put_att(map_file%ncid, map_file%tmax_varid, 'long_name', 'Duration cell is considered wet'))  
-      NF90(nf90_put_att(map_file%ncid, map_file%tmax_varid, 'cell_methods', 'time: sum'))    
-      NF90(nf90_put_att(map_file%ncid, map_file%tmax_varid, 'coordinates', 'x y'))
-   endif
-   !
-   if (store_t_zsmax) then
-      NF90(nf90_def_var(map_file%ncid, 't_zsmax', NF90_FLOAT, (/map_file%m_dimid, map_file%n_dimid, map_file%timemax_dimid/), map_file%t_zsmax_varid)) ! when zsmax occured
-      NF90(nf90_def_var_deflate(map_file%ncid, map_file%t_zsmax_varid, 1, 1, nc_deflate_level)) ! deflate
-      NF90(nf90_put_att(map_file%ncid, map_file%t_zsmax_varid, '_FillValue', FILL_VALUE))
-      NF90(nf90_put_att(map_file%ncid, map_file%t_zsmax_varid, 'units', 'seconds since ' // trim(trefstr_iso8601) ))  ! time stamp following ISO 8601
-      NF90(nf90_put_att(map_file%ncid, map_file%t_zsmax_varid, 'standard_name', 'time_of_max_water_level')) 
-      NF90(nf90_put_att(map_file%ncid, map_file%t_zsmax_varid, 'long_name', 'Moment when zsmax occurs'))  
-      NF90(nf90_put_att(map_file%ncid, map_file%t_zsmax_varid, 'cell_methods', 'time: max'))    
-      NF90(nf90_put_att(map_file%ncid, map_file%t_zsmax_varid, 'coordinates', 'x y'))
-   endif
-   !
-   if (store_maximum_waterlevel) then
-      if (subgrid .eqv. .false. .or. store_hsubgrid .eqv. .true.) then   
-         NF90(nf90_def_var(map_file%ncid, 'hmax', NF90_FLOAT, (/map_file%m_dimid, map_file%n_dimid, map_file%timemax_dimid/), map_file%hmax_varid)) ! time-varying maximum water depth map
-         NF90(nf90_def_var_deflate(map_file%ncid, map_file%hmax_varid, 1, 1, nc_deflate_level)) ! deflate
-         NF90(nf90_put_att(map_file%ncid, map_file%hmax_varid, '_FillValue', FILL_VALUE))   
-         NF90(nf90_put_att(map_file%ncid, map_file%hmax_varid, 'units', 'm'))
-         NF90(nf90_put_att(map_file%ncid, map_file%hmax_varid, 'standard_name', 'sea_floor_depth_below_sea_surface')) 
-         NF90(nf90_put_att(map_file%ncid, map_file%hmax_varid, 'long_name', 'Maximum water depth')) 
-         NF90(nf90_put_att(map_file%ncid, map_file%hmax_varid, 'cell_methods', 'time: maximum'))    
-         NF90(nf90_put_att(map_file%ncid, map_file%hmax_varid, 'coordinates', 'x y'))
-      endif
-   endif
-   !
-   if (store_maximum_velocity) then
-      NF90(nf90_def_var(map_file%ncid, 'vmax', NF90_FLOAT, (/map_file%m_dimid, map_file%n_dimid, map_file%timemax_dimid/), map_file%vmax_varid)) ! maximum flow velocity map
-      NF90(nf90_def_var_deflate(map_file%ncid, map_file%vmax_varid, 1, 1, nc_deflate_level)) ! deflate
-      NF90(nf90_put_att(map_file%ncid, map_file%vmax_varid, '_FillValue', FILL_VALUE))   
-      NF90(nf90_put_att(map_file%ncid, map_file%vmax_varid, 'units', 'm s-1'))
-      NF90(nf90_put_att(map_file%ncid, map_file%vmax_varid, 'standard_name', 'maximum_flow_velocity')) ! no standard name available
-      NF90(nf90_put_att(map_file%ncid, map_file%vmax_varid, 'long_name', 'Maximum flow velocity')) 
-      NF90(nf90_put_att(map_file%ncid, map_file%vmax_varid, 'cell_methods', 'time: maximum'))
-      NF90(nf90_put_att(map_file%ncid, map_file%vmax_varid, 'coordinates', 'x y'))
-   endif
-   !
-   if (store_maximum_flux) then
-      NF90(nf90_def_var(map_file%ncid, 'qmax', NF90_FLOAT, (/map_file%m_dimid, map_file%n_dimid, map_file%timemax_dimid/), map_file%qmax_varid)) ! maximum flux map
-      NF90(nf90_def_var_deflate(map_file%ncid, map_file%qmax_varid, 1, 1, nc_deflate_level)) ! deflate
-      NF90(nf90_put_att(map_file%ncid, map_file%qmax_varid, '_FillValue', FILL_VALUE))   
-      NF90(nf90_put_att(map_file%ncid, map_file%qmax_varid, 'units', 'm^2 s-1'))
-      NF90(nf90_put_att(map_file%ncid, map_file%qmax_varid, 'standard_name', 'maximum_flux')) ! no standard name available
-      NF90(nf90_put_att(map_file%ncid, map_file%qmax_varid, 'long_name', 'maximum_flux')) 
-      NF90(nf90_put_att(map_file%ncid, map_file%qmax_varid, 'cell_methods', 'time: maximum'))
-      NF90(nf90_put_att(map_file%ncid, map_file%qmax_varid, 'coordinates', 'x y'))
-   endif
-   !
-   if (timestep_analysis) then
-      !
-      ! Average time step (written once at end of simulation, no time dimension)
-      NF90(nf90_def_var(map_file%ncid, 'average_required_timestep', NF90_FLOAT, (/map_file%m_dimid, map_file%n_dimid/), map_file%average_required_timestep_varid))
-      NF90(nf90_def_var_deflate(map_file%ncid, map_file%average_required_timestep_varid, 1, 1, nc_deflate_level)) ! deflate
-      NF90(nf90_put_att(map_file%ncid, map_file%average_required_timestep_varid, '_FillValue', FILL_VALUE))
-      NF90(nf90_put_att(map_file%ncid, map_file%average_required_timestep_varid, 'units', 's'))
-      NF90(nf90_put_att(map_file%ncid, map_file%average_required_timestep_varid, 'standard_name', 'average_required_timestep'))
-      NF90(nf90_put_att(map_file%ncid, map_file%average_required_timestep_varid, 'long_name', 'Average required time step'))
-      NF90(nf90_put_att(map_file%ncid, map_file%average_required_timestep_varid, 'cell_methods', 'time: average'))
-      NF90(nf90_put_att(map_file%ncid, map_file%average_required_timestep_varid, 'coordinates', 'x y'))
-      !
-      ! Times limiting (written once at end of simulation, no time dimension)
-      NF90(nf90_def_var(map_file%ncid, 'percentage_limiting_timestep', NF90_FLOAT, (/map_file%m_dimid, map_file%n_dimid/), map_file%percentage_limiting_varid))
-      NF90(nf90_def_var_deflate(map_file%ncid, map_file%percentage_limiting_varid, 1, 1, nc_deflate_level)) ! deflate
-      NF90(nf90_put_att(map_file%ncid, map_file%percentage_limiting_varid, '_FillValue', FILL_VALUE))
-      NF90(nf90_put_att(map_file%ncid, map_file%percentage_limiting_varid, 'units', '%'))
-      NF90(nf90_put_att(map_file%ncid, map_file%percentage_limiting_varid, 'standard_name', 'percentage_limiting_timestep'))
-      NF90(nf90_put_att(map_file%ncid, map_file%percentage_limiting_varid, 'long_name', 'Fraction of timesteps cell was limiting'))
-      NF90(nf90_put_att(map_file%ncid, map_file%percentage_limiting_varid, 'cell_methods', 'time: maximum'))
-      NF90(nf90_put_att(map_file%ncid, map_file%percentage_limiting_varid, 'coordinates', 'x y'))
-      !
-   endif
-   !
-   if (store_cumulative_precipitation) then
-       NF90(nf90_def_var(map_file%ncid, 'cuminf', NF90_FLOAT, (/map_file%m_dimid, map_file%n_dimid, map_file%timemax_dimid/), map_file%cuminf_varid)) ! time-varying cumulative infiltration map
-       NF90(nf90_def_var_deflate(map_file%ncid, map_file%cuminf_varid, 1, 1, nc_deflate_level)) ! deflate
-       NF90(nf90_put_att(map_file%ncid, map_file%cuminf_varid, '_FillValue', FILL_VALUE))          
-       NF90(nf90_put_att(map_file%ncid, map_file%cuminf_varid, 'units', 'm'))
-       NF90(nf90_put_att(map_file%ncid, map_file%cuminf_varid, 'standard_name', 'cumulative_infiltration_depth')) 
-       NF90(nf90_put_att(map_file%ncid, map_file%cuminf_varid, 'long_name', 'Cumulative infiltration depth')) 
-       NF90(nf90_put_att(map_file%ncid, map_file%cuminf_varid, 'cell_methods', 'time: sum'))     
-       NF90(nf90_put_att(map_file%ncid, map_file%cuminf_varid, 'coordinates', 'x y'))
-   endif
-   !
-   if (store_meteo) then  
-      !
-      if (wind) then
-         !
-         NF90(nf90_def_var(map_file%ncid, 'wind_u', NF90_FLOAT, (/map_file%m_dimid, map_file%n_dimid, map_file%time_dimid/), map_file%wind_u_varid)) ! cumulative precipitation map
-         NF90(nf90_def_var_deflate(map_file%ncid, map_file%wind_u_varid, 1, 1, nc_deflate_level)) ! deflate
-         NF90(nf90_put_att(map_file%ncid, map_file%wind_u_varid, '_FillValue', FILL_VALUE))          
-         NF90(nf90_put_att(map_file%ncid, map_file%wind_u_varid, 'units', 'm s-1'))
-         NF90(nf90_put_att(map_file%ncid, map_file%wind_u_varid, 'standard_name', 'eastward_wind'))
-         NF90(nf90_put_att(map_file%ncid, map_file%wind_u_varid, 'long_name', 'Wind speed u-component')) 
-         NF90(nf90_put_att(map_file%ncid, map_file%wind_u_varid, 'coordinates', 'x y'))
-         !
-         NF90(nf90_def_var(map_file%ncid, 'wind_v', NF90_FLOAT, (/map_file%m_dimid, map_file%n_dimid, map_file%time_dimid/), map_file%wind_v_varid)) ! cumulative precipitation map
-         NF90(nf90_def_var_deflate(map_file%ncid, map_file%wind_v_varid, 1, 1, nc_deflate_level)) ! deflate
-         NF90(nf90_put_att(map_file%ncid, map_file%wind_v_varid, '_FillValue', FILL_VALUE))          
-         NF90(nf90_put_att(map_file%ncid, map_file%wind_v_varid, 'units', 'm s-1'))
-         NF90(nf90_put_att(map_file%ncid, map_file%wind_v_varid, 'standard_name', 'northward_wind'))
-         NF90(nf90_put_att(map_file%ncid, map_file%wind_v_varid, 'long_name', 'Wind speed v-component')) 
-         NF90(nf90_put_att(map_file%ncid, map_file%wind_v_varid, 'coordinates', 'x y'))
-         !
-         if (meteo3d .and. store_wind_max) then  
-            NF90(nf90_def_var(map_file%ncid, 'windmax', NF90_FLOAT, (/map_file%m_dimid, map_file%n_dimid/), map_file%windmax_varid)) ! maximum wind speed 
-            NF90(nf90_def_var_deflate(map_file%ncid, map_file%windmax_varid, 1, 1, nc_deflate_level)) ! deflate
-            NF90(nf90_put_att(map_file%ncid, map_file%windmax_varid, '_FillValue', FILL_VALUE))          
-            NF90(nf90_put_att(map_file%ncid, map_file%windmax_varid, 'units', 'm s-1'))
-            NF90(nf90_put_att(map_file%ncid, map_file%windmax_varid, 'long_name', 'Maximum wind speed')) 
-            NF90(nf90_put_att(map_file%ncid, map_file%windmax_varid, 'cell_methods', 'time: sum'))       
-            NF90(nf90_put_att(map_file%ncid, map_file%windmax_varid, 'coordinates', 'x y'))
-        endif
-         !
-      endif
-      !
-      if (patmos) then
-         !
-         NF90(nf90_def_var(map_file%ncid, 'surface_air_pressure', NF90_FLOAT, (/map_file%m_dimid, map_file%n_dimid, map_file%time_dimid/), map_file%patm_varid)) ! cumulative precipitation map
-         NF90(nf90_def_var_deflate(map_file%ncid, map_file%patm_varid, 1, 1, nc_deflate_level)) ! deflate
-         NF90(nf90_put_att(map_file%ncid, map_file%patm_varid, '_FillValue', FILL_VALUE))          
-         NF90(nf90_put_att(map_file%ncid, map_file%patm_varid, 'units', 'N m-2'))
-         NF90(nf90_put_att(map_file%ncid, map_file%patm_varid, 'standard_name', 'surface_air_pressure'))
-         NF90(nf90_put_att(map_file%ncid, map_file%patm_varid, 'long_name', 'Surface air pressure')) 
-         NF90(nf90_put_att(map_file%ncid, map_file%patm_varid, 'coordinates', 'x y'))
-         !
-      endif   
-      !
-      if (precip) then
-         !
-         NF90(nf90_def_var(map_file%ncid, 'precipitation_rate', NF90_FLOAT, (/map_file%m_dimid, map_file%n_dimid, map_file%time_dimid/), map_file%precip_varid)) ! cumulative precipitation map
-         NF90(nf90_def_var_deflate(map_file%ncid, map_file%precip_varid, 1, 1, nc_deflate_level)) ! deflate
-         NF90(nf90_put_att(map_file%ncid, map_file%precip_varid, '_FillValue', FILL_VALUE))          
-         NF90(nf90_put_att(map_file%ncid, map_file%precip_varid, 'units', 'mm h-1'))
-         NF90(nf90_put_att(map_file%ncid, map_file%precip_varid, 'standard_name', 'precipitation_rate'))
-         NF90(nf90_put_att(map_file%ncid, map_file%precip_varid, 'long_name', 'precipitation_rate')) 
-         NF90(nf90_put_att(map_file%ncid, map_file%precip_varid, 'coordinates', 'x y'))
-         !
-      endif   
-      !
-   endif
-   !
-   if (snapwave) then  
-      !
-      NF90(nf90_def_var(map_file%ncid, 'snapwavemsk', NF90_FLOAT, (/map_file%m_dimid, map_file%n_dimid/), map_file%snapwavemsk_varid)) ! input snapwave msk value in cell centre
-      NF90(nf90_def_var_deflate(map_file%ncid, map_file%snapwavemsk_varid, 1, 1, nc_deflate_level)) ! deflate
-      NF90(nf90_put_att(map_file%ncid, map_file%snapwavemsk_varid, '_FillValue', FILL_VALUE))          
-      NF90(nf90_put_att(map_file%ncid, map_file%snapwavemsk_varid, 'units', '-'))
-      NF90(nf90_put_att(map_file%ncid, map_file%snapwavemsk_varid, 'standard_name', 'snapwavemask'))
-      NF90(nf90_put_att(map_file%ncid, map_file%snapwavemsk_varid, 'long_name', 'SnapWave active cells mask')) 
-      NF90(nf90_put_att(map_file%ncid, map_file%snapwavemsk_varid, 'description', 'inactive=0, active=1, wave_boundary=2, neumann_boundary=3'))       
-      NF90(nf90_put_att(map_file%ncid, map_file%snapwavemsk_varid, 'coordinates', 'x y'))      
-      !
-      NF90(nf90_def_var(map_file%ncid, 'hm0', NF90_FLOAT, (/map_file%m_dimid, map_file%n_dimid, map_file%time_dimid/), map_file%hm0_varid))
-      NF90(nf90_def_var_deflate(map_file%ncid, map_file%hm0_varid, 1, 1, nc_deflate_level)) ! deflate
-      NF90(nf90_put_att(map_file%ncid, map_file%hm0_varid, '_FillValue', FILL_VALUE))          
-      NF90(nf90_put_att(map_file%ncid, map_file%hm0_varid, 'units', 'm'))
-      NF90(nf90_put_att(map_file%ncid, map_file%hm0_varid, 'standard_name', 'hm0_wave_height'))
-      NF90(nf90_put_att(map_file%ncid, map_file%hm0_varid, 'long_name', 'Hm0 wave height')) 
-      NF90(nf90_put_att(map_file%ncid, map_file%hm0_varid, 'coordinates', 'x y'))
-      !
-      NF90(nf90_def_var(map_file%ncid, 'hm0ig', NF90_FLOAT, (/map_file%m_dimid, map_file%n_dimid, map_file%time_dimid/), map_file%hm0ig_varid))
-      NF90(nf90_def_var_deflate(map_file%ncid, map_file%hm0ig_varid, 1, 1, nc_deflate_level)) ! deflate
-      NF90(nf90_put_att(map_file%ncid, map_file%hm0ig_varid, '_FillValue', FILL_VALUE))          
-      NF90(nf90_put_att(map_file%ncid, map_file%hm0ig_varid, 'units', 'm'))
-      NF90(nf90_put_att(map_file%ncid, map_file%hm0ig_varid, 'standard_name', 'hm0_ig_wave_height'))
-      NF90(nf90_put_att(map_file%ncid, map_file%hm0ig_varid, 'long_name', 'Hm0 infragravity wave height')) 
-      NF90(nf90_put_att(map_file%ncid, map_file%hm0ig_varid, 'coordinates', 'x y'))
-      !
-      if (store_wave_forces) then
-         !
-         NF90(nf90_def_var(map_file%ncid, 'fwx', NF90_FLOAT, (/map_file%m_dimid, map_file%n_dimid, map_file%time_dimid/), map_file%fwx_varid))
-         NF90(nf90_def_var_deflate(map_file%ncid, map_file%fwx_varid, 1, 1, nc_deflate_level)) ! deflate
-         NF90(nf90_put_att(map_file%ncid, map_file%fwx_varid, '_FillValue', FILL_VALUE))          
-         NF90(nf90_put_att(map_file%ncid, map_file%fwx_varid, 'units', 'm'))
-         NF90(nf90_put_att(map_file%ncid, map_file%fwx_varid, 'standard_name', 'wave_force_x'))
-         NF90(nf90_put_att(map_file%ncid, map_file%fwx_varid, 'long_name', 'Wave force x-component'))
-         NF90(nf90_put_att(map_file%ncid, map_file%fwx_varid, 'coordinates', 'x y'))
-         !
-         NF90(nf90_def_var(map_file%ncid, 'fwy', NF90_FLOAT, (/map_file%m_dimid, map_file%n_dimid, map_file%time_dimid/), map_file%fwy_varid))
-         NF90(nf90_def_var_deflate(map_file%ncid, map_file%fwy_varid, 1, 1, nc_deflate_level)) ! deflate
-         NF90(nf90_put_att(map_file%ncid, map_file%fwy_varid, '_FillValue', FILL_VALUE))          
-         NF90(nf90_put_att(map_file%ncid, map_file%fwy_varid, 'units', 'm'))
-         NF90(nf90_put_att(map_file%ncid, map_file%fwy_varid, 'standard_name', 'wave_force_y'))
-         NF90(nf90_put_att(map_file%ncid, map_file%fwy_varid, 'long_name', 'Wave force y-component'))
-         NF90(nf90_put_att(map_file%ncid, map_file%fwy_varid, 'coordinates', 'x y'))
-         !
-         NF90(nf90_def_var(map_file%ncid, 'tp', NF90_FLOAT, (/map_file%m_dimid, map_file%n_dimid, map_file%time_dimid/), map_file%tp_varid))
-         NF90(nf90_def_var_deflate(map_file%ncid, map_file%tp_varid, 1, 1, nc_deflate_level)) ! deflate
-         NF90(nf90_put_att(map_file%ncid, map_file%tp_varid, '_FillValue', FILL_VALUE))          
-         NF90(nf90_put_att(map_file%ncid, map_file%tp_varid, 'units', 'm'))
-         NF90(nf90_put_att(map_file%ncid, map_file%tp_varid, 'standard_name', 'peak_wave_period'))
-         NF90(nf90_put_att(map_file%ncid, map_file%tp_varid, 'long_name', 'Peak wave period')) 
-         NF90(nf90_put_att(map_file%ncid, map_file%tp_varid, 'coordinates', 'x y'))
-         !
-         NF90(nf90_def_var(map_file%ncid, 'tpig', NF90_FLOAT, (/map_file%m_dimid, map_file%n_dimid, map_file%time_dimid/), map_file%tpig_varid))
-         NF90(nf90_def_var_deflate(map_file%ncid, map_file%tpig_varid, 1, 1, nc_deflate_level)) ! deflate
-         NF90(nf90_put_att(map_file%ncid, map_file%tpig_varid, '_FillValue', FILL_VALUE))          
-         NF90(nf90_put_att(map_file%ncid, map_file%tpig_varid, 'units', 'm'))
-         NF90(nf90_put_att(map_file%ncid, map_file%tpig_varid, 'standard_name', 'peak_ig_wave_period'))
-         NF90(nf90_put_att(map_file%ncid, map_file%tpig_varid, 'long_name', 'Peak infragravity wave period'))
-         NF90(nf90_put_att(map_file%ncid, map_file%tpig_varid, 'coordinates', 'x y'))
-         !
-         NF90(nf90_def_var(map_file%ncid, 'beta', NF90_FLOAT, (/map_file%m_dimid, map_file%n_dimid, map_file%time_dimid/), map_file%beta_varid))
-         NF90(nf90_def_var_deflate(map_file%ncid, map_file%beta_varid, 1, 1, nc_deflate_level)) ! deflate
-         NF90(nf90_put_att(map_file%ncid, map_file%beta_varid, '_FillValue', FILL_VALUE))          
-         NF90(nf90_put_att(map_file%ncid, map_file%beta_varid, 'units', '-'))
-         NF90(nf90_put_att(map_file%ncid, map_file%beta_varid, 'standard_name', 'directionally_averaged_local_bed_slope'))
-         NF90(nf90_put_att(map_file%ncid, map_file%beta_varid, 'long_name', 'Mean local bed slope'))
-         NF90(nf90_put_att(map_file%ncid, map_file%beta_varid, 'coordinates', 'x y'))
-         !
-         NF90(nf90_def_var(map_file%ncid, 'snapwavedepth', NF90_FLOAT, (/map_file%m_dimid, map_file%n_dimid, map_file%time_dimid/), map_file%snapwavedepth_varid))
-         NF90(nf90_def_var_deflate(map_file%ncid, map_file%snapwavedepth_varid, 1, 1, nc_deflate_level)) ! deflate
-         NF90(nf90_put_att(map_file%ncid, map_file%snapwavedepth_varid, '_FillValue', FILL_VALUE))          
-         NF90(nf90_put_att(map_file%ncid, map_file%snapwavedepth_varid, 'units', 'm'))
-         NF90(nf90_put_att(map_file%ncid, map_file%snapwavedepth_varid, 'standard_name', 'snapwave_waterdepth'))
-         NF90(nf90_put_att(map_file%ncid, map_file%snapwavedepth_varid, 'long_name', 'Interpolated water depth in Snapwave'))
-         NF90(nf90_put_att(map_file%ncid, map_file%snapwavedepth_varid, 'coordinates', 'x y'))     
-         !         
-      endif
-      !
-      if (wavemaker) then
-         !
-         NF90(nf90_def_var(map_file%ncid, 'zsm', NF90_FLOAT, (/map_file%m_dimid, map_file%n_dimid, map_file%time_dimid/), map_file%zsm_varid))
-         NF90(nf90_def_var_deflate(map_file%ncid, map_file%zsm_varid, 1, 1, nc_deflate_level)) ! deflate
-         NF90(nf90_put_att(map_file%ncid, map_file%zsm_varid, '_FillValue', FILL_VALUE))          
-         NF90(nf90_put_att(map_file%ncid, map_file%zsm_varid, 'units', 'm'))
-         NF90(nf90_put_att(map_file%ncid, map_file%zsm_varid, 'standard_name', 'mean_water_level'))
-         NF90(nf90_put_att(map_file%ncid, map_file%zsm_varid, 'long_name', 'Filtered water level')) 
-         NF90(nf90_put_att(map_file%ncid, map_file%zsm_varid, 'coordinates', 'x y'))
-         !
-      endif
-      !
-   endif
-   !
-   if (store_tsunami_arrival_time) then
-      ! 
-      NF90(nf90_def_var(map_file%ncid, 'tsunami_arrival_time', NF90_FLOAT, (/map_file%m_dimid, map_file%n_dimid/), map_file%tsunami_arrival_time_varid))
-      NF90(nf90_put_att(map_file%ncid, map_file%tsunami_arrival_time_varid, '_FillValue', FILL_VALUE))      
-      NF90(nf90_put_att(map_file%ncid, map_file%tsunami_arrival_time_varid, 'units', '-'))
-      NF90(nf90_put_att(map_file%ncid, map_file%tsunami_arrival_time_varid, 'standard_name', 'tsunami_arrival_time'))
-      NF90(nf90_put_att(map_file%ncid, map_file%tsunami_arrival_time_varid, 'long_name', 'Tsunami arrival time')) 
-      NF90(nf90_put_att(map_file%ncid, map_file%tsunami_arrival_time_varid, 'coordinates', 'x y'))   
-      NF90(nf90_def_var_deflate(map_file%ncid, map_file%tsunami_arrival_time_varid, 1, 1, nc_deflate_level)) ! deflate
-      !
-   endif
-   !
-   if (nonhydrostatic) then
-      !
-      NF90(nf90_def_var(map_file%ncid, 'pnonh', NF90_FLOAT, (/map_file%m_dimid, map_file%n_dimid, map_file%time_dimid/), map_file%pnonh_varid))
-      NF90(nf90_def_var_deflate(map_file%ncid, map_file%pnonh_varid, 1, 1, nc_deflate_level)) ! deflate
-      NF90(nf90_put_att(map_file%ncid, map_file%pnonh_varid, '_FillValue', FILL_VALUE))          
-      NF90(nf90_put_att(map_file%ncid, map_file%pnonh_varid, 'units', 'N m-2'))
-      NF90(nf90_put_att(map_file%ncid, map_file%pnonh_varid, 'long_name', 'Non-hydrostatic pressure')) 
-      NF90(nf90_put_att(map_file%ncid, map_file%pnonh_varid, 'coordinates', 'x y'))
-      ! 
-   endif
-   !
-   ! Add for final output:
-   !
-   NF90(nf90_def_var(map_file%ncid, 'total_runtime', NF90_FLOAT, (/map_file%runtime_dimid/),map_file%total_runtime_varid))
-   NF90(nf90_put_att(map_file%ncid, map_file%total_runtime_varid, 'units', 's'))   
-   NF90(nf90_put_att(map_file%ncid, map_file%total_runtime_varid, 'long_name', 'Total model runtime (s)'))
-   !
-   NF90(nf90_def_var(map_file%ncid, 'average_dt', NF90_FLOAT, (/map_file%runtime_dimid/), map_file%average_dt_varid))
-   NF90(nf90_put_att(map_file%ncid, map_file%total_runtime_varid, 'units', 's'))   
-   NF90(nf90_put_att(map_file%ncid, map_file%total_runtime_varid, 'long_name', 'Average model time step (s)'))   
-   !
-   NF90(nf90_def_var(map_file%ncid, 'status', NF90_FLOAT, (/map_file%runtime_dimid/), map_file%status_varid))
-   NF90(nf90_put_att(map_file%ncid, map_file%status_varid, 'units', '-'))   
-   NF90(nf90_put_att(map_file%ncid, map_file%status_varid, 'long_name', 'status of SFINCS simulation - 0 is no error'))     
-   ! 
-   ! Finish definitions
-   NF90(nf90_enddef(map_file%ncid))
-   ! 
-   ! Write grid to file
-   !
-   allocate(xz(mmax, nmax))
-   allocate(yz(mmax, nmax))
-   allocate(xg(mmax + 1, nmax + 1))
-   allocate(yg(mmax + 1, nmax + 1))
-   !
-   do n = 1, nmax
-      do m = 1, mmax
-         xz(m, n) = x0 + cosrot*(1.0*(m - 0.5))*dx - sinrot*(1.0*(n - 0.5))*dy
-         yz(m, n) = y0 + sinrot*(1.0*(m - 0.5))*dx + cosrot*(1.0*(n - 0.5))*dy
-      enddo
-   enddo   
-   !
-   do n = 1, nmax + 1
-      do m = 1, mmax + 1
-         xg(m, n) = x0 + cosrot*(1.0*(m - 1))*dx - sinrot*(1.0*(n - 1))*dy
-         yg(m, n) = y0 + sinrot*(1.0*(m - 1))*dx + cosrot*(1.0*(n - 1))*dy
-      enddo
-   enddo   
-   !
-   NF90(nf90_put_var(map_file%ncid, map_file%face_x_varid, xz, (/1, 1/))) ! write xz of faces 
-   !
-   NF90(nf90_put_var(map_file%ncid, map_file%face_y_varid, yz, (/1, 1/))) ! write yz of faces   
-   ! 
-   ! now for cell corners
-   NF90(nf90_put_var(map_file%ncid, map_file%corner_x_varid, xg, (/1, 1/))) ! write xg of corners
-   !
-   NF90(nf90_put_var(map_file%ncid, map_file%corner_y_varid, yg, (/1, 1/))) ! write yg of corners   
-   !
-   ! Write epsg, msk & bed level already to file
-   !
-   NF90(nf90_put_var(map_file%ncid, map_file%crs_varid, epsg))
-   !
-   allocate(zsg(mmax, nmax))
-   !
-   zsg = FILL_VALUE       
-   !   
-   if (.not. store_dynamic_bed_level) then
-      !
-      do nm = 1, np
-         !
-         n    = z_index_z_n(nm)
-         m    = z_index_z_m(nm)
-         !      
-         if (subgrid) then
-            zsg(m, n) = subgrid_z_zmin(nm)
-         else   
-            zsg(m, n) = zb(nm)
-         endif   
-         !
-      enddo
-      !
-      NF90(nf90_put_var(map_file%ncid, map_file%zb_varid, zsg, (/1, 1/))) ! write zb
-      !
-   endif
-   !
-   zsg = FILL_VALUE       
-   !   
-   ! Subgrid slope   
-   if (subgrid .and. store_hsubgrid .and. store_hmean) then
-      !
-      do nm = 1, np
-         !
-         n    = z_index_z_n(nm)
-         m    = z_index_z_m(nm)
-         !               
-         if (crsgeo) then
-             zsg(m, n) = (subgrid_z_zmax(nm) - subgrid_z_zmin(nm)) / sqrt(cell_area_m2(nm))
-         else   
-             zsg(m, n) = (subgrid_z_zmax(nm) - subgrid_z_zmin(nm)) / sqrt(cell_area(z_flags_iref(nm)))
-         endif
-         !
-      enddo
-      !
-      NF90(nf90_put_var(map_file%ncid, map_file%subgridslope_varid, zsg, (/1, 1/))) ! write subgridslope
-      !
-   endif
-   !
-   zsg = 0 ! initialise as inactive points       
-   !
-   do nm = 1, np
-      !
-      n    = z_index_z_n(nm)
-      m    = z_index_z_m(nm)
-      !      
-      zsg(m, n) = kcs(nm)
-      !
-   enddo
-   !
-   NF90(nf90_put_var(map_file%ncid, map_file%msk_varid, zsg, (/1, 1/))) ! write msk     
-   !
-   ! Write SnapWave msk
-   !
-   if (snapwave) then  
-      !
-      zsg = 0 ! initialise as inactive points       
-      !
-      do nm = 1, np
-         !
-         n    = z_index_z_n(nm)
-         m    = z_index_z_m(nm)
-         !      
-         zsg(m, n) = snapwave_mask(nm)
-         !
-      enddo
-      !
-      NF90(nf90_put_var(map_file%ncid, map_file%snapwavemsk_varid, zsg, (/1, 1/))) ! write snapwave msk     
-      !
-   endif
-   !
-   ! Write Manning (only non-subgrid model)
-   !
-   if (.not. subgrid .and. manning2d) then
-      ! 
-      zsg = FILL_VALUE       
-      !
-      do nm = 1, np
-         !
-         n    = z_index_z_n(nm)
-         m    = z_index_z_m(nm)
-         !      
-         zsg(m, n) = rghfield(nm) ! gn2uv is on uv-points, but rghfield is in center         
-         !
-      enddo
-      !
-      NF90(nf90_put_var(map_file%ncid, map_file%manning_varid, zsg, (/1, 1/)))    
-      !                              
-   endif
-   !
-   ! Write infiltration map
-   !
-   if (infiltration .and. allocated(qinffield)) then
-      !
-      zsg = FILL_VALUE
-      !
-      do nm = 1, np
-         !
-         n    = z_index_z_n(nm)
-         m    = z_index_z_m(nm)
-         !
-         if (inftype == 'con' .or. inftype == 'c2d') then
-            !
-            zsg(m, n) = qinffield(nm) * 3600 * 1000 ! Convert to mm / hour
-            !
-         else
-            !
-            zsg(m, n) = qinffield(nm)
-            !
-         endif
-         !
-      enddo
-      !
-      NF90(nf90_put_var(map_file%ncid, map_file%qinf_varid, zsg, (/1, 1/))) ! write infiltration map
-      !
-   endif
-   !
-   ! Write bucket capacity map (static)
-   !
-   if (inftype == 'bkt' .and. allocated(bucket_capacity)) then
-      !
-      zsg = FILL_VALUE
-      !
-      do nm = 1, np
-         n    = z_index_z_n(nm)
-         m    = z_index_z_m(nm)
-         zsg(m, n) = bucket_capacity(nm) * 1000.0 ! m to mm
-      enddo
-      !
-      NF90(nf90_put_var(map_file%ncid, map_file%qinf_varid, zsg, (/1, 1/))) ! write bucket capacity map
-      !
-   endif
-   !
-   ! write away intermediate data
-   !
-   NF90(nf90_sync(map_file%ncid)) !write away intermediate data
-   !   
-   end subroutine
-
-   
-   subroutine ncoutput_quadtree_map_init()
-   !
-   ! 1. Initialise dimensions/variables/attributes
-   ! 2. write grid/msk/zb to file
-   !
-   use sfincs_date
-   use sfincs_data   
-   use sfincs_snapwave   
+   use sfincs_snapwave
    use quadtree
    !
-   implicit none   
-   !   
-   integer    :: nm, nmq, nmu1, num1, n, m, nn, ntmx, n_nodes, n_faces, iref, isec
-   real*4     :: dxx, dyy
+   implicit none
    !
-   real,      dimension(:),   allocatable :: nodes_x
-   real,      dimension(:),   allocatable :: nodes_y
+   integer :: nm, nmq, n, m, ntmx, nn, n_nodes, n_faces, iref
+   real*4  :: dxx, dyy
+   !
+   ! sp_dimids is local scratch; nsd/dims_*/coord_str are module-level in
+   ! sfincs_ncoutput_helpers and are set here before any def_* calls.
+   integer :: sp_dimids(2)
+   !
+   ! Regular-grid coordinate arrays (xz/yz at face centres, xg/yg at corners)
+   real*4, dimension(:,:), allocatable :: xz, yz, xg, yg
+   !
+   ! Quadtree topology arrays
+   real,      dimension(:),   allocatable :: nodes_x, nodes_y
    integer*4, dimension(:,:), allocatable :: face_nodes
-   real*4,    dimension(:),   allocatable :: vtmp
-   integer*4, dimension(:),   allocatable :: vtmpi
-   real*4,    dimension(:,:), allocatable :: vtmp2d
    !
-   ! Very lazy for now
+   ! Pre-computed source for subgridslope (crsgeo branch lives in the expression)
+   real*4,    dimension(:),   allocatable :: slope_buf
    !
-   n_faces = quadtree_nr_points
-   n_nodes = quadtree_nr_points*4
+   ! -------------------------------------------------------
+   ! Setup dimension abstraction
+   ! -------------------------------------------------------
+   if (use_quadtree) then
+      nsd = 1
+      coord_str = ''
+   else
+      nsd = 2
+      coord_str = 'x y'
+   endif
    !
-   allocate(nodes_x(n_nodes))
-   allocate(nodes_y(n_nodes))
-   allocate(face_nodes(4, n_faces))
-   allocate(vtmp(n_faces))
-   allocate(vtmpi(n_faces))   
+   ! -------------------------------------------------------
+   ! Quadtree: build node/face arrays before creating file
+   ! -------------------------------------------------------
+   if (use_quadtree) then
+      !
+      n_faces = quadtree_nr_points
+      n_nodes = quadtree_nr_points * 4
+      !
+      allocate(nodes_x(n_nodes))
+      allocate(nodes_y(n_nodes))
+      allocate(face_nodes(4, n_faces))
+      !
+      nodes_x    = 0.0
+      nodes_y    = 0.0
+      face_nodes = 0
+      nn         = 0
+      !
+      do nmq = 1, quadtree_nr_points
+         n    = quadtree_n(nmq)
+         m    = quadtree_m(nmq)
+         iref = quadtree_level(nmq)
+         dxx  = quadtree_dxr(iref)
+         dyy  = quadtree_dyr(iref)
+         !
+         nn = nn + 1
+         nodes_x(nn) = x0 + cosrot*(m-1)*dxx - sinrot*(n-1)*dyy
+         nodes_y(nn) = y0 + sinrot*(m-1)*dxx + cosrot*(n-1)*dyy
+         face_nodes(1, nmq) = nn
+         !
+         nn = nn + 1
+         nodes_x(nn) = x0 + cosrot*(m  )*dxx - sinrot*(n-1)*dyy
+         nodes_y(nn) = y0 + sinrot*(m  )*dxx + cosrot*(n-1)*dyy
+         face_nodes(2, nmq) = nn
+         !
+         nn = nn + 1
+         nodes_x(nn) = x0 + cosrot*(m  )*dxx - sinrot*(n  )*dyy
+         nodes_y(nn) = y0 + sinrot*(m  )*dxx + cosrot*(n  )*dyy
+         face_nodes(3, nmq) = nn
+         !
+         nn = nn + 1
+         nodes_x(nn) = x0 + cosrot*(m-1)*dxx - sinrot*(n  )*dyy
+         nodes_y(nn) = y0 + sinrot*(m-1)*dxx + cosrot*(n  )*dyy
+         face_nodes(4, nmq) = nn
+      enddo
+      !
+   endif
    !
-   nodes_x = 0.0
-   nodes_y = 0.0
-   face_nodes = 0
-   !
-   nn = 0
-   !
-   do nmq = 1, quadtree_nr_points
-      !
-      n = quadtree_n(nmq)
-      m = quadtree_m(nmq)
-      !
-      iref = quadtree_level(nmq)
-      dxx  = quadtree_dxr(iref)
-      dyy  = quadtree_dyr(iref)
-      !         
-      nn = nn + 1
-      !
-      nodes_x(nn) = x0 + cosrot*(m - 1)*dxx - sinrot*(n - 1)*dyy
-      nodes_y(nn) = y0 + sinrot*(m - 1)*dxx + cosrot*(n - 1)*dyy
-      face_nodes(1, nmq) = nn
-      !         
-      nn = nn + 1
-      !
-      nodes_x(nn) = x0 + cosrot*(m    )*dxx - sinrot*(n - 1)*dyy
-      nodes_y(nn) = y0 + sinrot*(m    )*dxx + cosrot*(n - 1)*dyy
-      face_nodes(2, nmq) = nn
-      !         
-      nn = nn + 1
-      !
-      nodes_x(nn) = x0 + cosrot*(m    )*dxx - sinrot*(n    )*dyy
-      nodes_y(nn) = y0 + sinrot*(m    )*dxx + cosrot*(n    )*dyy
-      face_nodes(3, nmq) = nn
-      !         
-      nn = nn + 1
-      !
-      nodes_x(nn) = x0 + cosrot*(m - 1)*dxx - sinrot*(n    )*dyy
-      nodes_y(nn) = y0 + sinrot*(m - 1)*dxx + cosrot*(n    )*dyy
-      face_nodes(4, nmq) = nn
-      !
-   enddo   
-   !  
-   NF90(nf90_create('sfincs_map.nc', ior(NF90_CLOBBER, NF90_NETCDF4), map_file%ncid)) ! TL: removed 'NF90_64BIT_OFFSET'
+   ! -------------------------------------------------------
+   ! Create NetCDF file
+   ! -------------------------------------------------------
+   NF90(nf90_create('sfincs_map.nc', ior(NF90_CLOBBER, NF90_NETCDF4), map_file%ncid))
    !
    ! Create dimensions
-   ! grid, time, points
-   ! do mmax/nmax-2 to not write away dummy cells
    !
-   NF90(nf90_def_dim(map_file%ncid, 'nmesh2d_node', n_nodes, map_file%nmesh2d_node_dimid))
-   NF90(nf90_def_dim(map_file%ncid, 'nmesh2d_face', n_faces, map_file%nmesh2d_face_dimid))
-   NF90(nf90_def_dim(map_file%ncid, 'max_nmesh2d_face_nodes', 4, map_file%max_nmesh2d_face_nodes_dimid))
+   if (use_quadtree) then
+      !
+      NF90(nf90_def_dim(map_file%ncid, 'nmesh2d_node',           n_nodes, map_file%nmesh2d_node_dimid))
+      NF90(nf90_def_dim(map_file%ncid, 'nmesh2d_face',           n_faces, map_file%nmesh2d_face_dimid))
+      NF90(nf90_def_dim(map_file%ncid, 'max_nmesh2d_face_nodes', 4,       map_file%max_nmesh2d_face_nodes_dimid))
+      !
+      sp_dimids(1) = map_file%nmesh2d_face_dimid
+      !
+   else
+      !
+      NF90(nf90_def_dim(map_file%ncid, 'n',        nmax,     map_file%n_dimid))
+      NF90(nf90_def_dim(map_file%ncid, 'm',        mmax,     map_file%m_dimid))
+      NF90(nf90_def_dim(map_file%ncid, 'corner_n', nmax + 1, map_file%corner_n_dimid))
+      NF90(nf90_def_dim(map_file%ncid, 'corner_m', mmax + 1, map_file%corner_m_dimid))
+      !
+      sp_dimids(1) = map_file%m_dimid
+      sp_dimids(2) = map_file%n_dimid
+      !
+   endif
    !
-   ! Time
-   !
-   NF90(nf90_def_dim(map_file%ncid, 'time', NF90_UNLIMITED, map_file%time_dimid)) ! time
+   NF90(nf90_def_dim(map_file%ncid, 'time',    NF90_UNLIMITED, map_file%time_dimid))
    ntmx = max(ceiling((t1out - t0out)/dtmaxout), 1)
-   NF90(nf90_def_dim(map_file%ncid, 'timemax', ntmx, map_file%timemax_dimid)) ! time
-   NF90(nf90_def_dim(map_file%ncid, 'runtime', 1, map_file%runtime_dimid)) ! total_runtime, average_dt
+   NF90(nf90_def_dim(map_file%ncid, 'timemax', ntmx, map_file%timemax_dimid))
+   NF90(nf90_def_dim(map_file%ncid, 'runtime', 1,    map_file%runtime_dimid))
    !
    if (store_vegetation) then
       NF90(nf90_def_dim(map_file%ncid, 'nsec', vegetation_vertical_segments, map_file%nsec_dimid)) ! number of vegetation vertical sections
    endif
    !
-   ! Some metadata attributes
+   ! Build dim arrays
+   dims_s (1:nsd)   = sp_dimids(1:nsd)
+   dims_st(1:nsd)   = sp_dimids(1:nsd);  dims_st(nsd+1) = map_file%time_dimid
+   dims_sm(1:nsd)   = sp_dimids(1:nsd);  dims_sm(nsd+1) = map_file%timemax_dimid
    !
-   NF90(nf90_put_att(map_file%ncid,nf90_global, "Conventions", "Conventions = 'CF-1.8 UGRID-1.0 Deltares-0.10'")) 
-   NF90(nf90_put_att(map_file%ncid,nf90_global, "Build-Revision-Date-Netcdf-library", trim(nf90_inq_libvers()))) ! version of netcdf library
-   NF90(nf90_put_att(map_file%ncid,nf90_global, "Producer", "SFINCS model: Super-Fast INundation of CoastS"))
-   NF90(nf90_put_att(map_file%ncid,nf90_global, "Build-Revision", trim(build_revision))) 
-   NF90(nf90_put_att(map_file%ncid,nf90_global, "Build-Date", trim(build_date)))
-   NF90(nf90_put_att(map_file%ncid,nf90_global, "title", "SFINCS map netcdf output"))   
+   ! Global metadata
+   ! CF version unified at 1.8 across both grid types and the his file.
+   if (use_quadtree) then
+      NF90(nf90_put_att(map_file%ncid, nf90_global, "Conventions", "CF-1.8 UGRID-1.0 Deltares-0.10"))
+   else
+      NF90(nf90_put_att(map_file%ncid, nf90_global, "Conventions", "CF-1.8 SGRID-0.3"))
+   endif
+   NF90(nf90_put_att(map_file%ncid, nf90_global, "Build-Revision-Date-Netcdf-library", trim(nf90_inq_libvers())))
+   NF90(nf90_put_att(map_file%ncid, nf90_global, "Producer", "SFINCS model: Super-Fast INundation of CoastS"))
+   NF90(nf90_put_att(map_file%ncid, nf90_global, "Build-Revision", trim(build_revision)))
+   NF90(nf90_put_att(map_file%ncid, nf90_global, "Build-Date", trim(build_date)))
+   NF90(nf90_put_att(map_file%ncid, nf90_global, "title", "SFINCS map netcdf output"))
    !
-   ! Add input params for reproducability
+   call ncoutput_add_params(map_file%ncid, map_file%inp_varid)
    !
-   call ncoutput_add_params(map_file%ncid,map_file%inp_varid)   
-   !
-   ! Create variables
-   !
-   ! Domain
-   !
-   NF90(nf90_def_var(map_file%ncid, 'mesh2d', NF90_INT, (/map_file%runtime_dimid/), map_file%mesh2d_varid)) ! location of zb, zs etc. in cell centre
-   NF90(nf90_def_var_deflate(map_file%ncid, map_file%mesh2d_varid, 1, 1, nc_deflate_level))
-   NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_varid, 'cf_role', 'mesh_topology'))
-   NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_varid, 'long_name', 'Topology data of 2D network'))
-   NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_varid, 'topology_dimension', 2))
-   NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_varid, 'node_coordinates', 'mesh2d_node_x mesh2d_node_y'))
-   NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_varid, 'face_coordinates', 'mesh2d_face_x mesh2d_face_y'))
-   NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_varid, 'node_dimension', 'nmesh2d_node'))
-   NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_varid, 'max_face_nodes_dimension', 'max_nmesh2d_face_nodes'))
-   NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_varid, 'face_node_connectivity', 'mesh2d_face_nodes'))
-   NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_varid, 'face_dimension', 'nmesh2d_face'))
-   !
-   if (crsgeo) then
+   ! -------------------------------------------------------
+   ! Grid topology variables (grid-type specific)
+   ! -------------------------------------------------------
+   if (use_quadtree) then
       !
-      NF90(nf90_def_var(map_file%ncid, 'mesh2d_node_x', NF90_FLOAT, (/map_file%nmesh2d_node_dimid/), map_file%mesh2d_node_x_varid)) ! location of zb, zs etc. in cell centre
-      NF90(nf90_def_var_deflate(map_file%ncid, map_file%mesh2d_node_x_varid, 1, 1, nc_deflate_level))
-      NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_node_x_varid, 'units', 'degrees_east'))
-      NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_node_x_varid, 'standard_name', 'longitude'))
-      NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_node_x_varid, 'long_name', 'longitude'))
-      NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_node_x_varid, 'mesh', 'mesh2d'))
-      NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_node_x_varid, 'location', 'node'))
-      NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_node_x_varid, 'grid_mapping', 'crs'))
+      NF90(nf90_def_var(map_file%ncid, 'mesh2d', NF90_INT, (/map_file%runtime_dimid/), map_file%mesh2d_varid))
+      NF90(nf90_def_var_deflate(map_file%ncid, map_file%mesh2d_varid, 1, 1, nc_deflate_level))
+      NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_varid, 'cf_role',                   'mesh_topology'))
+      NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_varid, 'long_name',                 'Topology data of 2D network'))
+      NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_varid, 'topology_dimension',        2))
+      NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_varid, 'node_coordinates',          'mesh2d_node_x mesh2d_node_y'))
+      NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_varid, 'node_dimension',            'nmesh2d_node'))
+      NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_varid, 'max_face_nodes_dimension',  'max_nmesh2d_face_nodes'))
+      NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_varid, 'face_node_connectivity',    'mesh2d_face_nodes'))
+      NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_varid, 'face_dimension',            'nmesh2d_face'))
+      NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_varid, 'face_coordinates',          'mesh2d_face_x mesh2d_face_y'))
       !
-      NF90(nf90_def_var(map_file%ncid, 'mesh2d_node_y', NF90_FLOAT, (/map_file%nmesh2d_node_dimid/), map_file%mesh2d_node_y_varid)) ! location of zb, zs etc. in cell centre
-      NF90(nf90_def_var_deflate(map_file%ncid, map_file%mesh2d_node_y_varid, 1, 1, nc_deflate_level))
-      NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_node_y_varid, 'units', 'degrees_north'))
-      NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_node_y_varid, 'standard_name', 'latitude'))
-      NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_node_y_varid, 'long_name', 'latitude'))
-      NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_node_y_varid, 'mesh', 'mesh2d'))
-      NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_node_y_varid, 'location', 'node'))
-      NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_node_y_varid, 'grid_mapping', 'crs'))
+      call def_mesh2d_node_coord('x', map_file%mesh2d_node_x_varid)
+      !
+      call def_mesh2d_node_coord('y', map_file%mesh2d_node_y_varid)
+      !
+      NF90(nf90_def_var(map_file%ncid, 'mesh2d_face_nodes', NF90_INT, (/map_file%max_nmesh2d_face_nodes_dimid, map_file%nmesh2d_face_dimid/), map_file%mesh2d_face_nodes_varid))
+      NF90(nf90_def_var_deflate(map_file%ncid, map_file%mesh2d_face_nodes_varid, 1, 1, nc_deflate_level))
+      NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_face_nodes_varid, 'cf_role',   'face_node_connectivity'))
+      NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_face_nodes_varid, 'mesh',      'mesh2d'))
+      NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_face_nodes_varid, 'location',  'face'))
+      NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_face_nodes_varid, 'long_name', 'Mapping from every face to its corner nodes (counterclockwise)'))
+      NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_face_nodes_varid, 'start_index', 1))
+      NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_face_nodes_varid, '_FillValue', -999))
+      !
+      ! Face centroid coordinates (required by UGRID and MDAL/QGIS)
+      if (crsgeo) then
+         NF90(nf90_def_var(map_file%ncid, 'mesh2d_face_x', NF90_FLOAT, (/map_file%nmesh2d_face_dimid/), map_file%mesh2d_face_x_varid))
+         NF90(nf90_def_var_deflate(map_file%ncid, map_file%mesh2d_face_x_varid, 1, 1, nc_deflate_level))
+         NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_face_x_varid, 'units',         'degrees_east'))
+         NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_face_x_varid, 'standard_name', 'longitude'))
+         NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_face_x_varid, 'long_name',     'Characteristic longitude of mesh face'))
+         NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_face_x_varid, 'grid_mapping',  'crs'))
+         NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_face_x_varid, 'mesh',          'mesh2d'))
+         NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_face_x_varid, 'location',      'face'))
+         !
+         NF90(nf90_def_var(map_file%ncid, 'mesh2d_face_y', NF90_FLOAT, (/map_file%nmesh2d_face_dimid/), map_file%mesh2d_face_y_varid))
+         NF90(nf90_def_var_deflate(map_file%ncid, map_file%mesh2d_face_y_varid, 1, 1, nc_deflate_level))
+         NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_face_y_varid, 'units',         'degrees_north'))
+         NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_face_y_varid, 'standard_name', 'latitude'))
+         NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_face_y_varid, 'long_name',     'Characteristic latitude of mesh face'))
+         NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_face_y_varid, 'grid_mapping',  'crs'))
+         NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_face_y_varid, 'mesh',          'mesh2d'))
+         NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_face_y_varid, 'location',      'face'))
+      else
+         NF90(nf90_def_var(map_file%ncid, 'mesh2d_face_x', NF90_DOUBLE, (/map_file%nmesh2d_face_dimid/), map_file%mesh2d_face_x_varid))
+         NF90(nf90_def_var_deflate(map_file%ncid, map_file%mesh2d_face_x_varid, 1, 1, nc_deflate_level))
+         NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_face_x_varid, 'units',         'm'))
+         NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_face_x_varid, 'standard_name', 'projection_x_coordinate'))
+         NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_face_x_varid, 'long_name',     'Characteristic x-coordinate of mesh face'))
+         NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_face_x_varid, 'grid_mapping',  'crs'))
+         NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_face_x_varid, 'mesh',          'mesh2d'))
+         NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_face_x_varid, 'location',      'face'))
+         !
+         NF90(nf90_def_var(map_file%ncid, 'mesh2d_face_y', NF90_DOUBLE, (/map_file%nmesh2d_face_dimid/), map_file%mesh2d_face_y_varid))
+         NF90(nf90_def_var_deflate(map_file%ncid, map_file%mesh2d_face_y_varid, 1, 1, nc_deflate_level))
+         NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_face_y_varid, 'units',         'm'))
+         NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_face_y_varid, 'standard_name', 'projection_y_coordinate'))
+         NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_face_y_varid, 'long_name',     'Characteristic y-coordinate of mesh face'))
+         NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_face_y_varid, 'grid_mapping',  'crs'))
+         NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_face_y_varid, 'mesh',          'mesh2d'))
+         NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_face_y_varid, 'location',      'face'))
+      endif
+      !
+      NF90(nf90_def_var(map_file%ncid, 'crs', NF90_INT, map_file%crs_varid))
+      NF90(nf90_put_att(map_file%ncid, map_file%crs_varid, 'epsg',      epsg))
+      NF90(nf90_put_att(map_file%ncid, map_file%crs_varid, 'epsg_code', 'EPSG:' // trim(epsg_code)))
       !
    else
       !
-      NF90(nf90_def_var(map_file%ncid, 'mesh2d_node_x', NF90_DOUBLE, (/map_file%nmesh2d_node_dimid/), map_file%mesh2d_node_x_varid)) ! location of zb, zs etc. in cell centre
-      NF90(nf90_def_var_deflate(map_file%ncid, map_file%mesh2d_node_x_varid, 1, 1, nc_deflate_level))
-      NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_node_x_varid, 'units', 'm'))
-      NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_node_x_varid, 'standard_name', 'projection_x_coordinate'))
-      NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_node_x_varid, 'long_name', 'x-coordinate of mesh nodes'))
-      NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_node_x_varid, 'mesh', 'mesh2d'))
-      NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_node_x_varid, 'location', 'node'))
-      NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_node_x_varid, 'grid_mapping', 'crs'))
+      ! Regular: face / corner coordinate axes
+      call def_grid_axis_coord('x',        'x', (/map_file%m_dimid,        map_file%n_dimid/),        map_file%face_x_varid,   'face_x')
+      call def_grid_axis_coord('y',        'y', (/map_file%m_dimid,        map_file%n_dimid/),        map_file%face_y_varid,   'face_y')
+      call def_grid_axis_coord('corner_x', 'x', (/map_file%corner_m_dimid, map_file%corner_n_dimid/), map_file%corner_x_varid, 'corner_x')
+      call def_grid_axis_coord('corner_y', 'y', (/map_file%corner_m_dimid, map_file%corner_n_dimid/), map_file%corner_y_varid, 'corner_y')
       !
-      NF90(nf90_def_var(map_file%ncid, 'mesh2d_node_y', NF90_DOUBLE, (/map_file%nmesh2d_node_dimid/), map_file%mesh2d_node_y_varid)) ! location of zb, zs etc. in cell centre
-      NF90(nf90_def_var_deflate(map_file%ncid, map_file%mesh2d_node_y_varid, 1, 1, nc_deflate_level))
-      NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_node_y_varid, 'units', 'm'))
-      NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_node_y_varid, 'standard_name', 'projection_y_coordinate'))
-      NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_node_y_varid, 'long_name', 'y-coordinate of mesh nodes'))
-      NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_node_y_varid, 'mesh', 'mesh2d'))
-      NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_node_y_varid, 'location', 'node'))
-      NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_node_y_varid, 'grid_mapping', 'crs'))
+      NF90(nf90_def_var(map_file%ncid, 'crs', NF90_INT, map_file%crs_varid))
+      NF90(nf90_put_att(map_file%ncid, map_file%crs_varid, 'epsg',      epsg))
+      NF90(nf90_put_att(map_file%ncid, map_file%crs_varid, 'epsg_code', 'EPSG:' // trim(epsg_code)))
+      !
+      NF90(nf90_def_var(map_file%ncid, 'sfincsgrid', NF90_INT, map_file%grid_varid))
+      NF90(nf90_put_att(map_file%ncid, map_file%grid_varid, 'cf_role',           'grid_topology'))
+      NF90(nf90_put_att(map_file%ncid, map_file%grid_varid, 'topology_dimension', 2))
+      NF90(nf90_put_att(map_file%ncid, map_file%grid_varid, 'node_dimensions',   'n m'))
+      NF90(nf90_put_att(map_file%ncid, map_file%grid_varid, 'face_dimensions',   'n: m:'))
+      NF90(nf90_put_att(map_file%ncid, map_file%grid_varid, 'corner_dimensions', 'corner_n: corner_m:'))
+      NF90(nf90_put_att(map_file%ncid, map_file%grid_varid, 'face_coordinates',  'x y'))
+      NF90(nf90_put_att(map_file%ncid, map_file%grid_varid, 'corner_coordinates','corner_x corner_y'))
       !
    endif
    !
-   NF90(nf90_def_var(map_file%ncid, 'mesh2d_face_nodes', NF90_INT, (/map_file%max_nmesh2d_face_nodes_dimid, map_file%nmesh2d_face_dimid/), map_file%mesh2d_face_nodes_varid)) ! location of zb, zs etc. in cell centre
-   NF90(nf90_def_var_deflate(map_file%ncid, map_file%mesh2d_face_nodes_varid, 1, 1, nc_deflate_level))
-   NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_face_nodes_varid, 'cf_role', 'face_node_connectivity'))
-   NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_face_nodes_varid, 'mesh', 'mesh2d'))
-   NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_face_nodes_varid, 'location', 'face'))
-   NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_face_nodes_varid, 'long_name', 'Mapping from every face to its corner nodes (counterclockwise)'))
-   NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_face_nodes_varid, 'start_index', 1))
-   NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_face_nodes_varid, '_FillValue', -999))
+   ! -------------------------------------------------------
+   ! msk: NF90_INT on both grid types, described via CF flag_values /
+   ! flag_meanings. No CF standard_name exists for multi-valued masks
+   ! (the previously-used 'land_binary_mask' is strict 0/1 only).
+   ! -------------------------------------------------------
+   call def_static_cell_int('msk', map_file%msk_varid, 'Active cells mask', &
+        units='-', &
+        description='inactive=0, active=1, normal_boundary=2, outflow_boundary=3, wavemaker=4, downstream_boundary=5, neumann_boundary=6', &
+        flag_values=(/0, 1, 2, 3, 4, 5, 6/), &
+        flag_meanings='inactive active normal_boundary outflow_boundary wavemaker downstream_boundary neumann_boundary')
    !
-   ! Face centroid coordinates (x and y at face centers)
+   ! -------------------------------------------------------
+   ! Infiltration map (qinf) - both grid types, slightly different
+   ! -------------------------------------------------------
+   if (infiltration) then
+      if (inftype == 'cna') then
+         call def_static_cell_float('qinf', map_file%qinf_varid, 'm', 'moisture storage (S) capacity - Curve number', &
+              standard_name='S')
+      elseif (inftype == 'cnb') then
+         call def_static_cell_float('qinf', map_file%qinf_varid, 'm', 'maximum moisture storage (Smax) capacity - Curve number', &
+              standard_name='Smax')
+      elseif (inftype == 'gai') then
+         call def_static_cell_float('qinf', map_file%qinf_varid, 'm', 'suction head at the wetting front - Green and Ampt', &
+              standard_name='psi')
+      elseif (inftype == 'hor') then
+         call def_static_cell_float('qinf', map_file%qinf_varid, 'm', 'initial infiltration rate - Horton', standard_name='f0')
+      else
+         call def_static_cell_float('qinf', map_file%qinf_varid, 'mm h-1', 'infiltration rate - constant in time', &
+              standard_name='qinf')
+      endif
+   endif
    !
-   if (crsgeo) then
-      !
-      NF90(nf90_def_var(map_file%ncid, 'mesh2d_face_x', NF90_FLOAT, (/map_file%nmesh2d_face_dimid/), map_file%mesh2d_face_x_varid))
-      NF90(nf90_def_var_deflate(map_file%ncid, map_file%mesh2d_face_x_varid, 1, 1, nc_deflate_level))
-      NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_face_x_varid, 'units', 'degrees_east'))
-      NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_face_x_varid, 'standard_name', 'longitude'))
-      NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_face_x_varid, 'long_name', 'Characteristic longitude of mesh face'))
-      NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_face_x_varid, 'mesh', 'mesh2d'))
-      NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_face_x_varid, 'location', 'face'))
-      NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_face_x_varid, 'grid_mapping', 'crs'))
-      !
-      NF90(nf90_def_var(map_file%ncid, 'mesh2d_face_y', NF90_FLOAT, (/map_file%nmesh2d_face_dimid/), map_file%mesh2d_face_y_varid))
-      NF90(nf90_def_var_deflate(map_file%ncid, map_file%mesh2d_face_y_varid, 1, 1, nc_deflate_level))
-      NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_face_y_varid, 'units', 'degrees_north'))
-      NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_face_y_varid, 'standard_name', 'latitude'))
-      NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_face_y_varid, 'long_name', 'Characteristic latitude of mesh face'))
-      NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_face_y_varid, 'mesh', 'mesh2d'))
-      NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_face_y_varid, 'location', 'face'))
-      NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_face_y_varid, 'grid_mapping', 'crs'))
-      !
+   ! -------------------------------------------------------
+   ! zb: time-varying only on regular non-subgrid runs with store_dynamic_bed_level;
+   ! static for quadtree, subgrid, or static-bed regular runs.
+   ! Def condition matches the write condition in ncoutput_update_map.
+   ! -------------------------------------------------------
+   if (.not. use_quadtree .and. store_dynamic_bed_level .and. .not. subgrid) then
+      call def_time_cell_float('zb', map_file%zb_varid, 'm', 'Bed level above reference level', standard_name='altitude')
    else
-      !
-      NF90(nf90_def_var(map_file%ncid, 'mesh2d_face_x', NF90_DOUBLE, (/map_file%nmesh2d_face_dimid/), map_file%mesh2d_face_x_varid))
-      NF90(nf90_def_var_deflate(map_file%ncid, map_file%mesh2d_face_x_varid, 1, 1, nc_deflate_level))
-      NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_face_x_varid, 'units', 'm'))
-      NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_face_x_varid, 'standard_name', 'projection_x_coordinate'))
-      NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_face_x_varid, 'long_name', 'Characteristic x-coordinate of mesh face'))
-      NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_face_x_varid, 'mesh', 'mesh2d'))
-      NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_face_x_varid, 'location', 'face'))
-      NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_face_x_varid, 'grid_mapping', 'crs'))
-      !
-      NF90(nf90_def_var(map_file%ncid, 'mesh2d_face_y', NF90_DOUBLE, (/map_file%nmesh2d_face_dimid/), map_file%mesh2d_face_y_varid))
-      NF90(nf90_def_var_deflate(map_file%ncid, map_file%mesh2d_face_y_varid, 1, 1, nc_deflate_level))
-      NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_face_y_varid, 'units', 'm'))
-      NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_face_y_varid, 'standard_name', 'projection_y_coordinate'))
-      NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_face_y_varid, 'long_name', 'Characteristic y-coordinate of mesh face'))
-      NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_face_y_varid, 'mesh', 'mesh2d'))
-      NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_face_y_varid, 'location', 'face'))
-      NF90(nf90_put_att(map_file%ncid, map_file%mesh2d_face_y_varid, 'grid_mapping', 'crs'))
-      !
+      call def_static_cell_float('zb', map_file%zb_varid, 'm', 'Bed level above reference level', standard_name='altitude')
    endif
    !
-   NF90(nf90_def_var(map_file%ncid, 'crs', NF90_INT, map_file%crs_varid)) ! For EPSG code
-   NF90(nf90_put_att(map_file%ncid, map_file%crs_varid, 'epsg', epsg))
-   NF90(nf90_put_att(map_file%ncid, map_file%crs_varid, 'epsg_code', 'EPSG:' // trim(epsg_code) ))   !--> add epsg_code like FEWS wants
-   NF90(nf90_def_var(map_file%ncid, 'zb', NF90_FLOAT, (/map_file%nmesh2d_face_dimid/), map_file%zb_varid)) ! bed level in cell centre
-   NF90(nf90_def_var_deflate(map_file%ncid, map_file%zb_varid, 1, 1, nc_deflate_level))
-   NF90(nf90_put_att(map_file%ncid, map_file%zb_varid, '_FillValue', FILL_VALUE))   
-   NF90(nf90_put_att(map_file%ncid, map_file%zb_varid, 'units', 'm'))
-   NF90(nf90_put_att(map_file%ncid, map_file%zb_varid, 'standard_name', 'altitude'))
-   NF90(nf90_put_att(map_file%ncid, map_file%zb_varid, 'long_name', 'Bed level above reference level'))   
-   !
-   if (.not. subgrid) then
-      !
-      NF90(nf90_def_var(map_file%ncid, 'manning', NF90_FLOAT, (/map_file%nmesh2d_face_dimid/), map_file%manning_varid)) ! bed level in cell centre
-      NF90(nf90_def_var_deflate(map_file%ncid, map_file%manning_varid, 1, 1, nc_deflate_level))
-      NF90(nf90_put_att(map_file%ncid, map_file%manning_varid, '_FillValue', FILL_VALUE))   
-      NF90(nf90_put_att(map_file%ncid, map_file%manning_varid, 'units', 's/m^1/3'))
-      NF90(nf90_put_att(map_file%ncid, map_file%manning_varid, 'standard_name', 'manning'))
-      NF90(nf90_put_att(map_file%ncid, map_file%manning_varid, 'long_name', 'manning_roughness'))       
-      !
+   ! manning (only meaningful when manning2d, i.e. per-cell field, is set)
+   if (.not. subgrid .and. manning2d) then
+      call def_static_cell_float('manning', map_file%manning_varid, 's/m^1/3', 'Manning roughness coefficient', standard_name='manning')
    endif
    !
+   ! subgrid slope
    if (subgrid .and. store_hsubgrid .and. store_hmean) then
-      !
-      ! The subgrid slope (zmax - zmin) / sqrt(A) is used for making high-res flood maps
-      ! If the subgrid slope is lower than a threshold, the mean water depth in a cell
-      ! can be used instead of difference between the cell water level and the pixel heights
-      !
-      NF90(nf90_def_var(map_file%ncid, 'subgridslope', NF90_FLOAT, (/map_file%nmesh2d_face_dimid/), map_file%subgridslope_varid)) ! (zmax - zmin) / dx
-      NF90(nf90_def_var_deflate(map_file%ncid, map_file%subgridslope_varid, 1, 1, nc_deflate_level))
-      NF90(nf90_put_att(map_file%ncid, map_file%subgridslope_varid, '_FillValue', FILL_VALUE))   
-      NF90(nf90_put_att(map_file%ncid, map_file%subgridslope_varid, 'units', '-'))
-      NF90(nf90_put_att(map_file%ncid, map_file%subgridslope_varid, 'standard_name', 'subgrid_slope'))
-      NF90(nf90_put_att(map_file%ncid, map_file%subgridslope_varid, 'long_name', 'subgrid_slope'))
-      !
+      call def_static_cell_float('subgridslope', map_file%subgridslope_varid, '-', 'Subgrid slope', standard_name='subgrid_slope')
    endif
    !
-   NF90(nf90_def_var(map_file%ncid, 'msk', NF90_INT, (/map_file%nmesh2d_face_dimid/), map_file%msk_varid)) ! input msk value in cell centre
-   NF90(nf90_def_var_deflate(map_file%ncid, map_file%msk_varid, 1, 1, nc_deflate_level))
-   NF90(nf90_put_att(map_file%ncid, map_file%msk_varid, '_FillValue', -999))      
-   NF90(nf90_put_att(map_file%ncid, map_file%msk_varid, 'units', '-'))
-   NF90(nf90_put_att(map_file%ncid, map_file%msk_varid, 'standard_name', 'mask'))
-   NF90(nf90_put_att(map_file%ncid, map_file%msk_varid, 'long_name', 'msk_active_cells')) 
-   NF90(nf90_put_att(map_file%ncid, map_file%msk_varid, 'description', 'inactive=0, active=1, normal_boundary=2, outflow_boundary=3, wavemaker=4'))
-   !
+   ! vegetation stem properties (static, per vertical section)
    if (store_vegetation) then
-      !
-      NF90(nf90_def_var(map_file%ncid, 'vegetation_stems_cd', NF90_FLOAT, (/map_file%nmesh2d_face_dimid, map_file%nsec_dimid/), map_file%veg_cd_varid))
-      NF90(nf90_def_var_deflate(map_file%ncid, map_file%veg_cd_varid, 1, 1, nc_deflate_level))
-      NF90(nf90_put_att(map_file%ncid, map_file%veg_cd_varid, '_FillValue', FILL_VALUE))
-      NF90(nf90_put_att(map_file%ncid, map_file%veg_cd_varid, 'units', '-'))
-      NF90(nf90_put_att(map_file%ncid, map_file%veg_cd_varid, 'standard_name', 'vegetation_stems_cd'))
-      NF90(nf90_put_att(map_file%ncid, map_file%veg_cd_varid, 'long_name', 'Bulk drag coefficient per vegetation section'))
-      !
-      NF90(nf90_def_var(map_file%ncid, 'vegetation_stems_height', NF90_FLOAT, (/map_file%nmesh2d_face_dimid, map_file%nsec_dimid/), map_file%veg_ah_varid))
-      NF90(nf90_def_var_deflate(map_file%ncid, map_file%veg_ah_varid, 1, 1, nc_deflate_level))
-      NF90(nf90_put_att(map_file%ncid, map_file%veg_ah_varid, '_FillValue', FILL_VALUE))
-      NF90(nf90_put_att(map_file%ncid, map_file%veg_ah_varid, 'units', 'm'))
-      NF90(nf90_put_att(map_file%ncid, map_file%veg_ah_varid, 'standard_name', 'vegetation_stems_height'))
-      NF90(nf90_put_att(map_file%ncid, map_file%veg_ah_varid, 'long_name', 'Vegetation section thickness'))
-      !
-      NF90(nf90_def_var(map_file%ncid, 'vegetation_stems_diameter', NF90_FLOAT, (/map_file%nmesh2d_face_dimid, map_file%nsec_dimid/), map_file%veg_bstems_varid))
-      NF90(nf90_def_var_deflate(map_file%ncid, map_file%veg_bstems_varid, 1, 1, nc_deflate_level))
-      NF90(nf90_put_att(map_file%ncid, map_file%veg_bstems_varid, '_FillValue', FILL_VALUE))
-      NF90(nf90_put_att(map_file%ncid, map_file%veg_bstems_varid, 'units', 'm'))
-      NF90(nf90_put_att(map_file%ncid, map_file%veg_bstems_varid, 'standard_name', 'vegetation_stems_diameter'))
-      NF90(nf90_put_att(map_file%ncid, map_file%veg_bstems_varid, 'long_name', 'Diameter of individual vegetation stems per section'))
-      !
-      NF90(nf90_def_var(map_file%ncid, 'vegetation_stems_density', NF90_FLOAT, (/map_file%nmesh2d_face_dimid, map_file%nsec_dimid/), map_file%veg_Nstems_varid))
-      NF90(nf90_def_var_deflate(map_file%ncid, map_file%veg_Nstems_varid, 1, 1, nc_deflate_level))
-      NF90(nf90_put_att(map_file%ncid, map_file%veg_Nstems_varid, '_FillValue', FILL_VALUE))
-      NF90(nf90_put_att(map_file%ncid, map_file%veg_Nstems_varid, 'units', 'm-2'))
-      NF90(nf90_put_att(map_file%ncid, map_file%veg_Nstems_varid, 'standard_name', 'vegetation_stems_density'))
-      NF90(nf90_put_att(map_file%ncid, map_file%veg_Nstems_varid, 'long_name', 'Number of stems per unit horizontal area per section'))
-      !
+      call def_static_veg_float('vegetation_stems_cd',       map_file%veg_cd_varid,     '-',   'Bulk drag coefficient per vegetation section',         map_file%nsec_dimid, standard_name='vegetation_stems_cd')
+      call def_static_veg_float('vegetation_stems_height',   map_file%veg_ah_varid,     'm',   'Vegetation section thickness',                        map_file%nsec_dimid, standard_name='vegetation_stems_height')
+      call def_static_veg_float('vegetation_stems_diameter', map_file%veg_bstems_varid, 'm',   'Diameter of individual vegetation stems per section', map_file%nsec_dimid, standard_name='vegetation_stems_diameter')
+      call def_static_veg_float('vegetation_stems_density',  map_file%veg_Nstems_varid, 'm-2', 'Number of stems per unit horizontal area per section', map_file%nsec_dimid, standard_name='vegetation_stems_density')
    endif
    !
+   ! -------------------------------------------------------
    ! Time variables
-   !
+   ! -------------------------------------------------------
    trefstr_iso8601 = date_to_iso8601(trefstr)
+   NF90(nf90_def_var(map_file%ncid, 'time', NF90_FLOAT, (/map_file%time_dimid/), map_file%time_varid))
+   NF90(nf90_put_att(map_file%ncid, map_file%time_varid, 'units',     'seconds since ' // trim(trefstr_iso8601)))
+   NF90(nf90_put_att(map_file%ncid, map_file%time_varid, 'standard_name', 'time'))
+   NF90(nf90_put_att(map_file%ncid, map_file%time_varid, 'long_name', 'time_in_seconds_since_' // trim(trefstr_iso8601)))
    !
-   NF90(nf90_def_var(map_file%ncid, 'time', NF90_FLOAT, (/map_file%time_dimid/), map_file%time_varid)) ! time
-   NF90(nf90_put_att(map_file%ncid, map_file%time_varid, 'units', 'seconds since ' // trim(trefstr_iso8601) ))  ! time stamp following ISO 8601
-   NF90(nf90_put_att(map_file%ncid, map_file%time_varid, 'standard_name', 'time'))     
-   NF90(nf90_put_att(map_file%ncid, map_file%time_varid, 'long_name', 'time_in_seconds_since_' // trim(trefstr_iso8601) ))  
+   ! -------------------------------------------------------
+   ! Time-varying water level / depth / velocity
+   ! -------------------------------------------------------
+   call def_time_cell_float('zs', map_file%zs_varid, 'm', 'Water level', standard_name='sea_surface_height_above_reference_level')
    !
-   ! Time varying map output
-   !
-   NF90(nf90_def_var(map_file%ncid, 'zs', NF90_FLOAT, (/map_file%nmesh2d_face_dimid, map_file%time_dimid/), map_file%zs_varid)) ! time-varying water level map
-   NF90(nf90_def_var_deflate(map_file%ncid, map_file%zs_varid, 1, 1, nc_deflate_level))
-   NF90(nf90_put_att(map_file%ncid, map_file%zs_varid, '_FillValue', FILL_VALUE))
-   NF90(nf90_put_att(map_file%ncid, map_file%zs_varid, 'units', 'm'))
-   NF90(nf90_put_att(map_file%ncid, map_file%zs_varid, 'standard_name', 'sea_surface_height_above_reference_level')) 
-   NF90(nf90_put_att(map_file%ncid, map_file%zs_varid, 'long_name', 'Water level above reference level'))
-   !
-   if (subgrid .eqv. .false. .or. store_hsubgrid .eqv. .true.) then   
-      NF90(nf90_def_var(map_file%ncid, 'h', NF90_FLOAT, (/map_file%nmesh2d_face_dimid, map_file%time_dimid/), map_file%h_varid)) ! time-varying water level map
-      NF90(nf90_def_var_deflate(map_file%ncid, map_file%h_varid, 1, 1, nc_deflate_level))
-      NF90(nf90_put_att(map_file%ncid, map_file%h_varid, '_FillValue', FILL_VALUE))
-      NF90(nf90_put_att(map_file%ncid, map_file%h_varid, 'units', 'm'))
-      NF90(nf90_put_att(map_file%ncid, map_file%h_varid, 'standard_name', 'water_depth')) 
-      NF90(nf90_put_att(map_file%ncid, map_file%h_varid, 'long_name', 'Water depth'))  
+   if (subgrid .eqv. .false. .or. store_hsubgrid .eqv. .true.) then
+      call def_time_cell_float('h', map_file%h_varid, 'm', 'Water depth', standard_name='water_depth')
    endif
    !
    if (store_velocity) then
+      call def_time_cell_float('u', map_file%u_varid, 'm s-1', 'Flow velocity x-component', &
+           standard_name='eastward_sea_water_velocity')
       !
-      NF90(nf90_def_var(map_file%ncid, 'u', NF90_FLOAT, (/map_file%nmesh2d_face_dimid, map_file%time_dimid/), map_file%u_varid)) ! time-varying u map
-      NF90(nf90_def_var_deflate(map_file%ncid, map_file%u_varid, 1, 1, nc_deflate_level))
-      NF90(nf90_put_att(map_file%ncid, map_file%u_varid, '_FillValue', FILL_VALUE))   
-      NF90(nf90_put_att(map_file%ncid, map_file%u_varid, 'units', 'm s-1'))
-      NF90(nf90_put_att(map_file%ncid, map_file%u_varid, 'standard_name', 'sea_water_x_velocity')) ! not truly eastward when rotated, eastward_sea_water_velocity
-      NF90(nf90_put_att(map_file%ncid, map_file%u_varid, 'long_name', 'Flow velocity x-component'))
-      !
-      NF90(nf90_def_var(map_file%ncid, 'v', NF90_FLOAT, (/map_file%nmesh2d_face_dimid, map_file%time_dimid/), map_file%v_varid)) ! time-varying u map 
-      NF90(nf90_def_var_deflate(map_file%ncid, map_file%v_varid, 1, 1, nc_deflate_level))
-      NF90(nf90_put_att(map_file%ncid, map_file%v_varid, '_FillValue', FILL_VALUE))   
-      NF90(nf90_put_att(map_file%ncid, map_file%v_varid, 'units', 'm s-1'))
-      NF90(nf90_put_att(map_file%ncid, map_file%v_varid, 'standard_name', 'sea_water_y_velocity')) ! not truly eastward when rotated, eastward_sea_water_velocity
-      NF90(nf90_put_att(map_file%ncid, map_file%v_varid, 'long_name', 'Flow velocity y-component'))
-      !
+      call def_time_cell_float('v', map_file%v_varid, 'm s-1', 'Flow velocity y-component', &
+           standard_name='northward_sea_water_velocity')
    endif
    !
-   ! Volume in subgrid cell and storage volume
-   !
+   ! Subgrid volumes
    if (subgrid) then
-      !
       if (store_zvolume) then
-         !
-         NF90(nf90_def_var(map_file%ncid, 'subgrid_volume', NF90_FLOAT, (/map_file%nmesh2d_face_dimid, map_file%time_dimid/), map_file%zvolume_varid)) ! time-varying z_volume map
-         NF90(nf90_def_var_deflate(map_file%ncid, map_file%zvolume_varid, 1, 1, nc_deflate_level))          
-         NF90(nf90_put_att(map_file%ncid, map_file%zvolume_varid, '_FillValue', FILL_VALUE))
-         NF90(nf90_put_att(map_file%ncid, map_file%zvolume_varid, 'units', 'm3'))
-         NF90(nf90_put_att(map_file%ncid, map_file%zvolume_varid, 'standard_name', 'subgrid_volume_in_cell')) 
-         NF90(nf90_put_att(map_file%ncid, map_file%zvolume_varid, 'long_name', 'Subgrid volume in cell'))  
-         NF90(nf90_put_att(map_file%ncid, map_file%zvolume_varid, 'coordinates', 'x y'))
-         ! 
+         call def_time_cell_float('subgrid_volume', map_file%zvolume_varid, 'm3', 'Subgrid volume in cell', &
+              standard_name='subgrid_volume_in_cell')
       endif
-      !
       if (store_storagevolume) then
-         !
-         NF90(nf90_def_var(map_file%ncid, 'storage_volume', NF90_FLOAT, (/map_file%nmesh2d_face_dimid, map_file%time_dimid/), map_file%storagevolume_varid)) ! time-varying storage_volume map
-         NF90(nf90_def_var_deflate(map_file%ncid, map_file%storagevolume_varid, 1, 1, nc_deflate_level)) ! deflate
-         NF90(nf90_put_att(map_file%ncid, map_file%storagevolume_varid, '_FillValue', FILL_VALUE))
-         NF90(nf90_put_att(map_file%ncid, map_file%storagevolume_varid, 'units', 'm3'))
-         NF90(nf90_put_att(map_file%ncid, map_file%storagevolume_varid, 'standard_name', 'storage_volume_in_cell')) 
-         NF90(nf90_put_att(map_file%ncid, map_file%storagevolume_varid, 'long_name', 'Storage volume in cell'))  
-         NF90(nf90_put_att(map_file%ncid, map_file%storagevolume_varid, 'coordinates', 'x y'))
-         !           
+         call def_time_cell_float('storage_volume', map_file%storagevolume_varid, 'm3', 'Storage volume in cell', &
+              standard_name='storage_volume_in_cell')
       endif
-      !      
-   endif
-   !   
-   
-   ! Time varying spatial output
-   !
-   if (store_maximum_waterlevel) then
-      NF90(nf90_def_var(map_file%ncid, 'timemax', NF90_FLOAT, (/map_file%timemax_dimid/), map_file%timemax_varid)) ! time      
-      NF90(nf90_put_att(map_file%ncid, map_file%timemax_varid, 'units', 'seconds since ' // trim(trefstr_iso8601) ))  ! time stamp following ISO 8601
-      NF90(nf90_put_att(map_file%ncid, map_file%timemax_varid, 'standard_name', 'time'))     
-      NF90(nf90_put_att(map_file%ncid, map_file%timemax_varid, 'long_name', 'time_in_seconds_since_' // trim(trefstr_iso8601) ))  
    endif
    !
+   ! Infiltration state vars (Seff / sigma / f). Source arrays scs_Se,
+   ! GA_sigma and qinfmap are allocated unconditionally by sfincs_infiltration
+   ! whenever the corresponding inftype is active, on both regular and
+   ! quadtree grids.
+   if (inftype == 'cnb') then
+      call def_time_cell_float('Seff', map_file%infstate_varid, 'm', 'current moisture storage (Se) capacity', standard_name='Se')
+   elseif (inftype == 'gai') then
+      call def_time_cell_float('sigma', map_file%infstate_varid, '-', 'maximum soil moisture deficit', standard_name='sigma')
+   elseif (inftype == 'hor') then
+      call def_time_cell_float('f', map_file%infstate_varid, 'mm h-1', 'current infiltration capacity', standard_name='f')
+   endif
+   !
+   ! -------------------------------------------------------
+   ! Max-output time variable
+   ! -------------------------------------------------------
    if (store_maximum_waterlevel) then
-      NF90(nf90_def_var(map_file%ncid, 'zsmax', NF90_FLOAT, (/map_file%nmesh2d_face_dimid, map_file%timemax_dimid/), map_file%zsmax_varid)) ! time-varying maximum water level map
-      NF90(nf90_def_var_deflate(map_file%ncid, map_file%zsmax_varid, 1, 1, nc_deflate_level))
-      NF90(nf90_put_att(map_file%ncid, map_file%zsmax_varid, '_FillValue', FILL_VALUE))
-      NF90(nf90_put_att(map_file%ncid, map_file%zsmax_varid, 'units', 'm'))
-      NF90(nf90_put_att(map_file%ncid, map_file%zsmax_varid, 'standard_name', 'maximum of sea_surface_height_above_reference_level')) 
-      NF90(nf90_put_att(map_file%ncid, map_file%zsmax_varid, 'long_name', 'Maximum water level'))        
+      NF90(nf90_def_var(map_file%ncid, 'timemax', NF90_FLOAT, (/map_file%timemax_dimid/), map_file%timemax_varid))
+      NF90(nf90_put_att(map_file%ncid, map_file%timemax_varid, 'units',     'seconds since ' // trim(trefstr_iso8601)))
+      NF90(nf90_put_att(map_file%ncid, map_file%timemax_varid, 'standard_name', 'time'))
+      NF90(nf90_put_att(map_file%ncid, map_file%timemax_varid, 'long_name', 'time_in_seconds_since_' // trim(trefstr_iso8601)))
+   endif
+   !
+   if (store_maximum_waterlevel) then
+      call def_maxtime_cell_float('zsmax', map_file%zsmax_varid, 'm', 'Maximum water level', &
+           standard_name='maximum_sea_surface_height_above_reference_level')
+   endif
+   !
+   if (store_cumulative_precipitation) then
+      call def_maxtime_cell_float('cumprcp', map_file%cumprcp_varid, 'm', 'Cumulative precipitation depth', &
+           standard_name='cumulative_precipitation_depth', cell_methods='time: sum')
    endif
    !
    if (store_twet) then
-      NF90(nf90_def_var(map_file%ncid, 'tmax', NF90_FLOAT, (/map_file%nmesh2d_face_dimid, map_file%timemax_dimid/), map_file%tmax_varid)) ! time-varying duration wet cell
-      NF90(nf90_def_var_deflate(map_file%ncid, map_file%tmax_varid, 1, 1, nc_deflate_level))
-      NF90(nf90_put_att(map_file%ncid, map_file%tmax_varid, '_FillValue', FILL_VALUE))
-      NF90(nf90_put_att(map_file%ncid, map_file%tmax_varid, 'units', 'seconds'))
-      NF90(nf90_put_att(map_file%ncid, map_file%tmax_varid, 'standard_name', 'duration_wet_cell')) 
-      NF90(nf90_put_att(map_file%ncid, map_file%tmax_varid, 'long_name', 'Duration cell was considered wet'))   
-      NF90(nf90_put_att(map_file%ncid, map_file%tmax_varid, 'cell_methods', 'time: sum'))
+      call def_maxtime_cell_float('tmax', map_file%tmax_varid, 'seconds', 'Time cell was wet', &
+           standard_name='duration_wet', cell_methods='time: sum')
    endif
    !
    if (store_t_zsmax) then
-      NF90(nf90_def_var(map_file%ncid, 't_zsmax', NF90_FLOAT, (/map_file%nmesh2d_face_dimid, map_file%timemax_dimid/), map_file%t_zsmax_varid)) ! time-varying time stap of max water level in cell
-      NF90(nf90_def_var_deflate(map_file%ncid, map_file%t_zsmax_varid, 1, 1, nc_deflate_level))
-      NF90(nf90_put_att(map_file%ncid, map_file%t_zsmax_varid, '_FillValue', FILL_VALUE))
-      NF90(nf90_put_att(map_file%ncid, map_file%t_zsmax_varid, 'units', 'seconds since ' // trim(trefstr_iso8601) ))  ! time stamp following ISO 8601
-      NF90(nf90_put_att(map_file%ncid, map_file%t_zsmax_varid, 'standard_name', 'time_of_max_water_level')) 
-      NF90(nf90_put_att(map_file%ncid, map_file%t_zsmax_varid, 'long_name', 'Moment when zsmax occurs'))   
-      NF90(nf90_put_att(map_file%ncid, map_file%t_zsmax_varid, 'cell_methods', 'time: max'))
+      call def_maxtime_cell_float('t_zsmax', map_file%t_zsmax_varid, 'seconds since ' // trim(trefstr_iso8601), &
+           'time when zsmax occurs', standard_name='t_zsmax', cell_methods='time: maximum')
    endif
    !
    if (store_maximum_waterlevel) then
-      if (subgrid .eqv. .false. .or. store_hsubgrid .eqv. .true.) then   
-         NF90(nf90_def_var(map_file%ncid, 'hmax', NF90_FLOAT, (/map_file%nmesh2d_face_dimid, map_file%timemax_dimid/), map_file%hmax_varid)) ! time-varying maximum water depth map
-         NF90(nf90_def_var_deflate(map_file%ncid, map_file%hmax_varid, 1, 1, nc_deflate_level)) ! deflate
-         NF90(nf90_put_att(map_file%ncid, map_file%hmax_varid, '_FillValue', FILL_VALUE))   
-         NF90(nf90_put_att(map_file%ncid, map_file%hmax_varid, 'units', 'm'))
-         NF90(nf90_put_att(map_file%ncid, map_file%hmax_varid, 'standard_name', 'sea_floor_depth_below_sea_surface')) 
-         NF90(nf90_put_att(map_file%ncid, map_file%hmax_varid, 'long_name', 'Maximum water depth')) 
-         NF90(nf90_put_att(map_file%ncid, map_file%hmax_varid, 'cell_methods', 'time: maximum'))    
+      if (subgrid .eqv. .false. .or. store_hsubgrid .eqv. .true.) then
+         call def_maxtime_cell_float('hmax', map_file%hmax_varid, 'm', 'Maximum water depth', &
+              standard_name='sea_floor_depth_below_sea_surface', cell_methods='time: maximum')
       endif
    endif
    !
    if (store_maximum_velocity) then
-      NF90(nf90_def_var(map_file%ncid, 'vmax', NF90_FLOAT, (/map_file%nmesh2d_face_dimid, map_file%timemax_dimid/), map_file%vmax_varid)) ! maximum flow velocity map
-      NF90(nf90_def_var_deflate(map_file%ncid, map_file%vmax_varid, 1, 1, nc_deflate_level))
-      NF90(nf90_put_att(map_file%ncid, map_file%vmax_varid, '_FillValue', FILL_VALUE))   
-      NF90(nf90_put_att(map_file%ncid, map_file%vmax_varid, 'units', 'm s-1'))
-      NF90(nf90_put_att(map_file%ncid, map_file%vmax_varid, 'standard_name', 'maximum_flow_velocity')) ! no standard name available
-      NF90(nf90_put_att(map_file%ncid, map_file%vmax_varid, 'long_name', 'Maximum flow velocity')) 
-      NF90(nf90_put_att(map_file%ncid, map_file%vmax_varid, 'cell_methods', 'time: maximum'))
+      call def_maxtime_cell_float('vmax', map_file%vmax_varid, 'm s-1', 'Maximum flow velocity', &
+           standard_name='maximum_flow_velocity', cell_methods='time: maximum')
    endif
    !
    if (store_maximum_flux) then
-      NF90(nf90_def_var(map_file%ncid, 'qmax', NF90_FLOAT, (/map_file%nmesh2d_face_dimid, map_file%timemax_dimid/), map_file%qmax_varid)) ! maximum flux map
-      NF90(nf90_def_var_deflate(map_file%ncid, map_file%qmax_varid, 1, 1, nc_deflate_level)) ! deflate
-      NF90(nf90_put_att(map_file%ncid, map_file%qmax_varid, '_FillValue', FILL_VALUE))   
-      NF90(nf90_put_att(map_file%ncid, map_file%qmax_varid, 'units', 'm^2 s-1'))
-      NF90(nf90_put_att(map_file%ncid, map_file%qmax_varid, 'standard_name', 'maximum_flux')) ! no standard name available
-      NF90(nf90_put_att(map_file%ncid, map_file%qmax_varid, 'long_name', 'maximum_flux')) 
-      NF90(nf90_put_att(map_file%ncid, map_file%qmax_varid, 'cell_methods', 'time: maximum'))
-   endif
-   !
-   ! Store cumulative rainfall 
-   !
-   if (store_cumulative_precipitation) then  
-      !   
-      ! Cumulative precipitation
-      !
-      NF90(nf90_def_var(map_file%ncid, 'cumprcp', NF90_FLOAT, (/map_file%nmesh2d_face_dimid, map_file%timemax_dimid/), map_file%cumprcp_varid)) ! cumulative precipitation map
-      NF90(nf90_def_var_deflate(map_file%ncid, map_file%cumprcp_varid, 1, 1, nc_deflate_level))
-      NF90(nf90_put_att(map_file%ncid, map_file%cumprcp_varid, '_FillValue', FILL_VALUE))          
-      NF90(nf90_put_att(map_file%ncid, map_file%cumprcp_varid, 'units', 'm'))
-      NF90(nf90_put_att(map_file%ncid, map_file%cumprcp_varid, 'long_name', 'Cumulative precipitation depth')) 
-      NF90(nf90_put_att(map_file%ncid, map_file%cumprcp_varid, 'cell_methods', 'time: sum'))       
-      !   
-      ! Cumulative infiltration
-      !
-      NF90(nf90_def_var(map_file%ncid, 'cuminf', NF90_FLOAT, (/map_file%nmesh2d_face_dimid, map_file%timemax_dimid/), map_file%cuminf_varid)) ! cumulative infiltration map
-      NF90(nf90_def_var_deflate(map_file%ncid, map_file%cuminf_varid, 1, 1, nc_deflate_level))
-      NF90(nf90_put_att(map_file%ncid, map_file%cuminf_varid, '_FillValue', FILL_VALUE))
-      NF90(nf90_put_att(map_file%ncid, map_file%cuminf_varid, 'units', 'm'))
-      NF90(nf90_put_att(map_file%ncid, map_file%cuminf_varid, 'long_name', 'Cumulative infiltration depth')) 
-      NF90(nf90_put_att(map_file%ncid, map_file%cuminf_varid, 'cell_methods', 'time: sum'))     
-      !
-   endif
-   !
-   if (store_cumulative_urban_drainage .and. urban_drainage) then
-      !
-      NF90(nf90_def_var(map_file%ncid, 'urban_drainage_cumulative_depth', NF90_FLOAT, (/map_file%nmesh2d_face_dimid, map_file%timemax_dimid/), map_file%cumulative_urbdrain_varid))
-      NF90(nf90_def_var_deflate(map_file%ncid, map_file%cumulative_urbdrain_varid, 1, 1, nc_deflate_level))
-      NF90(nf90_put_att(map_file%ncid, map_file%cumulative_urbdrain_varid, '_FillValue', FILL_VALUE))
-      NF90(nf90_put_att(map_file%ncid, map_file%cumulative_urbdrain_varid, 'units', 'm'))
-      NF90(nf90_put_att(map_file%ncid, map_file%cumulative_urbdrain_varid, 'long_name', 'cumulative_urban_drainage_depth'))
-      NF90(nf90_put_att(map_file%ncid, map_file%cumulative_urbdrain_varid, 'cell_methods', 'time: sum'))
-      !
-   endif
-   !
-   if (store_meteo) then  
-      !
-      if (wind) then
-         !
-         NF90(nf90_def_var(map_file%ncid, 'wind_u', NF90_FLOAT, (/map_file%nmesh2d_face_dimid, map_file%time_dimid/), map_file%wind_u_varid)) ! time-varying wind_u map 
-         NF90(nf90_def_var_deflate(map_file%ncid, map_file%wind_u_varid, 1, 1, nc_deflate_level))
-         NF90(nf90_put_att(map_file%ncid, map_file%wind_u_varid, '_FillValue', FILL_VALUE))   
-         NF90(nf90_put_att(map_file%ncid, map_file%wind_u_varid, 'units', 'm s-1'))
-         NF90(nf90_put_att(map_file%ncid, map_file%wind_u_varid, 'standard_name', 'eastward_wind')) ! not truly eastward when rotated, eastward_sea_water_velocity
-         NF90(nf90_put_att(map_file%ncid, map_file%wind_u_varid, 'long_name', 'Wind speed u-component'))     
-         !
-         NF90(nf90_def_var(map_file%ncid, 'wind_v', NF90_FLOAT, (/map_file%nmesh2d_face_dimid, map_file%time_dimid/), map_file%wind_v_varid)) ! time-varying wind_u map 
-         NF90(nf90_def_var_deflate(map_file%ncid, map_file%wind_v_varid, 1, 1, nc_deflate_level))
-         NF90(nf90_put_att(map_file%ncid, map_file%wind_v_varid, '_FillValue', FILL_VALUE))   
-         NF90(nf90_put_att(map_file%ncid, map_file%wind_v_varid, 'units', 'm s-1'))
-         NF90(nf90_put_att(map_file%ncid, map_file%wind_v_varid, 'standard_name', 'northward_wind')) ! not truly eastward when rotated, eastward_sea_water_velocity
-         NF90(nf90_put_att(map_file%ncid, map_file%wind_v_varid, 'long_name', 'Wind speed v-component'))     
-         !
-         if (store_wind_max) then  
-            !
-            ! Store maximum wind speed
-            ! 
-            NF90(nf90_def_var(map_file%ncid, 'windmax', NF90_FLOAT, (/map_file%nmesh2d_face_dimid, map_file%timemax_dimid/), map_file%windmax_varid)) ! maximum wind speed m/s
-            NF90(nf90_def_var_deflate(map_file%ncid, map_file%windmax_varid, 1, 1, nc_deflate_level))
-            NF90(nf90_put_att(map_file%ncid, map_file%windmax_varid, '_FillValue', FILL_VALUE))
-            NF90(nf90_put_att(map_file%ncid, map_file%windmax_varid, 'units', 'm s-1'))
-            NF90(nf90_put_att(map_file%ncid, map_file%windmax_varid, 'long_name', 'Maximum wind speed')) 
-            NF90(nf90_put_att(map_file%ncid, map_file%windmax_varid, 'cell_methods', 'time: maximum'))         
-         endif
-         !
-      endif
-      !
-      if (patmos) then
-         !
-         NF90(nf90_def_var(map_file%ncid, 'surface_air_pressure', NF90_FLOAT, (/map_file%nmesh2d_face_dimid, map_file%time_dimid/), map_file%patm_varid)) ! atmospheric pressure map
-         NF90(nf90_def_var_deflate(map_file%ncid, map_file%patm_varid, 1, 1, nc_deflate_level)) ! deflate
-         NF90(nf90_put_att(map_file%ncid, map_file%patm_varid, '_FillValue', FILL_VALUE))          
-         NF90(nf90_put_att(map_file%ncid, map_file%patm_varid, 'units', 'N m-2'))
-         NF90(nf90_put_att(map_file%ncid, map_file%patm_varid, 'standard_name', 'surface_air_pressure'))
-         NF90(nf90_put_att(map_file%ncid, map_file%patm_varid, 'long_name', 'Surface air pressure')) 
-         !
-      endif   
-      !
-   endif
-   !
-   if (snapwave) then  
-      !
-      NF90(nf90_def_var(map_file%ncid, 'snapwavemsk', NF90_INT, (/map_file%nmesh2d_face_dimid/), map_file%snapwavemsk_varid)) ! input snapwave msk value in cell centre
-      NF90(nf90_def_var_deflate(map_file%ncid, map_file%snapwavemsk_varid, 1, 1, nc_deflate_level))
-      NF90(nf90_put_att(map_file%ncid, map_file%snapwavemsk_varid, '_FillValue', -999))      
-      NF90(nf90_put_att(map_file%ncid, map_file%snapwavemsk_varid, 'units', '-'))
-      NF90(nf90_put_att(map_file%ncid, map_file%snapwavemsk_varid, 'standard_name', 'snapwavemask'))
-      NF90(nf90_put_att(map_file%ncid, map_file%snapwavemsk_varid, 'long_name', 'SnapWave active cells mask')) 
-      NF90(nf90_put_att(map_file%ncid, map_file%snapwavemsk_varid, 'description', 'inactive=0, active=1, wave_boundary=2, neumann_boundary=3'))  
-      !
-      NF90(nf90_def_var(map_file%ncid, 'hm0', NF90_FLOAT, (/map_file%nmesh2d_face_dimid, map_file%time_dimid/), map_file%hm0_varid))
-      NF90(nf90_def_var_deflate(map_file%ncid, map_file%hm0_varid, 1, 1, nc_deflate_level))
-      NF90(nf90_put_att(map_file%ncid, map_file%hm0_varid, '_FillValue', FILL_VALUE))          
-      NF90(nf90_put_att(map_file%ncid, map_file%hm0_varid, 'units', 'm'))
-      NF90(nf90_put_att(map_file%ncid, map_file%hm0_varid, 'standard_name', 'hm0_wave_height'))
-      NF90(nf90_put_att(map_file%ncid, map_file%hm0_varid, 'long_name', 'Hm0 wave height')) 
-      !
-      NF90(nf90_def_var(map_file%ncid, 'hm0ig', NF90_FLOAT, (/map_file%nmesh2d_face_dimid, map_file%time_dimid/), map_file%hm0ig_varid))
-      NF90(nf90_def_var_deflate(map_file%ncid, map_file%hm0ig_varid, 1, 1, nc_deflate_level))
-      NF90(nf90_put_att(map_file%ncid, map_file%hm0ig_varid, '_FillValue', FILL_VALUE))          
-      NF90(nf90_put_att(map_file%ncid, map_file%hm0ig_varid, 'units', 'm'))
-      NF90(nf90_put_att(map_file%ncid, map_file%hm0ig_varid, 'standard_name', 'hm0_ig_wave_height'))
-      NF90(nf90_put_att(map_file%ncid, map_file%hm0ig_varid, 'long_name', 'Hm0 infragravity wave height')) 
-      !
-      if (store_wave_forces) then
-         !
-         NF90(nf90_def_var(map_file%ncid, 'fwx', NF90_FLOAT, (/map_file%nmesh2d_face_dimid, map_file%time_dimid/), map_file%fwx_varid))
-         NF90(nf90_def_var_deflate(map_file%ncid, map_file%fwx_varid, 1, 1, nc_deflate_level))
-         NF90(nf90_put_att(map_file%ncid, map_file%fwx_varid, '_FillValue', FILL_VALUE))          
-         NF90(nf90_put_att(map_file%ncid, map_file%fwx_varid, 'units', 'm'))
-         NF90(nf90_put_att(map_file%ncid, map_file%fwx_varid, 'standard_name', 'wave_force_x'))
-         NF90(nf90_put_att(map_file%ncid, map_file%fwx_varid, 'long_name', 'Wave force x-component'))
-         !
-         NF90(nf90_def_var(map_file%ncid, 'fwy', NF90_FLOAT, (/map_file%nmesh2d_face_dimid, map_file%time_dimid/), map_file%fwy_varid))
-         NF90(nf90_def_var_deflate(map_file%ncid, map_file%fwy_varid, 1, 1, nc_deflate_level))
-         NF90(nf90_put_att(map_file%ncid, map_file%fwy_varid, '_FillValue', FILL_VALUE))          
-         NF90(nf90_put_att(map_file%ncid, map_file%fwy_varid, 'units', 'm'))
-         NF90(nf90_put_att(map_file%ncid, map_file%fwy_varid, 'standard_name', 'wave_force_y'))
-         NF90(nf90_put_att(map_file%ncid, map_file%fwy_varid, 'long_name', 'Wave force y-component'))
-         !  
-         NF90(nf90_def_var(map_file%ncid, 'tp', NF90_FLOAT, (/map_file%nmesh2d_face_dimid, map_file%time_dimid/), map_file%tp_varid))
-         NF90(nf90_def_var_deflate(map_file%ncid, map_file%tp_varid, 1, 1, nc_deflate_level))
-         NF90(nf90_put_att(map_file%ncid, map_file%tp_varid, '_FillValue', FILL_VALUE))          
-         NF90(nf90_put_att(map_file%ncid, map_file%tp_varid, 'units', 's'))
-         NF90(nf90_put_att(map_file%ncid, map_file%tp_varid, 'standard_name', 'peak_wave_period'))
-         NF90(nf90_put_att(map_file%ncid, map_file%tp_varid, 'long_name', 'Peak wave period')) 
-         !
-         NF90(nf90_def_var(map_file%ncid, 'tpig', NF90_FLOAT, (/map_file%nmesh2d_face_dimid, map_file%time_dimid/), map_file%tpig_varid))
-         NF90(nf90_def_var_deflate(map_file%ncid, map_file%tpig_varid, 1, 1, nc_deflate_level))
-         NF90(nf90_put_att(map_file%ncid, map_file%tpig_varid, '_FillValue', FILL_VALUE))          
-         NF90(nf90_put_att(map_file%ncid, map_file%tpig_varid, 'units', 's'))
-         NF90(nf90_put_att(map_file%ncid, map_file%tpig_varid, 'standard_name', 'peak_ig_wave_period'))
-         NF90(nf90_put_att(map_file%ncid, map_file%tpig_varid, 'long_name', 'Peak infragravity wave period'))
-         !         
-         NF90(nf90_def_var(map_file%ncid, 'beta', NF90_FLOAT, (/map_file%nmesh2d_face_dimid, map_file%time_dimid/), map_file%beta_varid))
-         NF90(nf90_put_att(map_file%ncid, map_file%beta_varid, '_FillValue', FILL_VALUE))          
-         NF90(nf90_put_att(map_file%ncid, map_file%beta_varid, 'units', '-'))
-         NF90(nf90_put_att(map_file%ncid, map_file%beta_varid, 'standard_name', 'directionally_averaged_local_bed_slope')) 
-         NF90(nf90_put_att(map_file%ncid, map_file%beta_varid, 'long_name', 'Mean local bed slope'))
-         !           
-         NF90(nf90_def_var(map_file%ncid, 'snapwavedepth', NF90_FLOAT, (/map_file%nmesh2d_face_dimid, map_file%time_dimid/), map_file%snapwavedepth_varid))
-         NF90(nf90_put_att(map_file%ncid, map_file%snapwavedepth_varid, '_FillValue', FILL_VALUE))          
-         NF90(nf90_put_att(map_file%ncid, map_file%snapwavedepth_varid, 'units', 'm'))
-         NF90(nf90_put_att(map_file%ncid, map_file%snapwavedepth_varid, 'standard_name', 'snapwave_waterdepth'))
-         NF90(nf90_put_att(map_file%ncid, map_file%snapwavedepth_varid, 'long_name', 'Interpolated water depth in Snapwave')) 
-         !                            
-      endif
-      !
-      if (store_wave_direction) then
-         !
-         NF90(nf90_def_var(map_file%ncid, 'wavdir', NF90_FLOAT, (/map_file%nmesh2d_face_dimid, map_file%time_dimid/), map_file%wavdir_varid))          
-         NF90(nf90_put_att(map_file%ncid, map_file%wavdir_varid, '_FillValue', FILL_VALUE))
-         NF90(nf90_put_att(map_file%ncid, map_file%wavdir_varid, 'units', 'degrees'))
-         NF90(nf90_put_att(map_file%ncid, map_file%wavdir_varid, 'standard_name', 'mean_wave_direction')) 
-         NF90(nf90_put_att(map_file%ncid, map_file%wavdir_varid, 'long_name', 'Mean wave angle (deg)'))
-         !
-         !NF90(nf90_def_var(map_file%ncid, 'dirspr', NF90_FLOAT, (/map_file%nmesh2d_face_dimid, map_file%time_dimid/), map_file%dirspr_varid))                   
-         !NF90(nf90_put_att(map_file%ncid, map_file%dirspr_varid, '_FillValue', FILL_VALUE))
-         !NF90(nf90_put_att(map_file%ncid, map_file%dirspr_varid, 'units', 'degrees'))
-         !NF90(nf90_put_att(map_file%ncid, map_file%dirspr_varid, 'standard_name', 'wave_directional_spreading')) 
-         !NF90(nf90_put_att(map_file%ncid, map_file%dirspr_varid, 'long_name', 'Wave directional spreading'))  
-         !
-      endif         
-      !
-      if (wavemaker) then
-         !
-         NF90(nf90_def_var(map_file%ncid, 'zsm', NF90_FLOAT, (/map_file%nmesh2d_face_dimid, map_file%time_dimid/), map_file%zsm_varid))
-         NF90(nf90_def_var_deflate(map_file%ncid, map_file%zsm_varid, 1, 1, nc_deflate_level))
-         NF90(nf90_put_att(map_file%ncid, map_file%zsm_varid, '_FillValue', FILL_VALUE))          
-         NF90(nf90_put_att(map_file%ncid, map_file%zsm_varid, 'units', 'm'))
-         NF90(nf90_put_att(map_file%ncid, map_file%zsm_varid, 'standard_name', 'filtered_water_level'))
-         NF90(nf90_put_att(map_file%ncid, map_file%zsm_varid, 'long_name', 'Filtered water level')) 
-         !
-      endif   
-      !
-   endif
-   !
-   !
-   if (store_tsunami_arrival_time) then
-      ! 
-      NF90(nf90_def_var(map_file%ncid, 'tsunami_arrival_time', NF90_FLOAT, (/map_file%nmesh2d_face_dimid, map_file%time_dimid/), map_file%tsunami_arrival_time_varid))       
-      NF90(nf90_put_att(map_file%ncid, map_file%tsunami_arrival_time_varid, '_FillValue', FILL_VALUE))      
-      NF90(nf90_put_att(map_file%ncid, map_file%tsunami_arrival_time_varid, 'units', '-'))
-      NF90(nf90_put_att(map_file%ncid, map_file%tsunami_arrival_time_varid, 'standard_name', 'tsunami_arrival_time'))
-      NF90(nf90_put_att(map_file%ncid, map_file%tsunami_arrival_time_varid, 'long_name', 'Tsunami arrival time')) 
-      NF90(nf90_def_var_deflate(map_file%ncid, map_file%tsunami_arrival_time_varid, 1, 1, nc_deflate_level)) ! deflate
-      !
-   endif
-   !
-   if (infiltration) then
-       NF90(nf90_def_var(map_file%ncid, 'qinf', NF90_FLOAT, (/map_file%nmesh2d_face_dimid/), map_file%qinf_varid))
-       NF90(nf90_def_var_deflate(map_file%ncid, map_file%qinf_varid, 1, 1, nc_deflate_level))
-       NF90(nf90_put_att(map_file%ncid, map_file%qinf_varid, '_FillValue', FILL_VALUE))     
-       if (inftype == 'cna') then
-           NF90(nf90_put_att(map_file%ncid, map_file%qinf_varid, 'standard_name', 'S')) 
-           NF90(nf90_put_att(map_file%ncid, map_file%qinf_varid, 'long_name', 'moisture storage (S) capacity - Curve number')) 
-           NF90(nf90_put_att(map_file%ncid, map_file%qinf_varid, 'units', 'm'))
-       elseif (inftype == 'cnb') then
-           NF90(nf90_put_att(map_file%ncid, map_file%qinf_varid, 'standard_name', 'Smax')) 
-           NF90(nf90_put_att(map_file%ncid, map_file%qinf_varid, 'long_name', 'maximum moisture storage (Smax) capacity - Curve number')) 
-           NF90(nf90_put_att(map_file%ncid, map_file%qinf_varid, 'units', 'm'))
-       elseif (inftype == 'gai') then
-           NF90(nf90_put_att(map_file%ncid, map_file%qinf_varid, 'standard_name', 'psi')) 
-           NF90(nf90_put_att(map_file%ncid, map_file%qinf_varid, 'long_name', 'suction head at the wetting front - Green and Ampt')) 
-           NF90(nf90_put_att(map_file%ncid, map_file%qinf_varid, 'units', 'm'))
-       elseif (inftype == 'hor') then
-           NF90(nf90_put_att(map_file%ncid, map_file%qinf_varid, 'standard_name', 'f0'))
-           NF90(nf90_put_att(map_file%ncid, map_file%qinf_varid, 'long_name', 'initial infiltration rate - Horton'))
-           NF90(nf90_put_att(map_file%ncid, map_file%qinf_varid, 'units', 'mm h-1'))
-       elseif (inftype == 'bkt') then
-           NF90(nf90_put_att(map_file%ncid, map_file%qinf_varid, 'standard_name', 'bucket_capacity'))
-           NF90(nf90_put_att(map_file%ncid, map_file%qinf_varid, 'long_name', 'maximum bucket storage capacity'))
-           NF90(nf90_put_att(map_file%ncid, map_file%qinf_varid, 'units', 'mm'))
-       else
-           NF90(nf90_put_att(map_file%ncid, map_file%qinf_varid, 'standard_name', 'qinf'))
-           NF90(nf90_put_att(map_file%ncid, map_file%qinf_varid, 'long_name', 'infiltration rate - constant in time'))
-           NF90(nf90_put_att(map_file%ncid, map_file%qinf_varid, 'units', 'mm h-1'))
-       endif
-   endif
-   !
-   if (nonhydrostatic) then
-      !
-      NF90(nf90_def_var(map_file%ncid, 'pnonh', NF90_FLOAT, (/map_file%nmesh2d_face_dimid, map_file%time_dimid/), map_file%pnonh_varid))
-      NF90(nf90_def_var_deflate(map_file%ncid, map_file%pnonh_varid, 1, 1, nc_deflate_level)) ! deflate
-      NF90(nf90_put_att(map_file%ncid, map_file%pnonh_varid, '_FillValue', FILL_VALUE))          
-      NF90(nf90_put_att(map_file%ncid, map_file%pnonh_varid, 'units', 'N m-2'))
-      NF90(nf90_put_att(map_file%ncid, map_file%pnonh_varid, 'standard_name', 'non_hydrostatic_pressure'))
-      NF90(nf90_put_att(map_file%ncid, map_file%pnonh_varid, 'long_name', 'Non-hydrostatic pressure')) 
-      ! 
+      call def_maxtime_cell_float('qmax', map_file%qmax_varid, 'm^2 s-1', 'maximum_flux', standard_name='maximum_flux', &
+           cell_methods='time: maximum')
    endif
    !
    if (timestep_analysis) then
+      call def_static_cell_float('average_required_timestep', map_file%average_required_timestep_varid, 's', &
+           'time-averaged required timestep over the simulation', standard_name='average_required_timestep')
       !
-      ! Average time step (written once at end of simulation, no time dimension)
-      NF90(nf90_def_var(map_file%ncid, 'Average required time step', NF90_FLOAT, (/map_file%nmesh2d_face_dimid/), map_file%average_required_timestep_varid))
-      NF90(nf90_def_var_deflate(map_file%ncid, map_file%average_required_timestep_varid, 1, 1, nc_deflate_level)) ! deflate
-      NF90(nf90_put_att(map_file%ncid, map_file%average_required_timestep_varid, '_FillValue', FILL_VALUE))
-      NF90(nf90_put_att(map_file%ncid, map_file%average_required_timestep_varid, 'units', 's'))
-      NF90(nf90_put_att(map_file%ncid, map_file%average_required_timestep_varid, 'standard_name', 'Average required time step'))
-      NF90(nf90_put_att(map_file%ncid, map_file%average_required_timestep_varid, 'long_name', 'Average required time step'))
-      !NF90(nf90_put_att(map_file%ncid, map_file%average_required_timestep_varid, 'cell_methods', 'time: average'))
+      call def_static_cell_float('percentage_limiting_timestep', map_file%percentage_limiting_varid, '%', &
+           'percentage of simulation steps in which this cell was the limiting cell', &
+           standard_name='percentage_limiting_timestep')
+   endif
+   !
+   if (store_cumulative_precipitation .and. infiltration) then
+      call def_maxtime_cell_float('cuminf', map_file%cuminf_varid, 'm', 'cumulative_infiltration_depth', cell_methods='time: sum')
+   endif
+   !
+   ! -------------------------------------------------------
+   ! Meteo variables
+   ! -------------------------------------------------------
+   if (store_meteo) then
+      if (wind) then
+         call def_time_cell_float('wind_u', map_file%wind_u_varid, 'm s-1', 'Wind speed u-component', standard_name='eastward_wind')
+         !
+         call def_time_cell_float('wind_v', map_file%wind_v_varid, 'm s-1', 'Wind speed v-component', standard_name='northward_wind')
+         !
+         ! windmax (treated like all other max fields: max-time-varying)
+         if (store_wind_max .and. meteo3d) then
+            call def_maxtime_cell_float('windmax', map_file%windmax_varid, 'm s-1', 'Maximum wind speed', &
+                 cell_methods='time: maximum')
+         endif
+      endif
       !
-      ! Times limiting (written once at end of simulation, no time dimension)
-      NF90(nf90_def_var(map_file%ncid, 'percentage_limiting_timestep', NF90_FLOAT, (/map_file%nmesh2d_face_dimid/), map_file%percentage_limiting_varid))
-      NF90(nf90_def_var_deflate(map_file%ncid, map_file%percentage_limiting_varid, 1, 1, nc_deflate_level)) ! deflate
-      NF90(nf90_put_att(map_file%ncid, map_file%percentage_limiting_varid, '_FillValue', FILL_VALUE))
-      NF90(nf90_put_att(map_file%ncid, map_file%percentage_limiting_varid, 'units', '%'))
-      NF90(nf90_put_att(map_file%ncid, map_file%percentage_limiting_varid, 'standard_name', 'percentage_limiting_timestep'))
-      NF90(nf90_put_att(map_file%ncid, map_file%percentage_limiting_varid, 'long_name', 'Fraction of steps cell was limiting'))
-      !NF90(nf90_put_att(map_file%ncid, map_file%percentage_limiting_varid, 'cell_methods', 'time: maximum'))
+      if (patmos) then
+         call def_time_cell_float('surface_air_pressure', map_file%patm_varid, 'N m-2', 'Surface air pressure', &
+              standard_name='surface_air_pressure')
+      endif
+      !
+      ! precipitation_rate (prcp source array is np-shaped on both grids;
+      ! sfincs_meteo applies precip identically regardless of grid type)
+      if (precip) then
+         call def_time_cell_float('precipitation_rate', map_file%precip_varid, 'mm h-1', 'Precipitation rate', &
+              standard_name='precipitation_rate')
+      endif
+   endif
+   !
+   ! -------------------------------------------------------
+   ! SnapWave variables
+   ! -------------------------------------------------------
+   if (snapwave) then
+      !
+      ! snapwavemsk: NF90_INT on both grid types, described via CF
+      ! flag_values / flag_meanings.
+      call def_static_cell_int('snapwavemsk', map_file%snapwavemsk_varid, 'SnapWave active cells mask', &
+           units='-', &
+           description='inactive=0, active=1, wave_boundary=2, neumann_boundary=3', &
+           flag_values=(/0, 1, 2, 3/), &
+           flag_meanings='inactive active wave_boundary neumann_boundary')
+      !
+      call def_time_cell_float('hm0', map_file%hm0_varid, 'm', 'Hm0 wave height', standard_name='hm0_wave_height')
+      !
+      call def_time_cell_float('hm0ig', map_file%hm0ig_varid, 'm', 'Hm0 infragravity wave height', &
+           standard_name='hm0_ig_wave_height')
+      !
+      call def_time_cell_float('tp', map_file%tp_varid, 's', 'Peak wave period', standard_name='peak_wave_period')
+      !
+      call def_time_cell_float('tpig', map_file%tpig_varid, 's', 'Peak infragravity wave period', &
+           standard_name='peak_ig_wave_period')
+      !
+      if (store_wave_forces) then
+         call def_time_cell_float('fwx', map_file%fwx_varid, 'm', 'Wave force x-component', standard_name='wave_force_x')
+         !
+         call def_time_cell_float('fwy', map_file%fwy_varid, 'm', 'Wave force y-component', standard_name='wave_force_y')
+         !
+         call def_time_cell_float('beta', map_file%beta_varid, '-', 'Mean local bed slope', &
+              standard_name='directionally_averaged_local_bed_slope')
+         !
+         call def_time_cell_float('snapwavedepth', map_file%snapwavedepth_varid, 'm', 'Interpolated water depth in Snapwave', &
+              standard_name='snapwave_waterdepth')
+      endif
+      !
+      if (store_wave_direction) then
+         call def_time_cell_float('wavdir', map_file%wavdir_varid, 'degrees', 'Mean wave angle (deg)', &
+              standard_name='mean_wave_direction')
+      endif
+      !
+      if (wavemaker) then
+         call def_time_cell_float('zsm', map_file%zsm_varid, 'm', 'Filtered water level', standard_name='mean_water_level')
+      endif
       !
    endif
    !
-   ! Add for final output
+   ! tsunami_arrival_time (single value per cell, written once at finalize)
+   if (store_tsunami_arrival_time) then
+      call def_static_cell_float('tsunami_arrival_time', map_file%tsunami_arrival_time_varid, &
+           '-', 'Tsunami arrival time', standard_name='tsunami_arrival_time')
+   endif
    !
-   NF90(nf90_def_var(map_file%ncid, 'total_runtime', NF90_FLOAT, (/map_file%runtime_dimid/),map_file%total_runtime_varid))
-   NF90(nf90_put_att(map_file%ncid, map_file%total_runtime_varid, 'units', 's'))   
-   NF90(nf90_put_att(map_file%ncid, map_file%total_runtime_varid, 'long_name', 'Total model runtime (s)'))
+   if (nonhydrostatic) then
+      call def_time_cell_float('pnonh', map_file%pnonh_varid, 'N m-2', 'Non-hydrostatic pressure')
+   endif
    !
-   NF90(nf90_def_var(map_file%ncid, 'average_dt', NF90_FLOAT, (/map_file%runtime_dimid/), map_file%average_dt_varid))
-   NF90(nf90_put_att(map_file%ncid, map_file%total_runtime_varid, 'units', 's'))   
-   NF90(nf90_put_att(map_file%ncid, map_file%total_runtime_varid, 'long_name', 'Average model time step (s)'))   
+   ! Runtime scalars
+   call ncdef_float_var(map_file%ncid, 'total_runtime', (/map_file%runtime_dimid/), map_file%total_runtime_varid, &
+        's', 'Total model runtime (s)')
    !
-   NF90(nf90_def_var(map_file%ncid, 'status', NF90_FLOAT, (/map_file%runtime_dimid/), map_file%status_varid))
-   NF90(nf90_put_att(map_file%ncid, map_file%status_varid, 'units', '-'))   
-   NF90(nf90_put_att(map_file%ncid, map_file%status_varid, 'long_name', 'status of SFINCS simulation - 0 is no error'))        
-   ! 
+   call ncdef_float_var(map_file%ncid, 'average_dt', (/map_file%runtime_dimid/), map_file%average_dt_varid, &
+        's', 'Average model time step (s)')
+   !
+   call ncdef_float_var(map_file%ncid, 'status', (/map_file%runtime_dimid/), map_file%status_varid, &
+        '-', 'status of SFINCS simulation - 0 is no error')
+   !
+   ! -------------------------------------------------------
    ! Finish definitions
+   ! -------------------------------------------------------
    NF90(nf90_enddef(map_file%ncid))
    !
-   NF90(nf90_put_var(map_file%ncid, map_file%mesh2d_node_x_varid, nodes_x)) ! write node x 
+   ! -------------------------------------------------------
+   ! Write static grid data
+   ! -------------------------------------------------------
    !
-   NF90(nf90_put_var(map_file%ncid, map_file%mesh2d_node_y_varid, nodes_y)) ! write node y
-   ! 
-   NF90(nf90_put_var(map_file%ncid, map_file%mesh2d_face_nodes_varid, face_nodes))
-   !
-   ! Compute and write face centroids (average of node coordinates)
-   !
-   vtmp = FILL_VALUE
-   do nmq = 1, n_faces
-      vtmp(nmq) = sum(nodes_x(face_nodes(:,nmq))) / 4.0
-   enddo
-   NF90(nf90_put_var(map_file%ncid, map_file%mesh2d_face_x_varid, vtmp)) ! write face centroid x
-   !
-   vtmp = FILL_VALUE
-   do nmq = 1, n_faces
-      vtmp(nmq) = sum(nodes_y(face_nodes(:,nmq))) / 4.0
-   enddo
-   NF90(nf90_put_var(map_file%ncid, map_file%mesh2d_face_y_varid, vtmp)) ! write face centroid y
-   !
-!   ! now for cell edges
-!   NF90(nf90_put_var(map_file%ncid, map_file%face_x_varid, xz(2:nmax+1-1, 2:mmax+1-1), (/1, 1/))) ! write xz of edges
-!   !
-!   NF90(nf90_put_var(map_file%ncid, map_file%face_y_varid, yz(2:nmax+1-1, 2:mmax+1-1), (/1, 1/))) ! write yz of edges   
-   !
-   ! Write epsg, msk & bed level already to file
-   !
+   ! Topology / coordinate axes — grid-type-specific
+   if (use_quadtree) then
+      NF90(nf90_put_var(map_file%ncid, map_file%mesh2d_node_x_varid,     nodes_x))
+      NF90(nf90_put_var(map_file%ncid, map_file%mesh2d_node_y_varid,     nodes_y))
+      NF90(nf90_put_var(map_file%ncid, map_file%mesh2d_face_nodes_varid, face_nodes))
+      ! Write face centroid coordinates (cell centres)
+      block
+         real, allocatable :: face_cx(:), face_cy(:)
+         integer :: ifac, iref2
+         real    :: dxx2, dyy2
+         allocate(face_cx(n_faces), face_cy(n_faces))
+         do ifac = 1, n_faces
+            n    = quadtree_n(ifac)
+            m    = quadtree_m(ifac)
+            iref2 = quadtree_level(ifac)
+            dxx2  = quadtree_dxr(iref2)
+            dyy2  = quadtree_dyr(iref2)
+            face_cx(ifac) = x0 + cosrot*(m - 0.5)*dxx2 - sinrot*(n - 0.5)*dyy2
+            face_cy(ifac) = y0 + sinrot*(m - 0.5)*dxx2 + cosrot*(n - 0.5)*dyy2
+         enddo
+         NF90(nf90_put_var(map_file%ncid, map_file%mesh2d_face_x_varid, face_cx))
+         NF90(nf90_put_var(map_file%ncid, map_file%mesh2d_face_y_varid, face_cy))
+         deallocate(face_cx, face_cy)
+      end block
+   else
+      allocate(xz(mmax,     nmax))
+      allocate(yz(mmax,     nmax))
+      allocate(xg(mmax + 1, nmax + 1))
+      allocate(yg(mmax + 1, nmax + 1))
+      do n = 1, nmax
+         do m = 1, mmax
+            xz(m, n) = x0 + cosrot*(1.0*(m - 0.5))*dx - sinrot*(1.0*(n - 0.5))*dy
+            yz(m, n) = y0 + sinrot*(1.0*(m - 0.5))*dx + cosrot*(1.0*(n - 0.5))*dy
+         enddo
+      enddo
+      do n = 1, nmax + 1
+         do m = 1, mmax + 1
+            xg(m, n) = x0 + cosrot*(1.0*(m - 1))*dx - sinrot*(1.0*(n - 1))*dy
+            yg(m, n) = y0 + sinrot*(1.0*(m - 1))*dx + cosrot*(1.0*(n - 1))*dy
+         enddo
+      enddo
+      call put_2d(map_file%face_x_varid,   xz)
+      call put_2d(map_file%face_y_varid,   yz)
+      call put_2d(map_file%corner_x_varid, xg)
+      call put_2d(map_file%corner_y_varid, yg)
+   endif
    NF90(nf90_put_var(map_file%ncid, map_file%crs_varid, epsg))
    !
-   vtmp = FILL_VALUE
+   ! Cell-data writes — uniform via gather/put helpers
    !
-   if (subgrid) then
-      do nmq = 1, quadtree_nr_points
-         nm = index_sfincs_in_quadtree(nmq)
-         if (nm>0) then
-            vtmp(nmq) = subgrid_z_zmin(nm)
-         endif
-      enddo 
-      NF90(nf90_put_var(map_file%ncid, map_file%zb_varid, vtmp))
-   else
-      do nmq = 1, quadtree_nr_points
-         nm = index_sfincs_in_quadtree(nmq)
-         if (nm>0) then
-            vtmp(nmq) = zb(nm)
-         endif
-      enddo 
-      NF90(nf90_put_var(map_file%ncid, map_file%zb_varid, vtmp))
-   endif
-   !
-   ! Subgrid slope
-   !
-   if (subgrid .and. store_hsubgrid .and. store_hmean) then
-      !
-      vtmp = FILL_VALUE
-      !
-      do nmq = 1, quadtree_nr_points
-         nm = index_sfincs_in_quadtree(nmq)
-         if (nm>0) then
-            if (crsgeo) then
-               vtmp(nmq) = (subgrid_z_zmax(nm) - subgrid_z_zmin(nm)) / sqrt(cell_area_m2(nm))
-            else   
-               vtmp(nmq) = (subgrid_z_zmax(nm) - subgrid_z_zmin(nm)) / sqrt(cell_area(z_flags_iref(nm)))
-            endif
-         endif
-      enddo 
-      !
-      NF90(nf90_put_var(map_file%ncid, map_file%subgridslope_varid, vtmp))
-      !
-   endif
-   !   
-   vtmpi = 0
-   !
-   do nmq = 1, quadtree_nr_points
-      nm = index_sfincs_in_quadtree(nmq)
-      if (nm>0) then
-         vtmpi(nmq) = kcs(nm)
+   ! zb static write — fires whenever the def chose the static shape.
+   ! That is: quadtree, OR regular without dynamic bed level, OR subgrid
+   ! (subgrid_z_zmin is a single value per cell so dynamic bed level does
+   ! not apply). The complement (regular + dynamic bed level + non-subgrid)
+   ! is written each timestep in ncoutput_update_map instead.
+   if (use_quadtree .or. .not. store_dynamic_bed_level .or. subgrid) then
+      if (subgrid) then
+         call put_static_cell_float(map_file%ncid, map_file%zb_varid, subgrid_z_zmin, FILL_VALUE)
+      else
+         call put_static_cell_float(map_file%ncid, map_file%zb_varid, zb, FILL_VALUE)
       endif
-   enddo 
-   !
-   NF90(nf90_put_var(map_file%ncid, map_file%msk_varid, vtmpi)) ! write msk 
-   !
-   ! Write SnapWave msk
-   !
-   if (snapwave) then  
-      !
-      vtmpi = 0
-      !
-      do nmq = 1, quadtree_nr_points
-         nm = index_sw_in_qt(nmq)            
-         if (nm>0) then
-            vtmpi(nmq) = snapwave_mask(nm)                  
-         endif
-      enddo 
-      !
-      NF90(nf90_put_var(map_file%ncid, map_file%snapwavemsk_varid, vtmpi)) ! write snapwave msk  
-      !
-   endif
-   !   
-   ! Write Manning (only non-subgrid model)
-   !   
-   if (.not. subgrid .and. manning2d) then
-      !
-      vtmp = FILL_VALUE
-      !
-      do nmq = 1, quadtree_nr_points
-         !
-         nm = index_sfincs_in_quadtree(nmq)
-         !
-         if (nm>0) then
-            ! 
-            vtmp(nmq) = rghfield(nm) ! gn2uv is on uv-points, but rghfield is in center  
-            !
-         endif    
-         ! 
-      enddo 
-      !
-      NF90(nf90_put_var(map_file%ncid, map_file%manning_varid, vtmp))  
-      !
    endif
    !
-   ! Write infiltration map
-   !   
-   vtmp = FILL_VALUE
-   !
-   if (infiltration .and. allocated(qinffield)) then
-      !
-      if (inftype == 'con' .or. inftype == 'c2d') then
-         do nmq = 1, quadtree_nr_points
-            nm = index_sfincs_in_quadtree(nmq)
-            if (nm>0) then
-               vtmp(nmq) = qinffield(nm) * 3600 * 1000
-            endif
+   ! subgrid slope (precompute the source — denominator depends on crsgeo)
+   if (subgrid .and. store_hsubgrid .and. store_hmean) then
+      allocate(slope_buf(np))
+      if (crsgeo) then
+         do nm = 1, np
+            slope_buf(nm) = (subgrid_z_zmax(nm) - subgrid_z_zmin(nm)) / sqrt(cell_area_m2(nm))
          enddo
       else
-         do nmq = 1, quadtree_nr_points
-            nm = index_sfincs_in_quadtree(nmq)
-            if (nm>0) then
-               vtmp(nmq) = qinffield(nm)
-            endif
+         do nm = 1, np
+            slope_buf(nm) = (subgrid_z_zmax(nm) - subgrid_z_zmin(nm)) / sqrt(cell_area(z_flags_iref(nm)))
          enddo
       endif
-      !
-      NF90(nf90_put_var(map_file%ncid, map_file%qinf_varid, vtmp)) ! write infiltration map
-      !
+      call put_static_cell_float(map_file%ncid, map_file%subgridslope_varid, slope_buf, FILL_VALUE)
+      deallocate(slope_buf)
    endif
    !
-   ! Write bucket capacity map (static)
+   ! msk (kcs is integer*1 — cast to real*4 for the generic mask helper)
+   call put_static_cell_mask(map_file%ncid, map_file%msk_varid, real(kcs, 4))
    !
-   if (inftype == 'bkt' .and. allocated(bucket_capacity)) then
-      !
-      vtmp = FILL_VALUE
-      !
-      do nmq = 1, quadtree_nr_points
-         nm = index_sfincs_in_quadtree(nmq)
-         if (nm>0) then
-            vtmp(nmq) = bucket_capacity(nm) * 1000.0 ! m to mm
-         endif
-      enddo
-      !
-      NF90(nf90_put_var(map_file%ncid, map_file%qinf_varid, vtmp)) ! write bucket capacity map
-      !
+   ! snapwave msk (real*4 source; uses snapwave's own quadtree index)
+   if (snapwave) then
+      call put_static_cell_mask(map_file%ncid, map_file%snapwavemsk_varid, snapwave_mask, sw_index=.true.)
    endif
    !
-   ! Write vegetation fields (static, written once at init)
+   ! Manning
+   if (.not. subgrid .and. manning2d) then
+      call put_static_cell_float(map_file%ncid, map_file%manning_varid, rghfield, FILL_VALUE)
+   endif
    !
+   ! Infiltration map (cna/c2d are stored as mm h-1, others use raw qinffield units)
+   if (infiltration) then
+      if (inftype == 'con' .or. inftype == 'c2d') then
+         call put_static_cell_float(map_file%ncid, map_file%qinf_varid, qinffield, FILL_VALUE, scale=3.6e6)
+      else
+         call put_static_cell_float(map_file%ncid, map_file%qinf_varid, qinffield, FILL_VALUE)
+      endif
+   endif
+   !
+   ! Vegetation stem properties (static, written once at init)
    if (store_vegetation) then
-      !
-      allocate(vtmp2d(n_faces, vegetation_vertical_segments))
-      !
-      vtmp2d = FILL_VALUE
-      do nmq = 1, quadtree_nr_points
-         nm = index_sfincs_in_quadtree(nmq)
-         if (nm > 0) then
-            do isec = 1, vegetation_vertical_segments
-               vtmp2d(nmq, isec) = vegetation_stems_cd(nm, isec)
-            enddo
-         endif
-      enddo
-      NF90(nf90_put_var(map_file%ncid, map_file%veg_cd_varid, vtmp2d))
-      !
-      vtmp2d = FILL_VALUE
-      do nmq = 1, quadtree_nr_points
-         nm = index_sfincs_in_quadtree(nmq)
-         if (nm > 0) then
-            do isec = 1, vegetation_vertical_segments
-               vtmp2d(nmq, isec) = vegetation_stems_height(nm, isec)
-            enddo
-         endif
-      enddo
-      NF90(nf90_put_var(map_file%ncid, map_file%veg_ah_varid, vtmp2d))
-      !
-      vtmp2d = FILL_VALUE
-      do nmq = 1, quadtree_nr_points
-         nm = index_sfincs_in_quadtree(nmq)
-         if (nm > 0) then
-            do isec = 1, vegetation_vertical_segments
-               vtmp2d(nmq, isec) = vegetation_stems_diameter(nm, isec)
-            enddo
-         endif
-      enddo
-      NF90(nf90_put_var(map_file%ncid, map_file%veg_bstems_varid, vtmp2d))
-      !
-      vtmp2d = FILL_VALUE
-      do nmq = 1, quadtree_nr_points
-         nm = index_sfincs_in_quadtree(nmq)
-         if (nm > 0) then
-            do isec = 1, vegetation_vertical_segments
-               vtmp2d(nmq, isec) = vegetation_stems_density(nm, isec)
-            enddo
-         endif
-      enddo
-      NF90(nf90_put_var(map_file%ncid, map_file%veg_Nstems_varid, vtmp2d))
-      !
-      deallocate(vtmp2d)
-      !
+      call put_static_veg_float(map_file%ncid, map_file%veg_cd_varid,     vegetation_stems_cd,       vegetation_vertical_segments, FILL_VALUE)
+      call put_static_veg_float(map_file%ncid, map_file%veg_ah_varid,     vegetation_stems_height,   vegetation_vertical_segments, FILL_VALUE)
+      call put_static_veg_float(map_file%ncid, map_file%veg_bstems_varid, vegetation_stems_diameter, vegetation_vertical_segments, FILL_VALUE)
+      call put_static_veg_float(map_file%ncid, map_file%veg_Nstems_varid, vegetation_stems_density,  vegetation_vertical_segments, FILL_VALUE)
    endif
    !
-   ! write away intermediate data
+   NF90(nf90_sync(map_file%ncid))
    !
-   NF90(nf90_sync(map_file%ncid)) !write away intermediate data
-   !
-   end subroutine
+   end subroutine ncoutput_map_init
 
 
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+   !
    subroutine ncoutput_his_init()
    !
    ! 1. Initialise dimensions/variables/attributes
@@ -1918,8 +852,9 @@ contains
    NF90(nf90_def_dim(his_file%ncid, 'pointnamelength', 256, his_file%pointnamelength_dimid)) ! length of station_name per obs point  
    NF90(nf90_def_dim(his_file%ncid, 'runtime', 1, his_file%runtime_dimid)) ! total_runtime, average_dt    
    !
-   ! Some metadata attributes 
-   NF90(nf90_put_att(his_file%ncid,nf90_global, "Conventions", "Conventions = 'CF-1.6, SGRID-0.3")) 
+   ! Some metadata attributes
+   NF90(nf90_put_att(his_file%ncid, nf90_global, "Conventions",   "CF-1.8"))
+   NF90(nf90_put_att(his_file%ncid, nf90_global, "featureType",   "timeSeries"))
    NF90(nf90_put_att(his_file%ncid,nf90_global, "Build-Revision-Date-Netcdf-library", trim(nf90_inq_libvers()))) ! version of netcdf library
    NF90(nf90_put_att(his_file%ncid,nf90_global, "Producer", "SFINCS model: Super-Fast INundation of CoastS"))
    NF90(nf90_put_att(his_file%ncid,nf90_global, "Build-Revision", trim(build_revision))) 
@@ -1935,7 +870,6 @@ contains
    !NF90(nf90_put_att(his_file%ncid, his_file%station_id_varid, 'units', '-')) !not wanted in fews
    !
    NF90(nf90_def_var(his_file%ncid, 'station_name', NF90_CHAR, (/his_file%pointnamelength_dimid, his_file%points_dimid/), his_file%station_name_varid))
-   !NF90(nf90_put_att(his_file%ncid, his_file%station_name_varid, 'units', '-')) !not wanted in fews
    NF90(nf90_put_att(his_file%ncid, his_file%station_name_varid, 'cf_role', 'timeseries_id'))
    !
    if (nrcrosssections>0) then
@@ -1961,43 +895,18 @@ contains
    !NF90(nf90_put_att(his_file%ncid, his_file%station_name_varid, 'units', '-')) !not wanted in fews
    !
    ! Domain
-   NF90(nf90_def_var(his_file%ncid, 'station_x', NF90_FLOAT, (/his_file%points_dimid/), his_file%station_x_varid))   ! non snapped input coordinate 
-   NF90(nf90_put_att(his_file%ncid, his_file%station_x_varid, 'units', 'm'))
-   NF90(nf90_put_att(his_file%ncid, his_file%station_x_varid, 'standard_name', 'projection_x_coordinate'))
-   NF90(nf90_put_att(his_file%ncid, his_file%station_x_varid, 'long_name', 'original_x_coordinate_of_station'))
-   NF90(nf90_put_att(his_file%ncid, his_file%station_x_varid, 'grid_mapping', 'crs'))   
-   !NF90(nf90_put_att(his_file%ncid, his_file%station_x_varid, 'grid', 'sfincsgrid'))   !keep this?
-   !
-   NF90(nf90_def_var(his_file%ncid, 'station_y', NF90_FLOAT, (/his_file%points_dimid/), his_file%station_y_varid)) 
-   NF90(nf90_put_att(his_file%ncid, his_file%station_y_varid, 'units', 'm'))
-   NF90(nf90_put_att(his_file%ncid, his_file%station_y_varid, 'standard_name', 'projection_y_coordinate'))
-   NF90(nf90_put_att(his_file%ncid, his_file%station_y_varid, 'long_name', 'original_y_coordinate_of_station'))
-   NF90(nf90_put_att(his_file%ncid, his_file%station_y_varid, 'grid_mapping', 'crs'))   
-   !
-   NF90(nf90_def_var(his_file%ncid, 'point_x', NF90_FLOAT, (/his_file%points_dimid/), his_file%point_x_varid))  ! snapped coordinate as used in sfincs
-   NF90(nf90_put_att(his_file%ncid, his_file%point_x_varid, 'units', 'm'))
-   NF90(nf90_put_att(his_file%ncid, his_file%point_x_varid, 'standard_name', 'projection_x_coordinate'))
-   NF90(nf90_put_att(his_file%ncid, his_file%point_x_varid, 'long_name', 'point_x'))    
-   NF90(nf90_put_att(his_file%ncid, his_file%point_x_varid, 'grid_mapping', 'crs'))   
-   !NF90(nf90_put_att(his_file%ncid, his_file%point_x_varid, 'grid', 'sfincsgrid'))   !keep this?
-   !
-   NF90(nf90_def_var(his_file%ncid, 'point_y', NF90_FLOAT, (/his_file%points_dimid/), his_file%point_y_varid)) 
-   NF90(nf90_put_att(his_file%ncid, his_file%point_y_varid, 'units', 'm'))
-   NF90(nf90_put_att(his_file%ncid, his_file%point_y_varid, 'standard_name', 'projection_y_coordinate'))
-   NF90(nf90_put_att(his_file%ncid, his_file%point_y_varid, 'long_name', 'point_y'))
-   NF90(nf90_put_att(his_file%ncid, his_file%point_y_varid, 'grid_mapping', 'crs'))   
-   !NF90(nf90_put_att(his_file%ncid, his_file%point_y_varid, 'grid', 'sfincsgrid'))   !keep this?   
+   ! Station coordinates: input lat/lon or x/y (CRS-aware via crsgeo)
+   call def_his_point_coord('station_x', 'x', his_file%station_x_varid, 'original_x_coordinate_of_station')
+   call def_his_point_coord('station_y', 'y', his_file%station_y_varid, 'original_y_coordinate_of_station')
+   call def_his_point_coord('point_x',   'x', his_file%point_x_varid,   'point_x')
+   call def_his_point_coord('point_y',   'y', his_file%point_y_varid,   'point_y')
    !
    NF90(nf90_def_var(his_file%ncid, 'crs', NF90_INT, his_file%crs_varid)) ! For EPSG code
-   NF90(nf90_put_att(his_file%ncid, his_file%crs_varid, 'epsg', epsg))
+   NF90(nf90_put_att(his_file%ncid, his_file%crs_varid, 'epsg',      epsg))
    NF90(nf90_put_att(his_file%ncid, his_file%crs_varid, 'epsg_code', 'EPSG:' // trim(epsg_code) ))   !--> add epsg_code like FEWS wants
    !
-   NF90(nf90_def_var(his_file%ncid, 'point_zb', NF90_FLOAT, (/his_file%points_dimid/), his_file%zb_varid)) ! bed level in cell centre, for points
-   NF90(nf90_put_att(his_file%ncid, his_file%zb_varid, '_FillValue', FILL_VALUE))   
-   NF90(nf90_put_att(his_file%ncid, his_file%zb_varid, 'units', 'm'))
-   NF90(nf90_put_att(his_file%ncid, his_file%zb_varid, 'standard_name', 'altitude'))
-   NF90(nf90_put_att(his_file%ncid, his_file%zb_varid, 'long_name', 'Bed level above reference level'))
-   NF90(nf90_put_att(his_file%ncid, his_file%zb_varid, 'coordinates', 'station_id station_name point_x point_y'))
+   call ncdef_float_var(his_file%ncid, 'point_zb', (/his_file%points_dimid/), his_file%zb_varid, &
+        'm', 'Bed level above reference level', standard_name='altitude', coordinates=pt_coord)
    !
    if (nrstructures>0) then
       !
@@ -2013,11 +922,8 @@ contains
       NF90(nf90_put_att(his_file%ncid, his_file%structure_y_varid, 'long_name', 'structure_y'))    
       NF90(nf90_put_att(his_file%ncid, his_file%structure_y_varid, 'grid_mapping', 'crs'))   
       !
-      NF90(nf90_def_var(his_file%ncid, 'structure_height', NF90_FLOAT, (/his_file%structures_dimid/), his_file%structure_height_varid)) ! structure height 
-      NF90(nf90_put_att(his_file%ncid, his_file%structure_height_varid, '_FillValue', FILL_VALUE))   
-      NF90(nf90_put_att(his_file%ncid, his_file%structure_height_varid, 'units', 'm'))
-      NF90(nf90_put_att(his_file%ncid, his_file%structure_height_varid, 'standard_name', 'altitude'))
-      NF90(nf90_put_att(his_file%ncid, his_file%structure_height_varid, 'long_name', 'interpolated_structure_height_above_reference_level'))      
+      call ncdef_float_var(his_file%ncid, 'structure_height', (/his_file%structures_dimid/), his_file%structure_height_varid, &
+           'm', 'interpolated_structure_height_above_reference_level', standard_name='altitude')
       !
    endif
    !
@@ -2047,352 +953,133 @@ contains
    !
    ! Time varying map output
    !
-   NF90(nf90_def_var(his_file%ncid, 'point_zs', NF90_FLOAT, (/his_file%points_dimid, his_file%time_dimid/), his_file%zs_varid)) ! time-varying water level point
-   NF90(nf90_put_att(his_file%ncid, his_file%zs_varid, '_FillValue', FILL_VALUE))
-   NF90(nf90_put_att(his_file%ncid, his_file%zs_varid, 'units', 'm'))
-   NF90(nf90_put_att(his_file%ncid, his_file%zs_varid, 'standard_name', 'sea_surface_height_above_reference_level'))
-   NF90(nf90_put_att(his_file%ncid, his_file%zs_varid, 'long_name', 'Water level above reference level'))
-   NF90(nf90_put_att(his_file%ncid, his_file%zs_varid, 'coordinates', 'station_id station_name point_x point_y'))
+   call def_time_point_float('point_zs', his_file%zs_varid, 'm', 'Water level', &
+        standard_name='sea_surface_height_above_reference_level')
    !
    if (subgrid .eqv. .false. .or. store_hsubgrid .eqv. .true.) then
-      NF90(nf90_def_var(his_file%ncid, 'point_h', NF90_FLOAT, (/his_file%points_dimid, his_file%time_dimid/), his_file%h_varid)) ! time-varying water depth map
-      NF90(nf90_put_att(his_file%ncid, his_file%h_varid, '_FillValue', FILL_VALUE))
-      NF90(nf90_put_att(his_file%ncid, his_file%h_varid, 'units', 'm'))
-      NF90(nf90_put_att(his_file%ncid, his_file%h_varid, 'standard_name', 'depth')) 
-      NF90(nf90_put_att(his_file%ncid, his_file%h_varid, 'long_name', 'Water depth'))     
-      NF90(nf90_put_att(his_file%ncid, his_file%h_varid, 'coordinates', 'station_id station_name point_x point_y'))
+      call def_time_point_float('point_h', his_file%h_varid, 'm', 'Water depth', standard_name='depth')
    endif
    !
    if (store_velocity) then
+      call def_time_point_float('point_u', his_file%u_varid, 'm s-1', 'Flow velocity x-component', &
+           standard_name='sea_water_x_velocity')
       !
-      NF90(nf90_def_var(his_file%ncid, 'point_u', NF90_FLOAT, (/his_file%points_dimid, his_file%time_dimid/), his_file%u_varid)) ! time-varying u point 
-      NF90(nf90_put_att(his_file%ncid, his_file%u_varid, '_FillValue', FILL_VALUE))   
-      NF90(nf90_put_att(his_file%ncid, his_file%u_varid, 'units', 'm s-1'))
-      NF90(nf90_put_att(his_file%ncid, his_file%u_varid, 'standard_name', 'sea_water_x_velocity')) ! not truly eastward when rotated, eastward_sea_water_velocity
-      NF90(nf90_put_att(his_file%ncid, his_file%u_varid, 'long_name', 'flow_velocity_x_direction'))     
-      NF90(nf90_put_att(his_file%ncid, his_file%u_varid, 'coordinates', 'station_id station_name point_x point_y'))
+      call def_time_point_float('point_v', his_file%v_varid, 'm s-1', 'Flow velocity y-component', &
+           standard_name='sea_water_y_velocity')
       !
-      NF90(nf90_def_var(his_file%ncid, 'point_v', NF90_FLOAT, (/his_file%points_dimid, his_file%time_dimid/), his_file%v_varid)) ! time-varying u point 
-      NF90(nf90_put_att(his_file%ncid, his_file%v_varid, '_FillValue', FILL_VALUE))   
-      NF90(nf90_put_att(his_file%ncid, his_file%v_varid, 'units', 'm s-1'))
-      NF90(nf90_put_att(his_file%ncid, his_file%v_varid, 'standard_name', 'sea_water_y_velocity')) ! not truly northward when rotated, northward_sea_water_velocity
-      NF90(nf90_put_att(his_file%ncid, his_file%v_varid, 'long_name', 'flow_velocity_y_direction'))     
-      NF90(nf90_put_att(his_file%ncid, his_file%v_varid, 'coordinates', 'station_id station_name point_x point_y'))
+      call def_time_point_float('point_uvmag', his_file%uvmag_varid, 'm s-1', 'Flow velocity magnitude', &
+           standard_name='sea_water_velocity')
       !
-      NF90(nf90_def_var(his_file%ncid, 'point_uvmag', NF90_FLOAT, (/his_file%points_dimid, his_file%time_dimid/), his_file%uvmag_varid)) ! time-varying flow velocity magnitude 
-      NF90(nf90_put_att(his_file%ncid, his_file%uvmag_varid, '_FillValue', FILL_VALUE))   
-      NF90(nf90_put_att(his_file%ncid, his_file%uvmag_varid, 'units', 'm s-1'))
-      NF90(nf90_put_att(his_file%ncid, his_file%uvmag_varid, 'standard_name', 'sea_water_velocity'))
-      NF90(nf90_put_att(his_file%ncid, his_file%uvmag_varid, 'long_name', 'flow_velocity_magnitude'))     
-      NF90(nf90_put_att(his_file%ncid, his_file%uvmag_varid, 'coordinates', 'station_id station_name point_x point_y'))
-      !
-      NF90(nf90_def_var(his_file%ncid, 'point_uvdir', NF90_FLOAT, (/his_file%points_dimid, his_file%time_dimid/), his_file%uvdir_varid)) ! time-varying flow velocity direction 
-      NF90(nf90_put_att(his_file%ncid, his_file%uvdir_varid, '_FillValue', FILL_VALUE))   
-      NF90(nf90_put_att(his_file%ncid, his_file%uvdir_varid, 'units', 'degrees'))
-      NF90(nf90_put_att(his_file%ncid, his_file%uvdir_varid, 'standard_name', 'sea_water_velocity_direction'))
-      NF90(nf90_put_att(his_file%ncid, his_file%uvdir_varid, 'long_name', 'flow_velocity_direction'))     
-      NF90(nf90_put_att(his_file%ncid, his_file%uvdir_varid, 'coordinates', 'station_id station_name point_x point_y'))
-      !
+      call def_time_point_float('point_uvdir', his_file%uvdir_varid, 'degrees', 'Flow velocity bearing (deg)', &
+           standard_name='sea_water_velocity_direction')
    endif
    !
    ! Add infiltration
    !
    if (infiltration) then
-      !
-      NF90(nf90_def_var(his_file%ncid, 'point_qinf', NF90_FLOAT, (/his_file%points_dimid, his_file%time_dimid/), his_file%qinf_varid)) ! time-varying infiltration point 
-      NF90(nf90_put_att(his_file%ncid, his_file%qinf_varid, '_FillValue', FILL_VALUE))   
-      NF90(nf90_put_att(his_file%ncid, his_file%qinf_varid, 'units', 'mm hr-1'))
-      NF90(nf90_put_att(his_file%ncid, his_file%qinf_varid, 'long_name', 'infiltration_rate'))        
-      NF90(nf90_put_att(his_file%ncid, his_file%qinf_varid, 'coordinates', 'station_id station_name point_x point_y'))
-      !
-   endif
-   ! 
-   ! More output for CN method with recovery
-   !
-   if (inftype == 'cnb') then
-      NF90(nf90_def_var(his_file%ncid, 'point_S', NF90_FLOAT, (/his_file%points_dimid, his_file%time_dimid/), his_file%S_varid)) ! time-varying S
-      NF90(nf90_put_att(his_file%ncid, his_file%S_varid, '_FillValue', FILL_VALUE))   
-      NF90(nf90_put_att(his_file%ncid, his_file%S_varid, 'units', 'm'))
-      NF90(nf90_put_att(his_file%ncid, his_file%S_varid, 'long_name', 'current moisture storage (Se) capacity')) 
-      NF90(nf90_put_att(his_file%ncid, his_file%S_varid, 'coordinates', 'station_id station_name point_x point_y'))
+      call def_time_point_float('point_qinf', his_file%qinf_varid, 'mm hr-1', 'Infiltration rate')
    endif
    !
-   ! More output for CN method with recovery
-   !
-   if (inftype == 'gai') then
-      NF90(nf90_def_var(his_file%ncid, 'point_S', NF90_FLOAT, (/his_file%points_dimid, his_file%time_dimid/), his_file%S_varid)) ! time-varying S
-      NF90(nf90_put_att(his_file%ncid, his_file%S_varid, '_FillValue', FILL_VALUE))
-      NF90(nf90_put_att(his_file%ncid, his_file%S_varid, 'units', 'm'))
-      NF90(nf90_put_att(his_file%ncid, his_file%S_varid, 'long_name', 'maximum soil moisture deficit'))
-      NF90(nf90_put_att(his_file%ncid, his_file%S_varid, 'coordinates', 'station_id station_name point_x point_y'))
+   if (infiltration) then
+      if (inftype == 'cnb') then
+         call def_time_point_float('point_S', his_file%S_varid, 'm', 'current moisture storage (Se) capacity')
+      elseif (inftype == 'gai') then
+         call def_time_point_float('point_S', his_file%S_varid, 'm', 'maximum soil moisture deficit')
+      endif
    endif
    !
-   ! More output for Horton method
-   !
-   if (inftype == 'hor') then
-      NF90(nf90_def_var(his_file%ncid, 'point_S', NF90_FLOAT, (/his_file%points_dimid, his_file%time_dimid/), his_file%S_varid)) ! time-varying f
-      NF90(nf90_put_att(his_file%ncid, his_file%S_varid, '_FillValue', FILL_VALUE))
-      NF90(nf90_put_att(his_file%ncid, his_file%S_varid, 'units', 'mm hr-1'))
-      NF90(nf90_put_att(his_file%ncid, his_file%S_varid, 'long_name', 'current infiltration capacity'))
-      NF90(nf90_put_att(his_file%ncid, his_file%S_varid, 'coordinates', 'station_id station_name point_x point_y'))
-   endif
-   !
-   ! More output for Bucket model
-   !
-   if (inftype == 'bkt') then
-      NF90(nf90_def_var(his_file%ncid, 'point_S', NF90_FLOAT, (/his_file%points_dimid, his_file%time_dimid/), his_file%S_varid)) ! time-varying bucket volume
-      NF90(nf90_put_att(his_file%ncid, his_file%S_varid, '_FillValue', FILL_VALUE))
-      NF90(nf90_put_att(his_file%ncid, his_file%S_varid, 'units', 'm'))
-      NF90(nf90_put_att(his_file%ncid, his_file%S_varid, 'long_name', 'current bucket storage'))
-      NF90(nf90_put_att(his_file%ncid, his_file%S_varid, 'coordinates', 'station_id station_name point_x point_y'))
-   endif
-   !
-   if (snapwave) then  
+   if (snapwave) then
+      call def_time_point_float('point_hm0', his_file%hm0_varid, 'm', 'Hm0 wave height', standard_name='hm0_wave_height')
       !
-      NF90(nf90_def_var(his_file%ncid, 'point_hm0', NF90_FLOAT, (/his_file%points_dimid, his_file%time_dimid/), his_file%hm0_varid)) ! time-varying water level point
-      NF90(nf90_put_att(his_file%ncid, his_file%hm0_varid, '_FillValue', FILL_VALUE))
-      NF90(nf90_put_att(his_file%ncid, his_file%hm0_varid, 'units', 'm'))
-      NF90(nf90_put_att(his_file%ncid, his_file%hm0_varid, 'standard_name', 'hm0_wave_height')) 
-      NF90(nf90_put_att(his_file%ncid, his_file%hm0_varid, 'long_name', 'Hm0 wave height'))  
-      NF90(nf90_put_att(his_file%ncid, his_file%hm0_varid, 'coordinates', 'station_id station_name point_x point_y'))
+      call def_time_point_float('point_hm0ig', his_file%hm0ig_varid, 'm', 'Hm0 infragravity wave height', &
+           standard_name='hm0_ig_wave_height')
       !
-      NF90(nf90_def_var(his_file%ncid, 'point_hm0ig', NF90_FLOAT, (/his_file%points_dimid, his_file%time_dimid/), his_file%hm0ig_varid)) ! time-varying water level point
-      NF90(nf90_put_att(his_file%ncid, his_file%hm0ig_varid, '_FillValue', FILL_VALUE))
-      NF90(nf90_put_att(his_file%ncid, his_file%hm0ig_varid, 'units', 'm'))
-      NF90(nf90_put_att(his_file%ncid, his_file%hm0ig_varid, 'standard_name', 'hm0_ig_wave_height')) 
-      NF90(nf90_put_att(his_file%ncid, his_file%hm0ig_varid, 'long_name', 'Hm0 infragravity wave height'))  
-      NF90(nf90_put_att(his_file%ncid, his_file%hm0ig_varid, 'coordinates', 'station_id station_name point_x point_y'))
+      call def_time_point_float('point_tp', his_file%tp_varid, 's', 'Peak wave period', standard_name='peak_wave_period')
       !
-      NF90(nf90_def_var(his_file%ncid, 'point_tp', NF90_FLOAT, (/his_file%points_dimid, his_file%time_dimid/), his_file%tp_varid)) ! time-varying water level point
-      NF90(nf90_put_att(his_file%ncid, his_file%tp_varid, '_FillValue', FILL_VALUE))
-      NF90(nf90_put_att(his_file%ncid, his_file%tp_varid, 'units', 's'))
-      NF90(nf90_put_att(his_file%ncid, his_file%tp_varid, 'standard_name', 'peak_wave_period')) 
-      NF90(nf90_put_att(his_file%ncid, his_file%tp_varid, 'long_name', 'Peak wave period'))  
-      NF90(nf90_put_att(his_file%ncid, his_file%tp_varid, 'coordinates', 'station_id station_name point_x point_y'))
-      !
-      NF90(nf90_def_var(his_file%ncid, 'point_tpig', NF90_FLOAT, (/his_file%points_dimid, his_file%time_dimid/), his_file%tpig_varid)) ! time-varying water level point
-      NF90(nf90_put_att(his_file%ncid, his_file%tpig_varid, '_FillValue', FILL_VALUE))
-      NF90(nf90_put_att(his_file%ncid, his_file%tpig_varid, 'units', 's'))
-      NF90(nf90_put_att(his_file%ncid, his_file%tpig_varid, 'standard_name', 'ig_peak_wave_period')) 
-      NF90(nf90_put_att(his_file%ncid, his_file%tpig_varid, 'long_name', 'Peak wave period Infragravity wave'))  
-      NF90(nf90_put_att(his_file%ncid, his_file%tpig_varid, 'coordinates', 'station_id station_name point_x point_y'))      
+      call def_time_point_float('point_tpig', his_file%tpig_varid, 's', 'Peak wave period Infragravity wave', &
+           standard_name='ig_peak_wave_period')
       !
       if (store_wave_direction) then
-         !
-         NF90(nf90_def_var(his_file%ncid, 'point_wavdir', NF90_FLOAT, (/his_file%points_dimid, his_file%time_dimid/), his_file%wavdir_varid)) ! time-varying water level point
-         NF90(nf90_put_att(his_file%ncid, his_file%wavdir_varid, '_FillValue', FILL_VALUE))
-         NF90(nf90_put_att(his_file%ncid, his_file%wavdir_varid, 'units', 'degrees'))
-         NF90(nf90_put_att(his_file%ncid, his_file%wavdir_varid, 'standard_name', 'mean_wave_direction')) 
-         NF90(nf90_put_att(his_file%ncid, his_file%wavdir_varid, 'long_name', 'Mean wave direction'))  
-         NF90(nf90_put_att(his_file%ncid, his_file%wavdir_varid, 'coordinates', 'station_id station_name point_x point_y'))
-         !
-         NF90(nf90_def_var(his_file%ncid, 'point_dirspr', NF90_FLOAT, (/his_file%points_dimid, his_file%time_dimid/), his_file%dirspr_varid)) ! time-varying water level point
-         NF90(nf90_put_att(his_file%ncid, his_file%dirspr_varid, '_FillValue', FILL_VALUE))
-         NF90(nf90_put_att(his_file%ncid, his_file%dirspr_varid, 'units', 's'))
-         NF90(nf90_put_att(his_file%ncid, his_file%dirspr_varid, 'standard_name', 'wave_directional_spreading')) 
-         NF90(nf90_put_att(his_file%ncid, his_file%dirspr_varid, 'long_name', 'Wave directional spreading'))  
-         NF90(nf90_put_att(his_file%ncid, his_file%dirspr_varid, 'coordinates', 'station_id station_name point_x point_y'))
-         !
-      endif   
+         call def_time_point_float('point_wavdir', his_file%wavdir_varid, 'degrees', 'Mean wave angle (deg)', &
+              standard_name='mean_wave_direction')
+         ! point_dirspr is gathered in ncoutput_update_his but the put_var is
+         ! currently commented out — do not define here either, otherwise the
+         ! file carries an empty variable.
+      endif
       !
       if (wavemaker) then
-         !
-         NF90(nf90_def_var(his_file%ncid, 'point_zsm', NF90_FLOAT, (/his_file%points_dimid, his_file%time_dimid/), his_file%zsm_varid)) ! time-varying water level point
-         NF90(nf90_put_att(his_file%ncid, his_file%zsm_varid, '_FillValue', FILL_VALUE))
-         NF90(nf90_put_att(his_file%ncid, his_file%zsm_varid, 'units', 'm'))
-         NF90(nf90_put_att(his_file%ncid, his_file%zsm_varid, 'standard_name', 'filtered_water_level')) 
-         NF90(nf90_put_att(his_file%ncid, his_file%zsm_varid, 'long_name', 'Filtered water level'))  
-         NF90(nf90_put_att(his_file%ncid, his_file%zsm_varid, 'coordinates', 'station_id station_name point_x point_y'))
-         !
-      endif   
+         call def_time_point_float('point_zsm', his_file%zsm_varid, 'm', 'Filtered water level', &
+              standard_name='filtered_water_level')
+      endif
       !
       if (store_wave_forces) then
+         call def_time_point_float('point_dw', his_file%dw_varid, 'm', 'directionally averaged wave breaking dissipation', &
+              standard_name='directionally_averaged_wave_breaking_dissipation')
          !
-         NF90(nf90_def_var(his_file%ncid, 'point_dw', NF90_FLOAT, (/his_file%points_dimid, his_file%time_dimid/), his_file%dw_varid)) ! time-varying water level point
-         NF90(nf90_put_att(his_file%ncid, his_file%dw_varid, '_FillValue', FILL_VALUE))
-         NF90(nf90_put_att(his_file%ncid, his_file%dw_varid, 'units', 'm'))
-         NF90(nf90_put_att(his_file%ncid, his_file%dw_varid, 'standard_name', 'directionally_averaged_wave_breaking_dissipation')) 
-         NF90(nf90_put_att(his_file%ncid, his_file%dw_varid, 'long_name', 'directionally averaged wave breaking dissipation'))  
-         NF90(nf90_put_att(his_file%ncid, his_file%dw_varid, 'coordinates', 'station_id station_name point_x point_y'))
-         !      
-         NF90(nf90_def_var(his_file%ncid, 'point_df', NF90_FLOAT, (/his_file%points_dimid, his_file%time_dimid/), his_file%df_varid)) ! time-varying water level point
-         NF90(nf90_put_att(his_file%ncid, his_file%df_varid, '_FillValue', FILL_VALUE))
-         NF90(nf90_put_att(his_file%ncid, his_file%df_varid, 'units', 'm'))
-         NF90(nf90_put_att(his_file%ncid, his_file%df_varid, 'standard_name', 'directionally_averaged_wave_friction_dissipation')) 
-         NF90(nf90_put_att(his_file%ncid, his_file%df_varid, 'long_name', 'directionally averaged wave friction dissipation'))  
-         NF90(nf90_put_att(his_file%ncid, his_file%df_varid, 'coordinates', 'station_id station_name point_x point_y'))
-         !       
-         NF90(nf90_def_var(his_file%ncid, 'point_dwig', NF90_FLOAT, (/his_file%points_dimid, his_file%time_dimid/), his_file%dwig_varid)) ! time-varying water level point
-         NF90(nf90_put_att(his_file%ncid, his_file%dwig_varid, '_FillValue', FILL_VALUE))
-         NF90(nf90_put_att(his_file%ncid, his_file%dwig_varid, 'units', 'm'))
-         NF90(nf90_put_att(his_file%ncid, his_file%dwig_varid, 'standard_name', 'directionally_averaged_wave_breaking_dissipation_ig')) 
-         NF90(nf90_put_att(his_file%ncid, his_file%dwig_varid, 'long_name', 'directionally averaged wave breaking dissipation ig'))  
-         NF90(nf90_put_att(his_file%ncid, his_file%dwig_varid, 'coordinates', 'station_id station_name point_x point_y'))
-         !      
-         NF90(nf90_def_var(his_file%ncid, 'point_dfig', NF90_FLOAT, (/his_file%points_dimid, his_file%time_dimid/), his_file%dfig_varid)) ! time-varying water level point
-         NF90(nf90_put_att(his_file%ncid, his_file%dfig_varid, '_FillValue', FILL_VALUE))
-         NF90(nf90_put_att(his_file%ncid, his_file%dfig_varid, 'units', 'm'))
-         NF90(nf90_put_att(his_file%ncid, his_file%dfig_varid, 'standard_name', 'directionally_averaged_wave_friction_dissipation_ig')) 
-         NF90(nf90_put_att(his_file%ncid, his_file%dfig_varid, 'long_name', 'directionally averaged wave friction dissipation ig'))  
-         NF90(nf90_put_att(his_file%ncid, his_file%dfig_varid, 'coordinates', 'station_id station_name point_x point_y'))
-         !               
-         NF90(nf90_def_var(his_file%ncid, 'point_cg', NF90_FLOAT, (/his_file%points_dimid, his_file%time_dimid/), his_file%cg_varid)) ! time-varying water level point
-         NF90(nf90_put_att(his_file%ncid, his_file%cg_varid, '_FillValue', FILL_VALUE))
-         NF90(nf90_put_att(his_file%ncid, his_file%cg_varid, 'units', 'm/s'))
-         NF90(nf90_put_att(his_file%ncid, his_file%cg_varid, 'standard_name', 'wave_group_velocity')) 
-         NF90(nf90_put_att(his_file%ncid, his_file%cg_varid, 'long_name', 'wave group velocity'))  
-         NF90(nf90_put_att(his_file%ncid, his_file%cg_varid, 'coordinates', 'station_id station_name point_x point_y'))
-         !               
-         NF90(nf90_def_var(his_file%ncid, 'point_beta', NF90_FLOAT, (/his_file%points_dimid, his_file%time_dimid/), his_file%beta_varid)) ! time-varying water level point
-         NF90(nf90_put_att(his_file%ncid, his_file%beta_varid, '_FillValue', FILL_VALUE))
-         NF90(nf90_put_att(his_file%ncid, his_file%beta_varid, 'units', '-'))
-         NF90(nf90_put_att(his_file%ncid, his_file%beta_varid, 'standard_name', 'directionally_averaged_local_bed_slope')) 
-         NF90(nf90_put_att(his_file%ncid, his_file%beta_varid, 'long_name', 'directionally averaged normalised bed slope'))  
-         NF90(nf90_put_att(his_file%ncid, his_file%beta_varid, 'coordinates', 'station_id station_name point_x point_y'))
-         !               
-         NF90(nf90_def_var(his_file%ncid, 'point_srcig', NF90_FLOAT, (/his_file%points_dimid, his_file%time_dimid/), his_file%srcig_varid)) ! time-varying water level point
-         NF90(nf90_put_att(his_file%ncid, his_file%srcig_varid, '_FillValue', FILL_VALUE))
-         NF90(nf90_put_att(his_file%ncid, his_file%srcig_varid, 'units', '-'))
-         NF90(nf90_put_att(his_file%ncid, his_file%srcig_varid, 'standard_name', 'directionally_averaged_ig_energy_source')) 
-         NF90(nf90_put_att(his_file%ncid, his_file%srcig_varid, 'long_name', 'directionally averaged ig energy source'))  
-         NF90(nf90_put_att(his_file%ncid, his_file%srcig_varid, 'coordinates', 'station_id station_name point_x point_y'))
-         !                   
-         NF90(nf90_def_var(his_file%ncid, 'point_alphaig', NF90_FLOAT, (/his_file%points_dimid, his_file%time_dimid/), his_file%alphaig_varid)) ! time-varying water level point
-         NF90(nf90_put_att(his_file%ncid, his_file%alphaig_varid, '_FillValue', FILL_VALUE))
-         NF90(nf90_put_att(his_file%ncid, his_file%alphaig_varid, 'units', '-'))
-         NF90(nf90_put_att(his_file%ncid, his_file%alphaig_varid, 'standard_name', 'directionally_averaged_infragravity_waves_shoaling_factor')) 
-         NF90(nf90_put_att(his_file%ncid, his_file%alphaig_varid, 'long_name', 'directionally averaged infragravity waves shoaling factor'))  
-         NF90(nf90_put_att(his_file%ncid, his_file%alphaig_varid, 'coordinates', 'station_id station_name point_x point_y'))         
+         call def_time_point_float('point_df', his_file%df_varid, 'm', 'directionally averaged wave friction dissipation', &
+              standard_name='directionally_averaged_wave_friction_dissipation')
          !
+         call def_time_point_float('point_dwig', his_file%dwig_varid, 'm', 'directionally averaged wave breaking dissipation ig', &
+              standard_name='directionally_averaged_wave_breaking_dissipation_ig')
+         !
+         call def_time_point_float('point_dfig', his_file%dfig_varid, 'm', 'directionally averaged wave friction dissipation ig', &
+              standard_name='directionally_averaged_wave_friction_dissipation_ig')
+         !
+         call def_time_point_float('point_cg', his_file%cg_varid, 'm/s', 'wave group velocity', &
+              standard_name='wave_group_velocity')
+         !
+         call def_time_point_float('point_beta', his_file%beta_varid, '-', 'directionally averaged normalised bed slope', &
+              standard_name='directionally_averaged_local_bed_slope')
+         !
+         call def_time_point_float('point_srcig', his_file%srcig_varid, '-', 'directionally averaged ig energy source', &
+              standard_name='directionally_averaged_ig_energy_source')
+         !
+         call def_time_point_float('point_alphaig', his_file%alphaig_varid, '-', &
+              'directionally averaged infragravity waves shoaling factor', &
+              standard_name='directionally_averaged_infragravity_waves_shoaling_factor')
       endif
    endif
    !
-   if (store_meteo) then      
-      !
+   if (store_meteo) then
       if (wind) then
+         call def_time_point_float('point_wind_speed', his_file%wind_speed_varid, 'm s-1', 'Wind speed')
          !
-         NF90(nf90_def_var(his_file%ncid, 'point_wind_speed', NF90_FLOAT, (/his_file%points_dimid, his_file%time_dimid/), his_file%wind_speed_varid)) ! time-varying patm point 
-         NF90(nf90_put_att(his_file%ncid, his_file%wind_speed_varid, '_FillValue', FILL_VALUE))   
-         NF90(nf90_put_att(his_file%ncid, his_file%wind_speed_varid, 'units', 'm s-1'))
-         NF90(nf90_put_att(his_file%ncid, his_file%wind_speed_varid, 'long_name', 'wind_speed'))        
-         NF90(nf90_put_att(his_file%ncid, his_file%wind_speed_varid, 'coordinates', 'station_id station_name point_x point_y'))
-         !
-         NF90(nf90_def_var(his_file%ncid, 'point_wind_direction', NF90_FLOAT, (/his_file%points_dimid, his_file%time_dimid/), his_file%wind_dir_varid)) ! time-varying patm point 
-         NF90(nf90_put_att(his_file%ncid, his_file%wind_dir_varid, '_FillValue', FILL_VALUE))   
-         NF90(nf90_put_att(his_file%ncid, his_file%wind_dir_varid, 'units', 'degrees'))
-         NF90(nf90_put_att(his_file%ncid, his_file%wind_dir_varid, 'long_name', 'wind_direction'))        
-         NF90(nf90_put_att(his_file%ncid, his_file%wind_dir_varid, 'coordinates', 'station_id station_name point_x point_y'))
-         !
+         call def_time_point_float('point_wind_direction', his_file%wind_dir_varid, 'degrees', 'Wind direction (deg)')
       endif
-      !
-      if (patmos) then      
-         !
-         NF90(nf90_def_var(his_file%ncid, 'point_patm', NF90_FLOAT, (/his_file%points_dimid, his_file%time_dimid/), his_file%patm_varid)) ! time-varying patm point 
-         NF90(nf90_put_att(his_file%ncid, his_file%patm_varid, '_FillValue', FILL_VALUE))   
-         NF90(nf90_put_att(his_file%ncid, his_file%patm_varid, 'units', 'Pa'))
-         NF90(nf90_put_att(his_file%ncid, his_file%patm_varid, 'long_name', 'Surface air pressure'))        
-         NF90(nf90_put_att(his_file%ncid, his_file%patm_varid, 'coordinates', 'station_id station_name point_x point_y'))
-         !
+      if (patmos) then
+         call def_time_point_float('point_patm', his_file%patm_varid, 'Pa', 'Surface air pressure')
       endif
-      !
       if (precip) then
-         !
-         NF90(nf90_def_var(his_file%ncid, 'point_prcp', NF90_FLOAT, (/his_file%points_dimid, his_file%time_dimid/), his_file%prcp_varid)) ! time-varying prcp point 
-         NF90(nf90_put_att(his_file%ncid, his_file%prcp_varid, '_FillValue', FILL_VALUE))   
-         NF90(nf90_put_att(his_file%ncid, his_file%prcp_varid, 'units', 'mm hr-1'))
-         NF90(nf90_put_att(his_file%ncid, his_file%prcp_varid, 'long_name', 'precipitation_rate'))        
-         NF90(nf90_put_att(his_file%ncid, his_file%prcp_varid, 'coordinates', 'station_id station_name point_x point_y'))
-         !
+         call def_time_point_float('point_prcp', his_file%prcp_varid, 'mm hr-1', 'Precipitation rate')
          if (store_cumulative_precipitation) then
-            !
-            NF90(nf90_def_var(his_file%ncid, 'point_cumprcp', NF90_FLOAT, (/his_file%points_dimid, his_file%time_dimid/), his_file%cumprcp_varid)) ! time-varying prcp point 
-            NF90(nf90_put_att(his_file%ncid, his_file%cumprcp_varid, '_FillValue', FILL_VALUE))   
-            NF90(nf90_put_att(his_file%ncid, his_file%cumprcp_varid, 'units', 'm'))
-            NF90(nf90_put_att(his_file%ncid, his_file%cumprcp_varid, 'long_name', 'cumulative_precipitation'))        
-            NF90(nf90_put_att(his_file%ncid, his_file%cumprcp_varid, 'coordinates', 'station_id station_name point_x point_y'))
-            !
+            call def_time_point_float('point_cumprcp', his_file%cumprcp_varid, 'm', 'Cumulative precipitation')
          endif
-         !
       endif
-      ! 
-   endif   
+   endif
    !   
    if (nrcrosssections>0) then
-      !
-      NF90(nf90_def_var(his_file%ncid, 'crosssection_discharge', NF90_FLOAT, (/his_file%crosssections_dimid, his_file%time_dimid/), his_file%discharge_varid)) ! time-varying crossection discharge 
-      NF90(nf90_put_att(his_file%ncid, his_file%discharge_varid, '_FillValue', FILL_VALUE))   
-      NF90(nf90_put_att(his_file%ncid, his_file%discharge_varid, 'units', 'm3 s-1'))
-      NF90(nf90_put_att(his_file%ncid, his_file%discharge_varid, 'long_name', 'discharge'))
-      NF90(nf90_put_att(his_file%ncid, his_file%discharge_varid, 'coordinates', 'crosssection_name'))
-      !
-   endif
-   !   
-   if (nr_src_structures>0) then
-      !
-      NF90(nf90_def_var(his_file%ncid, 'drainage_discharge', NF90_FLOAT, (/his_file%drain_dimid, his_file%time_dimid/), his_file%drain_varid)) ! time-varying discharge through drainage structure
-      NF90(nf90_put_att(his_file%ncid, his_file%drain_varid, '_FillValue', FILL_VALUE))
-      NF90(nf90_put_att(his_file%ncid, his_file%drain_varid, 'units', 'm3 s-1'))
-      NF90(nf90_put_att(his_file%ncid, his_file%drain_varid, 'long_name', 'discharge through drainage structure'))
-      NF90(nf90_put_att(his_file%ncid, his_file%drain_varid, 'coordinates', 'drainage_name'))
-      !
-      if (any(src_struc_type == structure_dike_breach)) then
-         NF90(nf90_def_var(his_file%ncid, 'breach_width', NF90_FLOAT, (/his_file%drain_dimid, his_file%time_dimid/), his_file%breach_width_varid))
-         NF90(nf90_put_att(his_file%ncid, his_file%breach_width_varid, '_FillValue', FILL_VALUE))
-         NF90(nf90_put_att(his_file%ncid, his_file%breach_width_varid, 'units', 'm'))
-         NF90(nf90_put_att(his_file%ncid, his_file%breach_width_varid, 'long_name', 'dike breach width'))
-         NF90(nf90_put_att(his_file%ncid, his_file%breach_width_varid, 'coordinates', 'drainage_name'))
-      endif
-      !
-      NF90(nf90_def_var(his_file%ncid, 'drainage_fraction_open', NF90_FLOAT, (/his_file%drain_dimid, his_file%time_dimid/), his_file%drain_fraction_open_varid)) ! time-varying gate open fraction (1=open, 0=closed)
-      NF90(nf90_put_att(his_file%ncid, his_file%drain_fraction_open_varid, '_FillValue', FILL_VALUE))
-      NF90(nf90_put_att(his_file%ncid, his_file%drain_fraction_open_varid, 'units', '1'))
-      NF90(nf90_put_att(his_file%ncid, his_file%drain_fraction_open_varid, 'long_name', 'gate open fraction (1 = fully open, 0 = fully closed)'))
-      NF90(nf90_put_att(his_file%ncid, his_file%drain_fraction_open_varid, 'coordinates', 'drainage_name'))
-      !
+      call ncdef_float_var(his_file%ncid, 'crosssection_discharge', (/his_file%crosssections_dimid, his_file%time_dimid/), his_file%discharge_varid, &
+           'm3 s-1', 'discharge', coordinates='crosssection_name')
    endif
    !
-   if (nr_discharge_points>0 .and. store_river_discharge) then
-      !
-      NF90(nf90_def_var(his_file%ncid, 'river_discharge', NF90_FLOAT, (/his_file%river_dimid, his_file%time_dimid/), his_file%river_varid)) ! time-varying river point discharge
-      NF90(nf90_put_att(his_file%ncid, his_file%river_varid, '_FillValue', FILL_VALUE))
-      NF90(nf90_put_att(his_file%ncid, his_file%river_varid, 'units', 'm3 s-1'))
-      NF90(nf90_put_att(his_file%ncid, his_file%river_varid, 'long_name', 'river point discharge'))
-      NF90(nf90_put_att(his_file%ncid, his_file%river_varid, 'coordinates', 'river_name'))
-      !
+   if (ndrn>0) then
+      call ncdef_float_var(his_file%ncid, 'drainage_discharge', (/his_file%drain_dimid, his_file%time_dimid/), his_file%drain_varid, &
+           'm3 s-1', 'discharge through drainage structure')
    endif
    !
-   if (nr_urban_drainage_zones > 0 .and. store_urban_drainage_discharge) then
-      !
-      NF90(nf90_def_var(his_file%ncid, 'urban_drainage_discharge', NF90_FLOAT, (/his_file%urbdrain_dimid, his_file%time_dimid/), his_file%urbdrain_varid)) ! per-zone outfall discharge
-      NF90(nf90_put_att(his_file%ncid, his_file%urbdrain_varid, '_FillValue', FILL_VALUE))
-      NF90(nf90_put_att(his_file%ncid, his_file%urbdrain_varid, 'units', 'm3 s-1'))
-      NF90(nf90_put_att(his_file%ncid, his_file%urbdrain_varid, 'long_name', 'urban drainage zone net outfall discharge'))
-      NF90(nf90_put_att(his_file%ncid, his_file%urbdrain_varid, 'coordinates', 'urban_drainage_zone_name'))
-      !
-   endif
-   !   
    if (nr_runup_gauges > 0) then
-      !
-      NF90(nf90_def_var(his_file%ncid, 'runup_gauge_zs', NF90_FLOAT, (/his_file%runup_gauges_dimid, his_file%time_dimid/), his_file%runup_gauge_zs_varid)) ! time-varying crossection discharge 
-      NF90(nf90_put_att(his_file%ncid, his_file%runup_gauge_zs_varid, '_FillValue', FILL_VALUE))   
-      NF90(nf90_put_att(his_file%ncid, his_file%runup_gauge_zs_varid, 'units', 'm'))
-      NF90(nf90_put_att(his_file%ncid, his_file%runup_gauge_zs_varid, 'long_name', 'run-up elevation'))
-      NF90(nf90_put_att(his_file%ncid, his_file%runup_gauge_zs_varid, 'coordinates', 'runup_gauge_name'))
-      !
+      call ncdef_float_var(his_file%ncid, 'runup_gauge_zs', (/his_file%runup_gauges_dimid, his_file%time_dimid/), his_file%runup_gauge_zs_varid, &
+           'm', 'run-up elevation', coordinates='runup_gauge_name')
    endif
    !
-   ! Add for final output:
-   NF90(nf90_def_var(his_file%ncid, 'total_runtime', NF90_FLOAT, (/his_file%runtime_dimid/), his_file%total_runtime_varid))
-   NF90(nf90_put_att(his_file%ncid, his_file%total_runtime_varid, 'units', 's'))   
-   NF90(nf90_put_att(his_file%ncid, his_file%total_runtime_varid, 'long_name', 'Total model runtime (s)'))
+   call ncdef_float_var(his_file%ncid, 'total_runtime', (/his_file%runtime_dimid/), his_file%total_runtime_varid, &
+        's', 'Total model runtime (s)')
    !
-   NF90(nf90_def_var(his_file%ncid, 'average_dt', NF90_FLOAT, (/his_file%runtime_dimid/), his_file%average_dt_varid))
-   NF90(nf90_put_att(his_file%ncid, his_file%average_dt_varid, 'units', 's'))   
-   NF90(nf90_put_att(his_file%ncid, his_file%average_dt_varid, 'long_name', 'Average model time step (s)'))   
+   call ncdef_float_var(his_file%ncid, 'average_dt', (/his_file%runtime_dimid/), his_file%average_dt_varid, &
+        's', 'Average model time step (s)')
    !
-   NF90(nf90_def_var(his_file%ncid, 'status', NF90_FLOAT, (/his_file%runtime_dimid/), his_file%status_varid))
-   NF90(nf90_put_att(his_file%ncid, his_file%status_varid, 'units', '-'))   
-   NF90(nf90_put_att(his_file%ncid, his_file%status_varid, 'long_name', 'status of SFINCS simulation - 0 is no error'))        
+   call ncdef_float_var(his_file%ncid, 'status', (/his_file%runtime_dimid/), his_file%status_varid, &
+        '-', 'status of SFINCS simulation - 0 is no error')
    !    
    ! Finish definitions
    NF90(nf90_enddef(his_file%ncid))
@@ -2523,879 +1210,153 @@ contains
    !     
    NF90(nf90_sync(his_file%ncid)) !write away intermediate data
    !
-   end subroutine
+   end subroutine ncoutput_his_init
    !
    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-   !  
-   subroutine ncoutput_update_regular_map(t,ntmapout)
    !
-   ! Write time, zs, u, v  
+
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+   !
+   subroutine ncoutput_update_map(t,ntmapout)
+   !
+   ! Write time-varying output to map file. Single linear flow — the
+   ! grid-type branch is hidden inside write_cell_var / write_cell_var_wet
+   ! and the two precompute helpers (compute_uv_at_cell_centers,
+   ! compute_pnh_unwrapped) below.
    !
    use sfincs_data
    use sfincs_nonhydrostatic
    use sfincs_snapwave
+   use quadtree
    !
-   implicit none   
+   implicit none
    !
-   real*8                       :: t  
-   real*4                       :: uz, vz
+   real*8  :: t
+   integer :: ntmapout
+   real*4  :: sq2
+   real*4, dimension(:), allocatable :: uxy, vxy, pnh_full
    !
-   integer  :: ntmapout       
+   sq2 = sqrt(2.0)
    !
-   integer                      :: nm, n, m, nmd1, nmu1, ndm1, num1
-   real*4, dimension(:,:), allocatable :: zsg
-   real*4, dimension(:,:), allocatable :: zsgu
-   real*4, dimension(:,:), allocatable :: zsgv
+   NF90(nf90_put_var(map_file%ncid, map_file%time_varid, t, (/ntmapout/)))
    !
-   NF90(nf90_put_var(map_file%ncid, map_file%time_varid, t, (/ntmapout/))) ! write time
-   !  
-   allocate(zsg(mmax, nmax))
-   !
-   zsg = FILL_VALUE       ! set to fill value
-   !
-   do nm = 1, np
-      !
-      n    = z_index_z_n(nm)
-      m    = z_index_z_m(nm)
-      !      
-      if (subgrid) then
-         if ((zs(nm) - subgrid_z_zmin(nm)) > huthresh) then
-            zsg(m, n) = zs(nm)
-         endif
-      else
-         if ((zs(nm) - zb(nm)) > huthresh) then
-            zsg(m, n) = zs(nm)
-         endif
-      endif
-   enddo
-   !
-   NF90(nf90_put_var(map_file%ncid, map_file%zs_varid, zsg, (/1, 1, ntmapout/))) ! write zs
-   !
-   if (store_dynamic_bed_level .and. .not. subgrid) then
-      !
-      do nm = 1, np
-         !
-         n = z_index_z_n(nm)
-         m = z_index_z_m(nm)
-         !      
-         zsg(m, n) = zb(nm)
-         !      
-      enddo
-      !
-      NF90(nf90_put_var(map_file%ncid, map_file%zb_varid, zsg, (/1, 1, ntmapout/))) ! write zb
-      !
-   endif   
-   !
-   if (subgrid .eqv. .false. .or. store_hsubgrid .eqv. .true.) then   
-      ! 
-      zsg = FILL_VALUE       
-      !
-      do nm = 1, np
-         !
-         n    = z_index_z_n(nm)
-         m    = z_index_z_m(nm)
-         !      
-         if (subgrid) then
-            zsg(m, n) = zs(nm) - subgrid_z_zmin(nm)
-         else
-            zsg(m, n) = zs(nm) - zb(nm)
-         endif
-      enddo
-      ! 
-      NF90(nf90_put_var(map_file%ncid, map_file%h_varid, zsg, (/1, 1, ntmapout/))) ! write h
-      !
-   endif
-   !            
-   if (store_velocity) then
-      !
-      allocate(zsgu(mmax, nmax))
-      allocate(zsgv(mmax, nmax))
-      zsgu = FILL_VALUE
-      zsgv = FILL_VALUE
-      !
-      do nm = 1, np
-         !
-         n    = z_index_z_n(nm)
-         m    = z_index_z_m(nm)
-         !
-         nmd1 = z_index_uv_md(nm)
-         nmu1 = z_index_uv_mu(nm)
-         uz = 0.0
-         if (nmd1>0) then
-            uz = uz + 0.5*uv(nmd1)
-         endif   
-         if (nmu1>0) then
-            uz = uz + 0.5*uv(nmu1)
-         endif   
-         !
-         ndm1 = z_index_uv_nd(nm)
-         num1 = z_index_uv_nu(nm)
-         vz = 0.0
-         if (ndm1>0) then
-            vz = vz + 0.5*uv(ndm1)
-         endif   
-         if (num1>0) then
-            vz = vz + 0.5*uv(num1)
-         endif   
-         !         
-         zsgu(m, n) = cosrot*uz - sinrot*vz            
-         zsgv(m, n) = sinrot*uz + cosrot*vz
-         !
-      enddo   
-      !
-      NF90(nf90_put_var(map_file%ncid, map_file%u_varid, zsgu, (/1, 1, ntmapout/)))
-      !
-      NF90(nf90_put_var(map_file%ncid, map_file%v_varid, zsgv, (/1, 1, ntmapout/)))
-      !
-      deallocate(zsgu)
-      deallocate(zsgv)
-      !
-   endif
-   !
+   ! -------------------------------------------------------
+   ! Water level / depth
+   ! -------------------------------------------------------
    if (subgrid) then
-      !
-      if (store_zvolume) then
-         !
-         zsg = FILL_VALUE       
-         !
-         do nm = 1, np
-            !
-            n    = z_index_z_n(nm)
-            m    = z_index_z_m(nm)
-            !      
-            zsg(m, n) = z_volume(nm)
-            !
-         enddo
-         ! 
-         NF90(nf90_put_var(map_file%ncid, map_file%zvolume_varid, zsg, (/1, 1, ntmapout/))) ! write z_volume         
-         !
-      endif
-      !
-      if (store_storagevolume) then
-         !
-         zsg = FILL_VALUE       
-         !
-         do nm = 1, np
-            !
-            n    = z_index_z_n(nm)
-            m    = z_index_z_m(nm)
-            !      
-            zsg(m, n) = storage_volume(nm)
-            !
-         enddo
-         ! 
-         NF90(nf90_put_var(map_file%ncid, map_file%storagevolume_varid, zsg, (/1, 1, ntmapout/))) ! write storage_volume         
-         !        
-      endif
-      !      
-   endif   
-   !
-   if (inftype == 'cnb') then
-      !
-      ! Store S_effective (only for CN method with recovery)
-      !
-      zsg = FILL_VALUE
-      !
-      do nm = 1, np
-         !
-         n    = z_index_z_n(nm)
-         m    = z_index_z_m(nm)
-         !      
-         zsg(m, n) = scs_Se(nm)
-         !
-      enddo
-      !
-      NF90(nf90_put_var(map_file%ncid, map_file%Seff_varid, zsg, (/1, 1, ntmapout/)))
-      !
-   elseif (inftype == 'gai') then
-      !
-      ! Store maximum soil moisture deficit (only for green-ampt)
-      !
-      zsg = FILL_VALUE
-      !
-      do nm = 1, np
-         !
-         n    = z_index_z_n(nm)
-         m    = z_index_z_m(nm)
-         !      
-         zsg(m, n) = GA_sigma(nm)
-         !
-      enddo
-      !
-      NF90(nf90_put_var(map_file%ncid, map_file%Seff_varid, zsg, (/1, 1, ntmapout/)))
-      !
-   elseif (inftype == 'hor') then
-      !
-      ! Store current infiltration from Horton
-      !
-      zsg = FILL_VALUE
-      !
-      do nm = 1, np
-         !
-         n    = z_index_z_n(nm)
-         m    = z_index_z_m(nm)
-         !
-         zsg(m, n) = qinfmap(nm)
-         !
-      enddo
-      !
-      NF90(nf90_put_var(map_file%ncid, map_file%Seff_varid, zsg, (/1, 1, ntmapout/)))
-      !
-   elseif (inftype == 'bkt') then
-      !
-      ! Store current bucket volume
-      !
-      zsg = FILL_VALUE
-      !
-      do nm = 1, np
-         !
-         n    = z_index_z_n(nm)
-         m    = z_index_z_m(nm)
-         !
-         zsg(m, n) = bucket_volume(nm)
-         !
-      enddo
-      !
-      NF90(nf90_put_var(map_file%ncid, map_file%Seff_varid, zsg, (/1, 1, ntmapout/)))
-      !
-   endif
-   !           
-   if (store_meteo) then
-      !
-      if (wind) then
-         !
-         zsg = FILL_VALUE
-         !
-         do nm = 1, np
-            !
-            n    = z_index_z_n(nm)
-            m    = z_index_z_m(nm)
-            !      
-            zsg(m, n) = windu(nm)
-            !
-         enddo
-         !
-         NF90(nf90_put_var(map_file%ncid, map_file%wind_u_varid, zsg, (/1, 1, ntmapout/)))
-         !
-         zsg = FILL_VALUE
-         !
-         do nm = 1, np
-            !
-            n    = z_index_z_n(nm)
-            m    = z_index_z_m(nm)
-            !      
-            zsg(m, n) = windv(nm)
-            !
-         enddo
-         !
-         NF90(nf90_put_var(map_file%ncid, map_file%wind_v_varid, zsg, (/1, 1, ntmapout/)))
-         !
-      endif
-      !
-      if (patmos) then
-         !
-         zsg = FILL_VALUE
-         !
-         do nm = 1, np
-            !
-            n    = z_index_z_n(nm)
-            m    = z_index_z_m(nm)
-            !      
-            zsg(m, n) = patm(nm)
-            !
-         enddo
-         !
-         NF90(nf90_put_var(map_file%ncid, map_file%patm_varid, zsg, (/1, 1, ntmapout/)))
-         !
-      endif   
-      !
-      if (precip) then
-         !
-         zsg = FILL_VALUE
-         !
-         do nm = 1, np
-            !
-            n    = z_index_z_n(nm)
-            m    = z_index_z_m(nm)
-            !      
-            zsg(m, n) = prcp(nm)*3600000
-            !
-         enddo
-         !
-         NF90(nf90_put_var(map_file%ncid, map_file%precip_varid, zsg, (/1, 1, ntmapout/)))
-         !
-      endif   
-      !
+      call write_cell_var_wet(map_file%ncid, map_file%zs_varid, real(zs,4), subgrid_z_zmin, ntmapout)
+   else
+      call write_cell_var_wet(map_file%ncid, map_file%zs_varid, real(zs,4), zb,             ntmapout)
    endif
    !
-   if (snapwave) then
-      ! 
-      zsg = FILL_VALUE       
-      !
-      do nm = 1, np
-         !
-         n    = z_index_z_n(nm)
-         m    = z_index_z_m(nm)
-         !      
-         zsg(m, n) = hm0(nm) ! TL: TODO: clean up difference of using hm0 here, and SnapWave_H for quadtree grid!
-         !
-      enddo
-      !
-      NF90(nf90_put_var(map_file%ncid, map_file%hm0_varid, zsg, (/1, 1, ntmapout/))) ! write hm0
-      ! 
-      zsg = FILL_VALUE       
-      !
-      do nm = 1, np
-         !
-         n    = z_index_z_n(nm)
-         m    = z_index_z_m(nm)
-         !      
-         zsg(m, n) = hm0_ig(nm)
-         !
-      enddo
-      !
-      NF90(nf90_put_var(map_file%ncid, map_file%hm0ig_varid, zsg, (/1, 1, ntmapout/))) ! write hm0ig
-      !            
-      if (store_wave_forces) then
-         !      
-         zsg = FILL_VALUE       
-         !
-         do nm = 1, np
-            !
-            n    = z_index_z_n(nm)
-            m    = z_index_z_m(nm)
-            !      
-            zsg(m, n) = fwx(nm)
-            !
-         enddo
-         ! 
-         NF90(nf90_put_var(map_file%ncid, map_file%fwx_varid, zsg, (/1, 1, ntmapout/))) ! write h
-         !            
-         zsg = FILL_VALUE       
-         ! 
-         do nm = 1, np
-            !
-            n    = z_index_z_n(nm)
-            m    = z_index_z_m(nm)
-            !      
-            zsg(m, n) = fwy(nm)
-            !
-         enddo
-         !
-         NF90(nf90_put_var(map_file%ncid, map_file%fwy_varid, zsg, (/1, 1, ntmapout/))) ! write h
-         ! 
-         zsg = FILL_VALUE       
-         !
-         do nm = 1, np
-            !
-            n    = z_index_z_n(nm)
-            m    = z_index_z_m(nm)
-            !      
-            zsg(m, n) = sw_tp(nm)
-            !
-         enddo
-         !
-         NF90(nf90_put_var(map_file%ncid, map_file%tp_varid, zsg, (/1, 1, ntmapout/))) ! write Tp
-         ! 
-         zsg = FILL_VALUE       
-         !
-         do nm = 1, np
-            !
-            n    = z_index_z_n(nm)
-            m    = z_index_z_m(nm)
-            !      
-            zsg(m, n) = sw_tp_ig(nm)
-            !
-         enddo
-         !
-         NF90(nf90_put_var(map_file%ncid, map_file%tpig_varid, zsg, (/1, 1, ntmapout/))) ! write Tpig
-         !
-         zsg = FILL_VALUE       
-         !
-         do nm = 1, np
-            !
-            n    = z_index_z_n(nm)
-            m    = z_index_z_m(nm)
-            !      
-            zsg(m, n) = betamean(nm)
-            !
-         enddo
-         !
-         NF90(nf90_put_var(map_file%ncid, map_file%beta_varid, zsg, (/1, 1, ntmapout/))) ! write beta
-         !         
-         zsg = FILL_VALUE       
-         !
-         do nm = 1, np
-            !
-            n    = z_index_z_n(nm)
-            m    = z_index_z_m(nm)
-            !      
-            zsg(m, n) = snapwave_depth(nm)
-            !
-         enddo
-         !
-         NF90(nf90_put_var(map_file%ncid, map_file%snapwavedepth_varid, zsg, (/1, 1, ntmapout/))) ! write snapwavedepth
-         !
-      endif
-      !            
-      if (wavemaker) then
-         !
-         zsg = FILL_VALUE       
-         !
-         do nm = 1, np
-            !
-            n    = z_index_z_n(nm)
-            m    = z_index_z_m(nm)
-            !       
-            zsg(m, n) = zsm(nm)
-            !
-         enddo
-         !
-         NF90(nf90_put_var(map_file%ncid, map_file%zsm_varid, zsg, (/1, 1, ntmapout/))) ! write h
-         !
-      endif
-      !
-   endif   
-   !
-   if (nonhydrostatic) then
-      !
-      zsg = FILL_VALUE       
-      !
-      do nm = 1, np
-         !
-         n    = z_index_z_n(nm)
-         m    = z_index_z_m(nm)
-         !
-         ! Look up pressure in 'limited' nonh array that only has values where nonh mask is set to active
-         !
-         if (row_index_of_nm(nm) > 0) then
-            !
-            zsg(m, n) = pnh(row_index_of_nm(nm))
-            !
-         endif   
-         !
-      enddo
-      !
-      NF90(nf90_put_var(map_file%ncid, map_file%pnonh_varid, zsg, (/1, 1, ntmapout/))) ! write h
-      !
+   ! Optional time-varying zb (regular grid, non-subgrid)
+   if (.not. use_quadtree .and. store_dynamic_bed_level .and. .not. subgrid) then
+      call write_cell_var(map_file%ncid, map_file%zb_varid, zb, ntmapout)
    endif
-   !           
-   NF90(nf90_sync(map_file%ncid)) !write away intermediate data ! TL: in first test it seems to be faster to let the file update than keep in memory
    !
-   end subroutine
-
-   
-   subroutine ncoutput_update_quadtree_map(t,ntmapout)
-      !
-      ! Write time, zs, u, v  
-      !
-      use sfincs_data   
-      use sfincs_snapwave
-      use sfincs_nonhydrostatic
-      use quadtree
-      ! use snapwave_data
-      !
-      implicit none   
-      !
-      real*8                       :: t  
-      !
-      integer  :: ntmapout       
-      !
-      integer   :: nm, nmq, n, m, nmu1, nmd1, num1, ndm1
-      real*4    :: uz, vz, sq2
-      !
-      real*4, dimension(:), allocatable :: utmp, vtmp 
-      !
-      NF90(nf90_put_var(map_file%ncid, map_file%time_varid, t, (/ntmapout/))) ! write time
-      !  
-      allocate(utmp(quadtree_nr_points))
-      allocate(vtmp(quadtree_nr_points))
-      !
-      sq2 = sqrt(2.0)
-      !
-      vtmp = FILL_VALUE
-      !
-      do nmq = 1, quadtree_nr_points
-         !
-         nm = index_sfincs_in_quadtree(nmq)
-         !
-         if (nm>0) then 
-            !
-            if (kcs(nm)>0) then
-               if (subgrid) then
-                  if ( (zs(nm) - subgrid_z_zmin(nm)) > huthresh) then
-                     vtmp(nmq) = zs(nm)
-                  endif
-               else
-                  if ( (zs(nm) - zb(nm)) > huthresh) then
-                     vtmp(nmq) = zs(nm)
-                  endif
-               endif
-            endif
-            !
-         endif
-         !
-      enddo
-      !
-      NF90(nf90_put_var(map_file%ncid, map_file%zs_varid, vtmp, (/1, ntmapout/))) ! write zs
-      !
-            endif
-            !
-         enddo
-         !
-         NF90(nf90_put_var(map_file%ncid, map_file%zb_varid, vtmp, (/1, ntmapout/))) ! write zb (subgrid_z_zmin for subgrid runs)
-         !
-      endif
-      !
-      ! Water depth
-      !
-      if (subgrid .eqv. .false. .or. store_hsubgrid .eqv. .true.) then   
-         ! 
-         vtmp = FILL_VALUE
-         !
-         do nmq = 1, quadtree_nr_points
-            !
-            nm = index_sfincs_in_quadtree(nmq)
-            !
-            if (nm>0) then 
-               !
-               if (kcs(nm)>0) then
-                  if (subgrid) then
-                     if ( (zs(nm) - subgrid_z_zmin(nm)) > huthresh) then
-                        vtmp(nmq) = zs(nm) - subgrid_z_zmin(nm)
-                     endif
-                  else
-                     if ( (zs(nm) - zb(nm)) > huthresh) then
-                        vtmp(nmq) = zs(nm) - zb(nm)
-                     endif
-                  endif
-               endif
-               !
-            endif
-            !
-         enddo
-         !  
-         NF90(nf90_put_var(map_file%ncid, map_file%h_varid, vtmp, (/1, ntmapout/))) ! write h
-         !
-      endif
-      !            
-      if (store_velocity) then
-         !
-         utmp = FILL_VALUE
-         vtmp = FILL_VALUE
-         !
-         do nmq = 1, quadtree_nr_points
-            !
-            nm = index_sfincs_in_quadtree(nmq)
-            !
-            if (nm>0) then
-               !
-               ! Regular point with four surrounding cells of the same size
-               !
-               n = z_index_z_n(nm)
-               m = z_index_z_m(nm)
-               nmd1 = z_index_uv_md(nm)
-               nmu1 = z_index_uv_mu(nm)
-               ndm1 = z_index_uv_nd(nm)
-               num1 = z_index_uv_nu(nm)
-               uz = 0.5*(uv(nmd1) + uv(nmu1))
-               vz = 0.5*(uv(ndm1) + uv(num1))
-               !
-               utmp(nmq) = cosrot*uz - sinrot*vz            
-               vtmp(nmq) = sinrot*uz + cosrot*vz  
-               !
-            endif
-            !
-         enddo
-         !
-         NF90(nf90_put_var(map_file%ncid, map_file%u_varid, utmp, (/1, ntmapout/)))
-         NF90(nf90_put_var(map_file%ncid, map_file%v_varid, vtmp, (/1, ntmapout/)))
-         !
-      endif
-      !
+   ! h = zs - zref. Quadtree filters wet cells (legacy); regular keeps all.
+   if (subgrid .eqv. .false. .or. store_hsubgrid .eqv. .true.) then
       if (subgrid) then
-         !
-         if (store_zvolume) then
-            !
-            vtmp = FILL_VALUE
-            !
-            do nmq = 1, quadtree_nr_points
-               !
-               nm = index_sfincs_in_quadtree(nmq)
-               !
-               if (nm>0) then
-                  ! 
-                  vtmp(nmq) = z_volume(nm)
-                  !
-               endif   
-            enddo
-            !
-            NF90(nf90_put_var(map_file%ncid, map_file%zvolume_varid, vtmp, (/1, ntmapout/)))            
-            ! 
-         endif
-         !
-         if (store_storagevolume) then
-            !
-            vtmp = FILL_VALUE
-            !
-            do nmq = 1, quadtree_nr_points
-               !
-               nm = index_sfincs_in_quadtree(nmq)
-               !
-               if (nm>0) then
-                  ! 
-                  vtmp(nmq) = storage_volume(nm)
-                  !
-               endif   
-            enddo
-            !
-            NF90(nf90_put_var(map_file%ncid, map_file%storagevolume_varid, vtmp, (/1, ntmapout/)))            
-            ! 
-         endif
-         !      
-      endif      
-      !
-      if (store_meteo) then  
-          !
-          if (wind) then
-             utmp = FILL_VALUE
-             vtmp = FILL_VALUE
-             !
-             do nmq = 1, quadtree_nr_points
-                !
-                nm = index_sfincs_in_quadtree(nmq)
-                !
-                if (nm>0) then
-                   ! 
-                   utmp(nmq) = windu(nm)
-                   vtmp(nmq) = windv(nm)
-                   !
-                endif   
-             enddo
-             !
-             NF90(nf90_put_var(map_file%ncid, map_file%wind_u_varid, utmp, (/1, ntmapout/)))
-             NF90(nf90_put_var(map_file%ncid, map_file%wind_v_varid, vtmp, (/1, ntmapout/)))
-             !
-          endif
-          !
-          !
-          if (patmos) then
-             !
-             utmp = FILL_VALUE
-             !
-             do nmq = 1, quadtree_nr_points
-                !
-                nm = index_sfincs_in_quadtree(nmq)
-                !
-                if (nm>0) then
-                   ! 
-                   utmp(nmq) = patm(nm)
-                   !
-                endif   
-             enddo
-             !
-             NF90(nf90_put_var(map_file%ncid, map_file%patm_varid, utmp, (/1, ntmapout/)))
-             !
-          endif         
-          !
+         call write_cell_var_depth(map_file%ncid, map_file%h_varid, real(zs,4), subgrid_z_zmin, ntmapout, &
+              check_wet=use_quadtree)
+      else
+         call write_cell_var_depth(map_file%ncid, map_file%h_varid, real(zs,4), zb,             ntmapout, &
+              check_wet=use_quadtree)
       endif
-      !
-      if (snapwave) then
-         !
-         vtmp = FILL_VALUE
-         !
-         do nmq = 1, quadtree_nr_points
-            !
-            nm = index_sw_in_qt(nmq)
-            !
-            if (nm>0) then
-               ! 
-               vtmp(nmq) = snapwave_H(nm)*sq2 ! TL: TODO: clean up difference of using SnapWave_H here, and hm0 for regular grid!
-               !
-            endif   
-         enddo
-         !
-         NF90(nf90_put_var(map_file%ncid, map_file%hm0_varid, vtmp, (/1, ntmapout/)))
-         !
-         vtmp = FILL_VALUE
-         !
-         do nmq = 1, quadtree_nr_points
-            !
-            nm = index_sw_in_qt(nmq)
-            !
-            if (nm>0) then
-               ! 
-               vtmp(nmq) = snapwave_H_ig(nm)*sq2
-               ! 
-            endif   
-         enddo
-         !
-         NF90(nf90_put_var(map_file%ncid, map_file%hm0ig_varid, vtmp, (/1, ntmapout/)))      
-         !            
-         if (store_wave_forces) then
-            !      
-            utmp = FILL_VALUE
-            vtmp = FILL_VALUE
-            !
-            do nmq = 1, quadtree_nr_points
-               !
-               nm = index_sfincs_in_quadtree(nmq)
-               !
-               if (nm>0) then
-                  utmp(nmq) = fwx(nm)
-                  vtmp(nmq) = fwy(nm)
-               endif
-               !
-            enddo
-            !
-            NF90(nf90_put_var(map_file%ncid, map_file%fwx_varid, utmp, (/1, ntmapout/)))
-            NF90(nf90_put_var(map_file%ncid, map_file%fwy_varid, vtmp, (/1, ntmapout/)))
-            !
-            vtmp = FILL_VALUE
-            !
-            do nmq = 1, quadtree_nr_points
-               !
-               nm = index_sw_in_qt(nmq)
-               !
-               if (nm>0) then
-                  ! 
-                  vtmp(nmq) = snapwave_Tp(nm)
-                  !
-               endif   
-            enddo
-            !
-            NF90(nf90_put_var(map_file%ncid, map_file%tp_varid, vtmp, (/1, ntmapout/)))
-            !
-            vtmp = FILL_VALUE
-            !
-            do nmq = 1, quadtree_nr_points
-               !
-               nm = index_sw_in_qt(nmq)
-               !
-               if (nm>0) then
-                  ! 
-                  vtmp(nmq) = snapwave_Tp_ig(nm)
-                  ! 
-               endif   
-            enddo
-            !
-            NF90(nf90_put_var(map_file%ncid, map_file%tpig_varid, vtmp, (/1, ntmapout/)))            
-            !
-            utmp = FILL_VALUE
-            !
-            do nmq = 1, quadtree_nr_points
-               !
-               nm = index_sfincs_in_quadtree(nmq)
-               !
-               if (nm>0) then
-                  utmp(nmq) = betamean(nm)
-               endif
-               !
-            enddo        
-            !
-            NF90(nf90_put_var(map_file%ncid, map_file%beta_varid, utmp, (/1, ntmapout/)))     
-            !
-            vtmp = FILL_VALUE
-            !
-            do nmq = 1, quadtree_nr_points
-               !
-               nm = index_sw_in_qt(nmq)            
-               !
-               if (nm>0) then
-                  vtmp(nmq) = snapwave_depth(nm)                  
-               endif
-               !
-            enddo                    
-            !             
-            NF90(nf90_put_var(map_file%ncid, map_file%snapwavedepth_varid, vtmp, (/1, ntmapout/)))                             
-            !
-         endif
-         !
-         if (store_wave_direction) then
-            !
-            vtmp = FILL_VALUE
-            !
-            do nmq = 1, quadtree_nr_points
-               !
-               nm = index_sw_in_qt(nmq)            
-               !
-               if (nm>0) then
-                  vtmp(nmq) = snapwave_mean_direction(nm)               
-               endif
-               !
-            enddo                    
-            !             
-            NF90(nf90_put_var(map_file%ncid, map_file%wavdir_varid, vtmp, (/1, ntmapout/)))                
-            !
-            !vtmp = FILL_VALUE
-            !!
-            !do nmq = 1, quadtree_nr_points
-            !   !
-            !   nm = index_sw_in_qt(nmq)            
-            !   !
-            !   if (nm>0) then
-            !      vtmp(nmq) = wave_directional_spreading(nm)                  
-            !   endif
-            !   !
-            !enddo                    
-            !!             
-            !NF90(nf90_put_var(map_file%ncid, map_file%dirspr_varid, vtmp, (/1, ntmapout/)))  
-            !
-         endif         
-         !
-         if (wavemaker) then
-            !
-            vtmp = FILL_VALUE
-            !
-            do nmq = 1, quadtree_nr_points
-               !
-               nm = index_sfincs_in_quadtree(nmq)
-               !
-               if (nm>0) then
-                  vtmp(nmq) = zsm(nm)
-               endif
-               !
-            enddo
-            !
-            NF90(nf90_put_var(map_file%ncid, map_file%zsm_varid, vtmp, (/1, ntmapout/)))
-            !
-         endif            
-         !            
+   endif
+   !
+   ! -------------------------------------------------------
+   ! Velocity (cell-centered, computed once via 4-face average)
+   ! -------------------------------------------------------
+   if (store_velocity) then
+      allocate(uxy(np), vxy(np))
+      call compute_uv_at_cell_centers(uxy, vxy)
+      call write_cell_var(map_file%ncid, map_file%u_varid, uxy, ntmapout)
+      call write_cell_var(map_file%ncid, map_file%v_varid, vxy, ntmapout)
+      deallocate(uxy, vxy)
+   endif
+   !
+   ! -------------------------------------------------------
+   ! Subgrid volumes
+   ! -------------------------------------------------------
+   if (subgrid) then
+      if (store_zvolume) then
+         call write_cell_var(map_file%ncid, map_file%zvolume_varid, real(z_volume,4), ntmapout)
       endif
-      !
-      if (nonhydrostatic) then
-         !
-         vtmp = FILL_VALUE     
-         !
-         do nmq = 1, quadtree_nr_points
-            !
-            nm = index_sfincs_in_quadtree(nmq)
-            !
-            if (nm>0) then            
-               !
-               ! Look up pressure in 'limited' nonh array that only has values where nonh mask is set to active
-               !
-               if (row_index_of_nm(nm) > 0) then
-                  !
-                  vtmp(nmq) = pnh(row_index_of_nm(nm))
-                  !
-               endif   
-               !
-            endif   
-         enddo
-         !
-         NF90(nf90_put_var(map_file%ncid, map_file%pnonh_varid, vtmp, (/1, ntmapout/)))
-         !
+      if (store_storagevolume) then
+         call write_cell_var(map_file%ncid, map_file%storagevolume_varid, storage_volume, ntmapout)
       endif
-      !
-      NF90(nf90_sync(map_file%ncid)) !write away intermediate data ! TL: in first test it seems to be faster to let the file update than keep in memory
-      !      
-   end subroutine
-   
-   
-   
+   endif
+   !
+   ! -------------------------------------------------------
+   ! Infiltration state
+   ! -------------------------------------------------------
+   if (inftype == 'cnb') then
+      call write_cell_var(map_file%ncid, map_file%infstate_varid, scs_Se,   ntmapout)
+   elseif (inftype == 'gai') then
+      call write_cell_var(map_file%ncid, map_file%infstate_varid, GA_sigma, ntmapout)
+   elseif (inftype == 'hor') then
+      call write_cell_var(map_file%ncid, map_file%infstate_varid, qinfmap,  ntmapout)
+   endif
+   !
+   ! -------------------------------------------------------
+   ! Meteo
+   ! -------------------------------------------------------
+   if (store_meteo) then
+      if (wind) then
+         call write_cell_var(map_file%ncid, map_file%wind_u_varid, windu, ntmapout)
+         call write_cell_var(map_file%ncid, map_file%wind_v_varid, windv, ntmapout)
+      endif
+      if (patmos) then
+         call write_cell_var(map_file%ncid, map_file%patm_varid, patm, ntmapout)
+      endif
+      if (precip) then
+         call write_cell_var(map_file%ncid, map_file%precip_varid, prcp, ntmapout, scale=3600000.0)
+      endif
+   endif
+   !
+   ! -------------------------------------------------------
+   ! SnapWave (all fields read the snapwave_* node arrays via use_sw_index,
+   ! so quadtree and regular grids share the same output path)
+   ! -------------------------------------------------------
+   if (snapwave) then
+      call write_cell_var(map_file%ncid, map_file%hm0_varid,   snapwave_H,    ntmapout, use_sw_index=.true., scale=sq2)
+      call write_cell_var(map_file%ncid, map_file%hm0ig_varid, snapwave_H_ig, ntmapout, use_sw_index=.true., scale=sq2)
+      call write_cell_var(map_file%ncid, map_file%tp_varid,    snapwave_Tp,    ntmapout, use_sw_index=.true.)
+      call write_cell_var(map_file%ncid, map_file%tpig_varid,  snapwave_Tp_ig, ntmapout, use_sw_index=.true.)
+      if (store_wave_forces) then
+         call write_cell_var(map_file%ncid, map_file%fwx_varid,           snapwave_Fx,    ntmapout, use_sw_index=.true.)
+         call write_cell_var(map_file%ncid, map_file%fwy_varid,           snapwave_Fy,    ntmapout, use_sw_index=.true.)
+         call write_cell_var(map_file%ncid, map_file%beta_varid,          snapwave_beta,  ntmapout, use_sw_index=.true.)
+         call write_cell_var(map_file%ncid, map_file%snapwavedepth_varid, snapwave_depth, ntmapout, use_sw_index=.true.)
+      endif
+      if (store_wave_direction) then
+         call write_cell_var(map_file%ncid, map_file%wavdir_varid, snapwave_mean_direction, ntmapout, use_sw_index=.true.)
+      endif
+      if (wavemaker) then
+         call write_cell_var(map_file%ncid, map_file%zsm_varid, zsm, ntmapout)
+      endif
+   endif
+   !
+   ! -------------------------------------------------------
+   ! Non-hydrostatic pressure (precompute then write)
+   ! -------------------------------------------------------
+   if (nonhydrostatic) then
+      allocate(pnh_full(np))
+      call compute_pnh_unwrapped(pnh_full)
+      call write_cell_var(map_file%ncid, map_file%pnonh_varid, pnh_full, ntmapout)
+      deallocate(pnh_full)
+   endif
+   !
+   NF90(nf90_sync(map_file%ncid))
+   !
+   end subroutine ncoutput_update_map
+
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+   !
    subroutine ncoutput_update_his(t,nthisout)
-   ! Write time, zs, u, v, prcp of points 
+   !
+   ! Write time, zs, u, v, prcp etc. at observation points.
    !
    use sfincs_data
    use sfincs_crosssections
@@ -3407,241 +1368,84 @@ contains
    !
    implicit none
    !
-   integer :: iobs, nm, istruc
-   !
-   integer :: nthisout      
-   integer :: nmd1, nmu1, ndm1, num1
-   !
-   real*4                  :: uz, vz
-   real*8                  :: t
-!   real*4, dimension(nobs) :: zobs, hobs
-   real*4, dimension(nobs) :: uobs
-   real*4, dimension(nobs) :: vobs   
-   real*4, dimension(nobs) :: uvmag   
-   real*4, dimension(nobs) :: uvdir   
-   real*4, dimension(nobs) :: tprcp
-   real*4, dimension(nobs) :: tcumprcp
-   real*4, dimension(nobs) :: tqinf
-   real*4, dimension(nobs) :: tS_effective
-   real*4, dimension(nobs) :: tpatm
-   real*4, dimension(nobs) :: twndmag
-   real*4, dimension(nobs) :: twnddir
-   real*4, dimension(nobs) :: hm0obs
-   real*4, dimension(nobs) :: hm0igobs
-   real*4, dimension(nobs) :: zsmobs
-   real*4, dimension(nobs) :: tpobs
-   real*4, dimension(nobs) :: tpigobs   
-   real*4, dimension(nobs) :: wavdirobs
-   real*4, dimension(nobs) :: dirsprobs
-   real*4, dimension(nobs) :: dwobs
-   real*4, dimension(nobs) :: dfobs
-   real*4, dimension(nobs) :: dwigobs
-   real*4, dimension(nobs) :: dfigobs
-   real*4, dimension(nobs) :: cgobs
-   real*4, dimension(nobs) :: betaobs
-   real*4, dimension(nobs) :: srcigobs
-   real*4, dimension(nobs) :: alphaigobs
+   integer :: iobs, nm, idrn
+   integer :: nthisout
+   real*8  :: t
+   real*4, dimension(nobs) :: uobs, vobs, uvmag, uvdir
+   real*4, dimension(nobs) :: twndmag, twnddir
+   real*4, dimension(ndrn) :: q_drain
    real*4, dimension(:), allocatable :: qq, zz
    !
-   zobs         = FILL_VALUE
-   zsmobs       = FILL_VALUE
-   hobs         = FILL_VALUE         
-   hm0obs       = FILL_VALUE         
-   hm0igobs     = FILL_VALUE         
-   tpobs        = FILL_VALUE         
-   wavdirobs    = FILL_VALUE         
-   dirsprobs    = FILL_VALUE         
-   tprcp        = FILL_VALUE
-   tcumprcp     = FILL_VALUE
-   tqinf        = FILL_VALUE
-   tS_effective = FILL_VALUE
-   tpatm        = FILL_VALUE
-   twndmag      = FILL_VALUE
-   twnddir      = FILL_VALUE
-   dwobs        = FILL_VALUE
-   dfobs        = FILL_VALUE
-   cgobs        = FILL_VALUE
-   betaobs      = FILL_VALUE
-   srcigobs     = FILL_VALUE
-   alphaigobs   = FILL_VALUE   
+   zobs    = FILL_VALUE
+   hobs    = FILL_VALUE
+   q_drain = FILL_VALUE
    !
-   do iobs = 1, nobs ! determine zs and prcp of obervation points at required timestep
-      !
+   do iobs = 1, nobs
       nm = nmindobs(iobs)
-      !
       if (nm>0) then
-         !
-         zobs(iobs)  = zs(nm)
-         !
+         zobs(iobs) = zs(nm)
          if (subgrid) then
-            hobs(iobs)  = zs(nm) - subgrid_z_zmin(nm)
+            hobs(iobs) = zs(nm) - subgrid_z_zmin(nm)
          else
-            hobs(iobs)  = zs(nm) - zb(nm)
+            hobs(iobs) = zs(nm) - zb(nm)
          endif
-         !
-         if (store_velocity) then
-            !
-            ! Regular point with four surrounding cells of the same size
-            !
-            nmd1 = z_index_uv_md(nm)
-            nmu1 = z_index_uv_mu(nm)
-            ndm1 = z_index_uv_nd(nm)
-            num1 = z_index_uv_mu(nm)
-            uz  = 0.5 * (uv(nmd1) + uv(nmu1))
-            vz  = 0.5 * (uv(ndm1) + uv(num1))
-            !
-            uobs(iobs)  = cosrot * uz - sinrot * vz                         
-            vobs(iobs)  = sinrot * uz + cosrot * vz
-            uvmag(iobs) = sqrt(uobs(iobs)**2 + vobs(iobs)**2)
-            uvdir(iobs) = atan2(vobs(iobs), uobs(iobs)) * 180 / pi
-            !
-         endif
-         !
-         if (infiltration) then
-            !
-            tqinf(iobs) = qinfmap(nm) * 3600000 ! show as mm/hr
-            ! 
-            ! Output for CN and GA method
-            !
-            if (inftype == 'cnb') then
-               !
-               tS_effective(iobs) = scs_Se(nm)
-               !
-            elseif (inftype == 'gai') then
-               !
-               tS_effective(iobs) = GA_sigma(nm)
-            elseif (inftype == 'hor') then
-               tS_effective(iobs) = qinfmap(nm)*3.6e3*1.0e3 ! current f in mm/hr
-            elseif (inftype == 'bkt') then
-               tS_effective(iobs) = bucket_volume(nm)        ! current bucket storage in m
-            endif
-         endif
-         !
-         if (store_meteo) then
-            !
-            if (wind) then
-               !
-               twndmag(iobs) = sqrt(windu(nm)**2 + windv(nm)**2)
-               twnddir(iobs) = 270.0 - atan2(windv(nm), windu(nm)) * 180 / pi
-               if (twnddir(iobs) < 0.0) twnddir(iobs) = twnddir(iobs) + 360.0
-               if (twnddir(iobs) > 360.0) twnddir(iobs) = twnddir(iobs) - 360.0
-               !
-            endif   
-            !
-            if (patmos) then
-               !
-               tpatm(iobs) = patm(nm)
-               !
-            endif   
-            !
-            if (precip) then
-               !
-               tprcp(iobs) = prcp(nm) * 3600000 ! show as mm/hr
-               !
-               if (store_cumulative_precipitation) then
-                  !
-                  tcumprcp(iobs) = cumprcp(nm) ! show as m
-                  !
-               endif   
-               !
-            endif
-            !         
-         endif
-         !
-         if (snapwave) then
-            !
-            hm0obs(iobs)   = hm0(nm)
-            hm0igobs(iobs) = hm0_ig(nm)
-            tpobs(iobs)    = sw_tp(nm)
-            tpigobs(iobs)  = sw_tp_ig(nm)            
-            !
-            if (store_wave_direction) then
-               !
-               wavdirobs(iobs)   = mean_wave_direction(nm)
-               dirsprobs(iobs)   = wave_directional_spreading(nm)
-               !
-            endif
-            !            
-            if (wavemaker) then
-               !
-               zsmobs(iobs)   = zsm(nm)
-               !
-            endif   
-            !
-            if (store_wave_forces) then
-               !
-               dwobs(iobs)    = dw(nm)
-               dfobs(iobs)    = df(nm)
-               dwigobs(iobs)  = dwig(nm)
-               dfigobs(iobs)  = dfig(nm)
-               cgobs(iobs)    = cg(nm) 
-               betaobs(iobs)  = betamean(nm)               
-               srcigobs(iobs) = srcig(nm)               
-               alphaigobs(iobs) = alphaig(nm)                              
-               ! 
-            endif
-            !
-         endif   
-         !
       endif
-   enddo   
-   !   
-   NF90(nf90_put_var(his_file%ncid, his_file%time_varid, t, (/nthisout/))) ! write time
-   !   
-   NF90(nf90_put_var(his_file%ncid, his_file%zs_varid, zobs, (/1, nthisout/))) ! write point_zs
+   enddo
+   if (store_velocity)          call compute_uv_at_obs_points(uobs, vobs, uvmag, uvdir)
+   if (store_meteo .and. wind)  call compute_wind_at_obs_points(twndmag, twnddir)
    !
-   if (subgrid .eqv. .false. .or. store_hsubgrid .eqv. .true.) then   
+   NF90(nf90_put_var(his_file%ncid, his_file%time_varid, t, (/nthisout/)))
+   !
+   NF90(nf90_put_var(his_file%ncid, his_file%zs_varid, zobs, (/1, nthisout/)))
+   !
+   if (subgrid .eqv. .false. .or. store_hsubgrid .eqv. .true.) then
       !
-      NF90(nf90_put_var(his_file%ncid, his_file%h_varid, hobs, (/1, nthisout/))) ! write point_h   
+      NF90(nf90_put_var(his_file%ncid, his_file%h_varid, hobs, (/1, nthisout/)))
       !
    endif
    !
    if (infiltration) then
       !
-      NF90(nf90_put_var(his_file%ncid, his_file%qinf_varid, tqinf, (/1, nthisout/))) ! write qinf
+      call write_point_var(his_file%qinf_varid, qinfmap, nthisout, scale=3600000.0)
       !
-      if (inftype == 'cnb' .or. inftype == 'gai' .or. inftype == 'hor' .or. inftype == 'bkt') then
-         NF90(nf90_put_var(his_file%ncid, his_file%S_varid, tS_effective, (/1, nthisout/))) ! write S
+      if (inftype == 'cnb') then
+         call write_point_var(his_file%S_varid, scs_Se, nthisout)
+      elseif (inftype == 'gai') then
+         call write_point_var(his_file%S_varid, GA_sigma, nthisout)
       endif
       !
    endif
    !
-   if (snapwave) then  
+   if (snapwave) then
       !
-      NF90(nf90_put_var(his_file%ncid, his_file%hm0_varid, hm0obs, (/1, nthisout/)))
-      NF90(nf90_put_var(his_file%ncid, his_file%hm0ig_varid, hm0igobs, (/1, nthisout/)))
-      NF90(nf90_put_var(his_file%ncid, his_file%tp_varid, tpobs, (/1, nthisout/)))
-      NF90(nf90_put_var(his_file%ncid, his_file%tpig_varid, tpigobs, (/1, nthisout/)))      
+      call write_point_var(his_file%hm0_varid,    snapwave_H,     nthisout, use_sw_index=.true., scale=sqrt(2.0))
+      call write_point_var(his_file%hm0ig_varid,  snapwave_H_ig,  nthisout, use_sw_index=.true., scale=sqrt(2.0))
+      call write_point_var(his_file%tp_varid,     snapwave_Tp,    nthisout, use_sw_index=.true.)
+      call write_point_var(his_file%tpig_varid,   snapwave_Tp_ig, nthisout, use_sw_index=.true.)
       !
       if (store_wave_direction) then
-         !
-         NF90(nf90_put_var(his_file%ncid, his_file%wavdir_varid, wavdirobs, (/1, nthisout/)))
-         !NF90(nf90_put_var(his_file%ncid, his_file%dirspr_varid, dirsprobs, (/1, nthisout/)))
-         !
+         call write_point_var(his_file%wavdir_varid, snapwave_mean_direction, nthisout, use_sw_index=.true.)
       endif
-      !            
+      !
       if (wavemaker) then
          !
-         NF90(nf90_put_var(his_file%ncid, his_file%zsm_varid, zsmobs, (/1, nthisout/)))
+         call write_point_var(his_file%zsm_varid, zsm, nthisout)
          !
       endif
       !
       if (store_wave_forces) then
          !
-         NF90(nf90_put_var(his_file%ncid, his_file%dw_varid, dwobs, (/1, nthisout/)))
-         NF90(nf90_put_var(his_file%ncid, his_file%df_varid, dfobs, (/1, nthisout/)))        
-         ! 
-         NF90(nf90_put_var(his_file%ncid, his_file%dwig_varid, dwigobs, (/1, nthisout/)))
-         NF90(nf90_put_var(his_file%ncid, his_file%dfig_varid, dfigobs, (/1, nthisout/)))        
+         call write_point_var(his_file%dw_varid,      snapwave_Dw,      nthisout, use_sw_index=.true.)
+         call write_point_var(his_file%df_varid,      snapwave_Df,      nthisout, use_sw_index=.true.)
+         call write_point_var(his_file%dwig_varid,    snapwave_Dwig,    nthisout, use_sw_index=.true.)
+         call write_point_var(his_file%dfig_varid,    snapwave_Dfig,    nthisout, use_sw_index=.true.)
+         call write_point_var(his_file%cg_varid,      snapwave_cg,      nthisout, use_sw_index=.true.)
+         call write_point_var(his_file%beta_varid,    snapwave_beta,    nthisout, use_sw_index=.true.)
+         call write_point_var(his_file%srcig_varid,   snapwave_srcig,   nthisout, use_sw_index=.true.)
+         call write_point_var(his_file%alphaig_varid, snapwave_alphaig, nthisout, use_sw_index=.true.)
          !
-         NF90(nf90_put_var(his_file%ncid, his_file%cg_varid, cgobs, (/1, nthisout/)))
-         !
-         NF90(nf90_put_var(his_file%ncid, his_file%beta_varid, betaobs, (/1, nthisout/)))
-         NF90(nf90_put_var(his_file%ncid, his_file%srcig_varid, srcigobs, (/1, nthisout/)))                  
-         NF90(nf90_put_var(his_file%ncid, his_file%alphaig_varid, alphaigobs, (/1, nthisout/)))         
-         !            
       endif
-      !      
+      !
    endif
    !
    if (store_meteo) then
@@ -3650,49 +1454,42 @@ contains
          !
          NF90(nf90_put_var(his_file%ncid, his_file%wind_speed_varid, twndmag, (/1, nthisout/)))
          NF90(nf90_put_var(his_file%ncid, his_file%wind_dir_varid,   twnddir, (/1, nthisout/)))
-        !
-      endif      
+         !
+      endif
       !
       if (patmos) then
          !
-         NF90(nf90_put_var(his_file%ncid, his_file%patm_varid, tpatm, (/1, nthisout/))) ! write patmos
+         call write_point_var(his_file%patm_varid, patm, nthisout)
          !
-      endif   
+      endif
       !
       if (precip) then
          !
-         NF90(nf90_put_var(his_file%ncid, his_file%prcp_varid, tprcp, (/1, nthisout/))) ! write prcp
+         call write_point_var(his_file%prcp_varid, prcp, nthisout, scale=3600000.0)
          !
          if (store_cumulative_precipitation) then
             !
-            NF90(nf90_put_var(his_file%ncid, his_file%cumprcp_varid, tcumprcp, (/1, nthisout/))) ! write cumulative prcp
+            call write_point_var(his_file%cumprcp_varid, cumprcp, nthisout)
             !
-         endif   
+         endif
          !
       endif
-      !   
+      !
    endif
    !
    if (nrcrosssections>0) then
-      !
       !$acc update host(q)
-      !      
-      ! Get fluxes through cross sections
-      !
+      ! Get fluxes through cross sections (callee allocates qq)
       call get_discharges_through_crosssections(qq)
-      !
-      NF90(nf90_put_var(his_file%ncid, his_file%discharge_varid, qq, (/1, nthisout/))) ! write discharge
-      !
+      NF90(nf90_put_var(his_file%ncid, his_file%discharge_varid, qq, (/1, nthisout/)))
+      if (allocated(qq)) deallocate(qq)
    endif
    !
    if (nr_runup_gauges>0) then
-      !
-      ! Get run-up elevations
-      !
+      ! Get run-up elevations (callee allocates zz)
       call get_runup_levels(zz)
-      !
-      NF90(nf90_put_var(his_file%ncid, his_file%runup_gauge_zs_varid, zz, (/1, nthisout/))) ! write run up level
-      !
+      NF90(nf90_put_var(his_file%ncid, his_file%runup_gauge_zs_varid, zz, (/1, nthisout/)))
+      if (allocated(zz)) deallocate(zz)
    endif
    !
    if (nr_src_structures>0) then
@@ -3712,488 +1509,130 @@ contains
    if (nr_discharge_points>0 .and. store_river_discharge) then
       !
       !$acc update host(qtsrc)
+      ! Get fluxes through drainage structure
       !
-      NF90(nf90_put_var(his_file%ncid, his_file%river_varid, qtsrc, (/1, nthisout/))) ! write per-river-source discharge
+      idrn = 0
+      do iobs = nsrc + 1, nsrcdrn, 2 !TL: as in sfincs_output.f90
+         idrn = idrn + 1
+         q_drain(idrn) = qtsrc(iobs)
+      enddo
       !
-   endif
-   !
-   if (nr_urban_drainage_zones > 0 .and. store_urban_drainage_discharge) then
-      !
-      NF90(nf90_put_var(his_file%ncid, his_file%urbdrain_varid, urban_drainage_q_total, (/1, nthisout/))) ! write per-zone total discharge
+      NF90(nf90_put_var(his_file%ncid, his_file%drain_varid, q_drain, (/1, nthisout/)))
       !
    endif
    !
    if (store_velocity) then
       !
-      NF90(nf90_put_var(his_file%ncid, his_file%u_varid, uobs, (/1, nthisout/)))
-      NF90(nf90_put_var(his_file%ncid, his_file%v_varid, vobs, (/1, nthisout/)))   
-      NF90(nf90_put_var(his_file%ncid, his_file%uvmag_varid, uvmag, (/1, nthisout/)))   
-      NF90(nf90_put_var(his_file%ncid, his_file%uvdir_varid, uvdir, (/1, nthisout/)))   
+      NF90(nf90_put_var(his_file%ncid, his_file%u_varid,     uobs,  (/1, nthisout/)))
+      NF90(nf90_put_var(his_file%ncid, his_file%v_varid,     vobs,  (/1, nthisout/)))
+      NF90(nf90_put_var(his_file%ncid, his_file%uvmag_varid, uvmag, (/1, nthisout/)))
+      NF90(nf90_put_var(his_file%ncid, his_file%uvdir_varid, uvdir, (/1, nthisout/)))
       !
    endif
    !
-   NF90(nf90_sync(his_file%ncid)) !write away intermediate data ! TL: in first test it seems to be faster to let the file update than keep in memory
-   !   
+   NF90(nf90_sync(his_file%ncid)) !TL: in first test it seems to be faster to let the file update than keep in memory
+   !
    end subroutine
    !
    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!   
    !
+
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+   !
    subroutine ncoutput_update_max(t,ntmaxout)
    !
-   ! write zsmax per dtmaxout
+   ! Write maximum values to map file (handles both regular and quadtree grids)
    !
    use sfincs_data
-   use sfincs_urban_drainage, only: urban_drainage_cumulative_volume
-   !
-   implicit none
-   !
-   integer :: nm, n, m
-   !
-   real*8                       :: t  
-   !
-   integer  :: ntmaxout   
-   !
-   real*4, dimension(:,:), allocatable :: zstmp
-   real*4, dimension(:), allocatable    :: hmean ! Same size as zs 1D array   
-   !
-   allocate(zstmp(mmax, nmax))
-   !
-   zstmp = FILL_VALUE
-   !
-   if (subgrid) then   
-      !
-      do nm = 1, np
-         !
-         n    = z_index_z_n(nm)
-         m    = z_index_z_m(nm)
-         !      
-         if ( (zsmax(nm) - subgrid_z_zmin(nm)) > huthresh) then
-            zstmp(m, n) = zsmax(nm) 
-         endif
-      enddo
-   else
-      do nm = 1, np       
-         !
-         n    = z_index_z_n(nm)
-         m    = z_index_z_m(nm)
-         !      
-         if ( (zsmax(nm) - zb(nm)) > huthresh) then
-            zstmp(m, n) = zsmax(nm) 
-         endif      
-      enddo
-   endif
-   !
-   NF90(nf90_put_var(map_file%ncid, map_file%timemax_varid, t, (/ntmaxout/))) ! write time_max
-   NF90(nf90_put_var(map_file%ncid, map_file%zsmax_varid, zstmp, (/1, 1, ntmaxout/))) ! write zsmax      
-   !
-   ! Write maximum water depth (optional)   
-   if (subgrid .eqv. .false. .or. store_hsubgrid .eqv. .true.) then
-      !
-      zstmp = FILL_VALUE
-      !
-      if (store_hmean .and. subgrid .eqv. .true.) then
-         !
-         ! Obtain mean depth from subgrid tables
-         !
-         allocate(hmean(np))
-         !
-         call compute_subgrid_mean_depth(zsmax, hmean)
-         !
-      endif   
-      !
-      if (subgrid) then   
-         do nm = 1, np
-            !
-            n    = z_index_z_n(nm)
-            m    = z_index_z_m(nm)             
-            !
-            if ( (zsmax(nm) - subgrid_z_zmin(nm)) > huthresh) then
-               !             
-               if (store_hmean) then
-                  !
-                  ! Store mean depth in subgrid cell
-                  !               
-                  zstmp(m, n) = hmean(nm)
-                  !
-               else
-                  !
-                  ! Store maximum depth in subgrid cell
-                  !
-                  zstmp(m, n) = zsmax(nm) - subgrid_z_zmin(nm)
-                  !
-               endif   
-            endif                     
-         enddo
-      else
-         do nm = 1, np       
-            !
-            n    = z_index_z_n(nm)
-            m    = z_index_z_m(nm)
-            !      
-            if ( (zsmax(nm) - zb(nm)) > huthresh) then
-               zstmp(m, n) = zsmax(nm) - zb(nm)
-            endif      
-         enddo
-      endif 
-      NF90(nf90_put_var(map_file%ncid, map_file%hmax_varid, zstmp, (/1, 1, ntmaxout/))) ! write hmax   
-   endif
-   !
-   ! Write cumulative rainfall
-   ! 
-   if (store_cumulative_precipitation) then  
-      !
-      ! Precipitation
-      ! 
-      zstmp = FILL_VALUE
-      !
-      do nm = 1, np       
-         !
-         n    = z_index_z_n(nm)
-         m    = z_index_z_m(nm)
-         !      
-         zstmp(m, n) = cumprcp(nm)
-         !
-      enddo
-      !
-      NF90(nf90_put_var(map_file%ncid, map_file%cumprcp_varid, zstmp, (/1, 1, ntmaxout/))) ! write zsmax   
-      !
-      ! Infiltration
-      !
-      zstmp = FILL_VALUE
-      !
-      do nm = 1, np
-         n              = z_index_z_n(nm)
-         m              = z_index_z_m(nm)
-         zstmp(m, n)    = cuminf(nm) 
-      enddo
-      !
-      NF90(nf90_put_var(map_file%ncid, map_file%cuminf_varid, zstmp, (/1, 1, ntmaxout/))) ! write cuminf
-      !
-   endif
-   !
-   ! Cumulative urban drainage depth (volume / cell_area)
-   !
-   if (store_cumulative_urban_drainage .and. urban_drainage) then
-      !
-      zstmp = FILL_VALUE
-      !
-      do nm = 1, np
-         !
-         n = z_index_z_n(nm)
-         m = z_index_z_m(nm)
-         !
-         if (crsgeo) then
-            zstmp(m, n) = urban_drainage_cumulative_volume(nm) / cell_area_m2(nm)
-         else
-            zstmp(m, n) = urban_drainage_cumulative_volume(nm) / cell_area(z_flags_iref(nm))
-         endif
-         !
-      enddo
-      !
-      NF90(nf90_put_var(map_file%ncid, map_file%cumulative_urbdrain_varid, zstmp, (/1, 1, ntmaxout/))) ! write cumulative urban drainage depth
-      !
-   endif
-   !
-   ! Maximum flow velocity
-   !
-   if (store_maximum_velocity) then
-      zstmp = FILL_VALUE
-      do nm = 1, np   
-         n              = z_index_z_n(nm)
-         m              = z_index_z_m(nm)
-         zstmp(m, n)    = vmax(nm)
-      enddo
-      NF90(nf90_put_var(map_file%ncid, map_file%vmax_varid, zstmp, (/1, 1, ntmaxout/))) ! write vmax
-   endif
-   !
-   ! Maximum flow flux
-   !
-   if (store_maximum_flux) then
-      zstmp = FILL_VALUE
-      do nm = 1, np   
-         n              = z_index_z_n(nm)
-         m              = z_index_z_m(nm)
-         zstmp(m, n)    = qmax(nm)
-      enddo
-      NF90(nf90_put_var(map_file%ncid, map_file%qmax_varid, zstmp, (/1, 1, ntmaxout/))) ! write qmax
-   endif   
-   !
-   ! Duration wet cell
-   !
-   if (store_twet) then
-      zstmp = FILL_VALUE
-      do nm = 1, np
-         n              = z_index_z_n(nm)
-         m              = z_index_z_m(nm)
-         zstmp(m, n)    = twet(nm) 
-      enddo
-      NF90(nf90_put_var(map_file%ncid, map_file%tmax_varid, zstmp, (/1, 1, ntmaxout/))) ! write tmax   
-   endif
-   !
-   ! When zsmax => t
-   !
-   if (store_t_zsmax) then
-      zstmp = FILL_VALUE
-      do nm = 1, np
-         n              = z_index_z_n(nm)
-         m              = z_index_z_m(nm)
-         if (t_zsmax(nm) > 0) then
-            zstmp(m, n)     = t_zsmax(nm) 
-         endif
-      enddo
-      NF90(nf90_put_var(map_file%ncid, map_file%t_zsmax_varid, zstmp, (/1, 1, ntmaxout/))) ! write t_zsmax
-   endif
-   !
-   ! Maximum wind speed
-   if (wind .and. store_wind_max .and. meteo3d) then 
-      zstmp = FILL_VALUE
-      do nm = 1, np
-         n              = z_index_z_n(nm)
-         m              = z_index_z_m(nm)
-         zstmp(m, n)    = windmax(nm) 
-      enddo
-      NF90(nf90_put_var(map_file%ncid, map_file%windmax_varid, zstmp, (/1, 1, ntmaxout/))) ! write windmax   
-   endif
-   !   
-   end subroutine
-
-
-   
-   subroutine ncoutput_update_quadtree_max(t,ntmaxout)
-   !
-   ! write zsmax per dtmaxout
-   !
-   use sfincs_data
-   !use sfincs_snapwave
    use quadtree
    use sfincs_urban_drainage, only: urban_drainage_cumulative_volume
    !
    implicit none
    !
-   integer                              :: nmq, nm, ntmaxout
-   real*8                               :: t  
+   real*8                            :: t
+   integer                           :: ntmaxout, nm
+   real*4, dimension(:), allocatable :: hmax_out, hmean
    !
-   real*4, dimension(:), allocatable    :: zstmp ! Same size as quadtree
-   real*4, dimension(:), allocatable    :: hmean ! Same size as zs
+   ! Scalar time of this max-record (defined only when store_maximum_waterlevel)
+   if (store_maximum_waterlevel) then
+      NF90(nf90_put_var(map_file%ncid, map_file%timemax_varid, t, (/ntmaxout/)))
+   endif
    !
-   allocate(zstmp(quadtree_nr_points))
+   ! Maximum water level
+   if (store_maximum_waterlevel) then
+      if (subgrid) then
+         call write_cell_var_wet(map_file%ncid, map_file%zsmax_varid, zsmax, subgrid_z_zmin, ntmaxout)
+      else
+         call write_cell_var_wet(map_file%ncid, map_file%zsmax_varid, zsmax, zb,             ntmaxout)
+      endif
+   endif
    !
-   zstmp = FILL_VALUE
-   !
-   ! Write maximum water level
-   !
-   do nmq = 1, quadtree_nr_points
-       !
-       nm = index_sfincs_in_quadtree(nmq)
-       !
-       if (nm>0) then       
-           if (kcs(nm)>0) then
-               if (subgrid) then
-                   if ( (zsmax(nm) - subgrid_z_zmin(nm)) > huthresh) then
-                       zstmp(nmq) = zsmax(nm)
-                   endif
-               else
-                  if ( (zsmax(nm) - zb(nm)) > huthresh) then
-                      zstmp(nmq) = zsmax(nm)
-                  endif
-               endif
-           endif
-       endif       
-   enddo
-   !
-   NF90(nf90_put_var(map_file%ncid, map_file%timemax_varid, t, (/ntmaxout/)))       ! write time_max
-   NF90(nf90_put_var(map_file%ncid, map_file%zsmax_varid, zstmp, (/1, ntmaxout/)))  ! write zsmax   
-   !
-   ! Write maximum water depth
-   !
-   if (subgrid .eqv. .false. .or. store_hsubgrid .eqv. .true.) then
-      ! 
-      zstmp = FILL_VALUE
-      !        
-      if (store_hmean .and. subgrid .eqv. .true.) then
-         !
-         ! Obtain mean depth from subgrid tables
-         !
+   ! Maximum water depth (optional, supports subgrid mean-depth)
+   if (store_maximum_waterlevel .and. (.not. subgrid .or. store_hsubgrid)) then
+      if (subgrid .and. store_hmean) then
+         ! 
+         ! Subgrid mean depth needs a per-cell precompute; mask to wet cells and write.
+         allocate(hmax_out(np))
          allocate(hmean(np))
+         hmax_out = FILL_VALUE
          !
          call compute_subgrid_mean_depth(zsmax, hmean)
          !
-      endif   
-      !   
-      do nmq = 1, quadtree_nr_points
-         !
-         nm = index_sfincs_in_quadtree(nmq)
-         !
-         if (nm > 0) then ! Check if point is in SFINCS domain
-            if (kcs(nm) > 0) then ! Check if point is active
-               !
-               if (subgrid) then
-                  !
-                  if ( (zsmax(nm) - subgrid_z_zmin(nm)) > huthresh) then
-                     !
-                     if (store_hmean) then
-                        !
-                        ! Store mean depth in subgrid cell
-                        !
-                        zstmp(nmq) = hmean(nm)
-                        !
-                     else
-                        !
-                        ! Store maximum depth in subgrid cell
-                        !
-                        zstmp(nmq) = zsmax(nm) - subgrid_z_zmin(nm)
-                        !
-                     endif   
-                     !
-                  endif
-                  !
-               else
-                  !
-                  ! Regular depth
-                  !
-                  if ( (zsmax(nm) - zb(nm)) > huthresh) then
-                     zstmp(nmq) = zsmax(nm) - zb(nm)
-                  endif
-                  !
-               endif
-               !
+         do nm = 1, np
+            if ( (zsmax(nm) - subgrid_z_zmin(nm)) > huthresh) then
+               hmax_out(nm) = hmean(nm)
             endif
-         endif
-      enddo      
-      !
-      NF90(nf90_put_var(map_file%ncid, map_file%hmax_varid, zstmp, (/1, ntmaxout/))) ! write hmax   
-      !
+         enddo
+         !
+         call write_cell_var(map_file%ncid, map_file%hmax_varid, hmax_out, ntmaxout, check_kcs=.true.)
+         !
+         deallocate(hmax_out)
+         deallocate(hmean)
+         !
+      elseif (subgrid) then
+         call write_cell_var_depth(map_file%ncid, map_file%hmax_varid, zsmax, subgrid_z_zmin, ntmaxout)
+      else
+         call write_cell_var_depth(map_file%ncid, map_file%hmax_varid, zsmax, zb,             ntmaxout)
+      endif
    endif
    !
-   ! Write cumulative rainfall
-   if (store_cumulative_precipitation) then  
-       !
-       ! Precipitation
-       !
-       zstmp = FILL_VALUE       
-       do nmq = 1, quadtree_nr_points
-           nm = index_sfincs_in_quadtree(nmq)
-           if (nm>0) then           
-               if (kcs(nm)>0) then
-                   zstmp(nmq) = cumprcp(nm)
-               endif
-           endif           
-       enddo
-       NF90(nf90_put_var(map_file%ncid, map_file%cumprcp_varid, zstmp, (/1, ntmaxout/))) ! write cumprcp
-       ! 
-       ! Infiltration
-       !
-       zstmp = FILL_VALUE       
-       do nmq = 1, quadtree_nr_points
-           nm = index_sfincs_in_quadtree(nmq)
-           if (nm>0) then
-               if (kcs(nm)>0) then
-                   zstmp(nmq) = cuminf(nm)
-               endif
-           endif           
-       enddo
-       NF90(nf90_put_var(map_file%ncid, map_file%cuminf_varid, zstmp, (/1, ntmaxout/))) ! write cuminf
-       !
+   ! Cumulative rainfall (always when store_cumulative_precipitation) and
+   ! cumulative infiltration (only when infiltration is on — same gate as the def)
+   if (store_cumulative_precipitation) then
+      call write_cell_var(map_file%ncid, map_file%cumprcp_varid, cumprcp, ntmaxout, check_kcs=.true.)
+      if (infiltration) then
+         call write_cell_var(map_file%ncid, map_file%cuminf_varid, cuminf, ntmaxout, check_kcs=.true.)
+      endif
    endif
    !
-   ! Cumulative urban drainage depth (volume / cell_area)
-   !
-   if (store_cumulative_urban_drainage .and. urban_drainage) then
-       !
-       zstmp = FILL_VALUE
-       !
-       do nmq = 1, quadtree_nr_points
-           nm = index_sfincs_in_quadtree(nmq)
-           if (nm > 0) then
-               if (kcs(nm) > 0) then
-                   if (crsgeo) then
-                       zstmp(nmq) = urban_drainage_cumulative_volume(nm) / cell_area_m2(nm)
-                   else
-                       zstmp(nmq) = urban_drainage_cumulative_volume(nm) / cell_area(z_flags_iref(nm))
-                   endif
-               endif
-           endif
-       enddo
-       !
-       NF90(nf90_put_var(map_file%ncid, map_file%cumulative_urbdrain_varid, zstmp, (/1, ntmaxout/))) ! write cumulative urban drainage depth
-       !
-   endif
-   !
-   ! Maximum flow velocity
+   ! Maximum flow velocity / flux
    if (store_maximum_velocity) then
-       zstmp = FILL_VALUE       
-       do nmq = 1, quadtree_nr_points
-           nm = index_sfincs_in_quadtree(nmq)
-           if (nm>0) then           
-               if (kcs(nm)>0) then
-                   zstmp(nmq) = vmax(nm)
-               endif
-           endif           
-       enddo
-      NF90(nf90_put_var(map_file%ncid, map_file%vmax_varid, zstmp, (/1, ntmaxout/))) ! write vmax   
+      call write_cell_var(map_file%ncid, map_file%vmax_varid, vmax, ntmaxout, check_kcs=.true.)
    endif
-   !   
-   ! Maximum flow flux
    if (store_maximum_flux) then
-       zstmp = FILL_VALUE       
-       do nmq = 1, quadtree_nr_points
-           nm = index_sfincs_in_quadtree(nmq)
-           if (nm>0) then                      
-               if (kcs(nm)>0) then
-                   zstmp(nmq) = qmax(nm)
-               endif
-           endif           
-       enddo
-      NF90(nf90_put_var(map_file%ncid, map_file%qmax_varid, zstmp, (/1, ntmaxout/))) ! write qmax   
-   endif   
+      call write_cell_var(map_file%ncid, map_file%qmax_varid, qmax, ntmaxout, check_kcs=.true.)
+   endif
    !
    ! Duration wet cell
    if (store_twet) then
-       zstmp = FILL_VALUE       
-       do nmq = 1, quadtree_nr_points
-           nm = index_sfincs_in_quadtree(nmq)
-           if (nm>0) then                                 
-               if (kcs(nm)>0) then
-                   zstmp(nmq) = twet(nm)
-               endif
-           endif
-       enddo
-      NF90(nf90_put_var(map_file%ncid, map_file%tmax_varid, zstmp, (/1, ntmaxout/))) ! write twet   
+      call write_cell_var(map_file%ncid, map_file%tmax_varid, twet, ntmaxout, check_kcs=.true.)
    endif
    !
-   ! When zsmax occured
+   ! When zsmax occurred (only cells where it actually happened, i.e. t_zsmax > 0)
    if (store_t_zsmax) then
-       zstmp = FILL_VALUE       
-       do nmq = 1, quadtree_nr_points
-           nm = index_sfincs_in_quadtree(nmq)
-           if (nm>0) then                                 
-               if (kcs(nm)>0) then
-                   zstmp(nmq) = t_zsmax(nm)
-               endif
-           endif
-       enddo
-      NF90(nf90_put_var(map_file%ncid, map_file%t_zsmax_varid, zstmp, (/1, ntmaxout/))) ! write t_zsmax
+      call write_cell_var(map_file%ncid, map_file%t_zsmax_varid, t_zsmax, ntmaxout, &
+           check_kcs=.true., min_value=0.0)
    endif
    !
-   ! Maximum wind speed
-   if (wind .and. store_wind_max .and. meteo3d) then 
-       zstmp = FILL_VALUE       
-       do nmq = 1, quadtree_nr_points
-           nm = index_sfincs_in_quadtree(nmq)
-           if (nm>0) then                                 
-               if (kcs(nm)>0) then
-                   zstmp(nmq) = windmax(nm)
-               endif
-           endif
-       enddo
-      NF90(nf90_put_var(map_file%ncid, map_file%windmax_varid, zstmp, (/1, ntmaxout/))) ! write windmax   
+   ! Maximum wind speed (def is gated on store_meteo .and. wind .and.
+   ! store_wind_max .and. meteo3d in ncoutput_map_init; mirror that here)
+   if (store_meteo .and. wind .and. store_wind_max .and. meteo3d) then
+      call write_cell_var(map_file%ncid, map_file%windmax_varid, windmax, ntmaxout, check_kcs=.true.)
    endif
    !
-   end subroutine   
-   !
-   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!   
-   !
-   subroutine ncoutput_map_finalize()
+   end subroutine ncoutput_update_max
+
+   subroutine ncoutput_map_finalize() 
    !
    ! Add total runtime, dtavg to file and close
    !
@@ -4221,129 +1660,6 @@ contains
    !
    end subroutine ncoutput_map_finalize
    !
-   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-   !
-   subroutine ncoutput_write_timestep_analysis()
-   !
-   ! Write timestep_analysis_average_required_timestep and timestep_analysis_percentage_limiting_per_cell once at end of simulation (no time dimension)
-   !
-   use sfincs_data
-   use quadtree
-   !
-   implicit none
-   !
-   real*4, dimension(:),   allocatable :: vtmp1, vtmp2, vtmp3
-   real*4, dimension(:,:), allocatable :: zsg1, zsg2
-   integer :: nm, nmq, n, m
-   !
-   if (use_quadtree) then
-      !
-      allocate(vtmp1(quadtree_nr_points))
-      allocate(vtmp2(quadtree_nr_points))
-      !
-      vtmp1 = FILL_VALUE
-      vtmp2 = FILL_VALUE
-      !
-      do nm = 1, np
-         !
-         nmq = index_quadtree_in_sfincs(nm)
-         !
-         if (timestep_analysis_average_required_timestep_per_cell(nm) > 0.0) then
-            !
-            vtmp1(nmq) = timestep_analysis_average_required_timestep_per_cell(nm)
-            !
-         endif
-         !
-         vtmp2(nmq) = timestep_analysis_percentage_limiting_per_cell(nm)
-         ! 
-      enddo
-      !
-      NF90(nf90_put_var(map_file%ncid, map_file%average_required_timestep_varid, vtmp1))
-      NF90(nf90_put_var(map_file%ncid, map_file%percentage_limiting_varid, vtmp2))
-      !
-      deallocate(vtmp1)
-      deallocate(vtmp2)
-      !
-   else
-      !
-      allocate(zsg1(mmax, nmax))
-      allocate(zsg2(mmax, nmax))
-      !
-      zsg1 = FILL_VALUE
-      zsg2 = FILL_VALUE
-      !
-      do nm = 1, np
-         !
-         n = z_index_z_n(nm)
-         m = z_index_z_m(nm)
-         !
-         if (timestep_analysis_average_required_timestep_per_cell(nm) > 0.0) then
-            !
-            zsg1(m, n) = timestep_analysis_average_required_timestep_per_cell(nm)
-            !
-         endif
-         !
-         zsg2(m, n) = timestep_analysis_percentage_limiting_per_cell(nm)
-         ! 
-      enddo
-      !
-      NF90(nf90_put_var(map_file%ncid, map_file%average_required_timestep_varid, zsg1))
-      NF90(nf90_put_var(map_file%ncid, map_file%percentage_limiting_varid, zsg2))
-      !
-      deallocate(zsg1)
-      deallocate(zsg2)
-      !
-   endif   
-   !
-   end subroutine ncoutput_write_timestep_analysis
-   !
-   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-   !
-   subroutine ncoutput_write_tsunami_arrival_time() 
-   ! Add tsunami_arrival_time
-   use sfincs_data
-   !   
-   implicit none  
-   !
-   real*4, dimension(:,:), allocatable :: zsg
-   real*4,    dimension(:),   allocatable :: vtmp   
-   integer    :: nm, nmq, n, m, n_faces, quadtree_nr_points   
-   !
-   if (use_quadtree) then
-       !
-       allocate(vtmp(n_faces))          
-       vtmp = FILL_VALUE   
-       !
-       do nmq = 1, quadtree_nr_points
-           nm = index_sfincs_in_quadtree(nmq)
-           if (nm>0) then
-           vtmp(nmq) = tsunami_arrival_time(nm)
-           endif
-       enddo
-       !
-       ! write tsunami_arrival_time_varid              
-       NF90(nf90_put_var(map_file%ncid, map_file%tsunami_arrival_time_varid, zsg))         
-       !
-   else
-       ! regular grid
-       allocate(zsg(mmax, nmax))   
-       zsg = FILL_VALUE
-       !   
-       do nm = 1, np
-           !
-           n    = z_index_z_n(nm)
-           m    = z_index_z_m(nm)
-           !       
-           zsg(m, n) = tsunami_arrival_time(nm)
-           !
-       enddo
-       !
-       ! write tsunami_arrival_time_varid       
-       NF90(nf90_put_var(map_file%ncid, map_file%tsunami_arrival_time_varid, zsg, (/1, 1/)))     
-       !
-   endif     
-   !
-   end subroutine   
    !
    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
    !
@@ -4351,9 +1667,16 @@ contains
    ! Add total runtime, dtavg to file and close
    !
    use sfincs_data
-   use sfincs_src_structures, only: nr_src_structures
-   use sfincs_discharges,     only: nr_discharge_points
-   use sfincs_urban_drainage, only: nr_urban_drainage_zones
+   !   
+   implicit none   
+   !   
+   ! Mirror the early-return condition from ncoutput_his_init exactly: if
+   ! none of these are present, no his file was created. (Note: thindams
+   ! alone do NOT trigger his-file creation in init, so they're not in
+   ! this list either.)
+   if (nobs==0 .and. nrcrosssections==0 .and. nrstructures==0 .and. ndrn==0 .and. nr_runup_gauges==0) then
+      return
+   endif
    !
    implicit none
    !
@@ -4380,8 +1703,8 @@ contains
    ! Because of overlapping names, only important specific values from snapwave_data
    use snapwave_data, only: gamma, gammax, alpha, hmin, fw0, fw0_ig, dt, tol, dtheta, crit, nr_sweeps, baldock_exponent, baldock_ratio, &
        igwaves_opt, alpha_ig, gamma_ig, gamma_fac_br, shinc2ig, alphaigfac, baldock_ratio_ig, ig_opt, herbers_opt, tpig_opt, eeinc2ig, tinc2ig, &
-       snapwave_jonswapfile, snapwave_encfile, snapwave_bndfile, snapwave_bhsfile, snapwave_btpfile, snapwave_bwdfile, snapwave_bdsfile, upwfile, gridfile
-   
+       snapwave_jonswapfile, snapwave_encfile, snapwave_bndfile, snapwave_bhsfile, snapwave_btpfile, snapwave_bwdfile, snapwave_bdsfile, upwfile, gridfile, &
+       jonswapgam, Tpini, sector, fwratio, fwigratio   
    !
    implicit none   
    !
@@ -4421,7 +1744,8 @@ contains
         NF90(nf90_put_att(ncid, varid, 'dtmax',dtmax))        
         NF90(nf90_put_att(ncid, varid, 'dtmin',dtmin))  
         NF90(nf90_put_att(ncid, varid, 'hmin_cfl',hmin_cfl))        
-        NF90(nf90_put_att(ncid, varid, 'huthresh',huthresh))        
+        NF90(nf90_put_att(ncid, varid, 'huthresh',huthresh))
+        NF90(nf90_put_att(ncid, varid, 'huvmin',huvmin))
         NF90(nf90_put_att(ncid, varid, 'rhoa',rhoa))        
         NF90(nf90_put_att(ncid, varid, 'rhow',rhow))        
         NF90(nf90_put_att(ncid, varid, 'inputformat',inputtype))        
@@ -4430,16 +1754,13 @@ contains
         NF90(nf90_put_att(ncid, varid, 'outputtype_his',outputtype_his))
         NF90(nf90_put_att(ncid, varid, 'bndtype',bndtype))
         NF90(nf90_put_att(ncid, varid, 'advection',logical2int(advection)))  
-        NF90(nf90_put_att(ncid, varid, 'wavemaker_nfreqs_ig', wavemaker_nfreqs_ig))  
-        NF90(nf90_put_att(ncid, varid, 'wavemaker_freqmin_ig',wavemaker_freqmin_ig))  
-        NF90(nf90_put_att(ncid, varid, 'wavemaker_freqmax_ig',wavemaker_freqmax_ig))  
         NF90(nf90_put_att(ncid, varid, 'latitude',latitude))  
         NF90(nf90_put_att(ncid, varid, 'pavbnd',pavbnd))  
         NF90(nf90_put_att(ncid, varid, 'gapres',gapres))  
         NF90(nf90_put_att(ncid, varid, 'baro',baro))  
         NF90(nf90_put_att(ncid, varid, 'utmzone',utmzone))  
         NF90(nf90_put_att(ncid, varid, 'epsg',epsg))  
-        NF90(nf90_put_att(ncid, varid, 'epsg_code',epsg_code))
+        NF90(nf90_put_att(ncid, varid, 'epsg_code',epsg_code))  
         NF90(nf90_put_att(ncid, varid, 'advlim',advlim))  
         NF90(nf90_put_att(ncid, varid, 'uvlim',uvlim))  
         NF90(nf90_put_att(ncid, varid, 'uvmax',uvmax))  
@@ -4476,7 +1797,24 @@ contains
         NF90(nf90_put_att(ncid, varid, 'wavemaker_hm0_inc_factor',wavemaker_hm0_inc_factor))         
         NF90(nf90_put_att(ncid, varid, 'wavemaker_gammax',wavemaker_gammax))         
         NF90(nf90_put_att(ncid, varid, 'wavemaker_tpmin',wavemaker_tpmin))
-        NF90(nf90_put_att(ncid, varid, 'horton_kr_kd',horton_kr_kd))         
+        NF90(nf90_put_att(ncid, varid, 'horton_kr_kd',horton_kr_kd))
+        NF90(nf90_put_att(ncid, varid, 'nuviscdim',nuviscdim))
+        NF90(nf90_put_att(ncid, varid, 'nuviscfac',nuviscfac))
+        NF90(nf90_put_att(ncid, varid, 'btrelax',btrelax))
+        NF90(nf90_put_att(ncid, varid, 'structure_relax',structure_relax))
+        NF90(nf90_put_att(ncid, varid, 'wave_enhanced_roughness',logical2int(wave_enhanced_roughness)))
+        NF90(nf90_put_att(ncid, varid, 'bathtub',logical2int(bathtub)))
+        NF90(nf90_put_att(ncid, varid, 'bathtub_fac_hs',bathtub_fac_hs))
+        NF90(nf90_put_att(ncid, varid, 'bathtub_dt',bathtub_dt))
+        NF90(nf90_put_att(ncid, varid, 'factor_wind',factor_wind))
+        NF90(nf90_put_att(ncid, varid, 'factor_pres',factor_pres))
+        NF90(nf90_put_att(ncid, varid, 'factor_prcp',factor_prcp))
+        NF90(nf90_put_att(ncid, varid, 'factor_spw_size',factor_spw_size))
+        NF90(nf90_put_att(ncid, varid, 'nonh',logical2int(nonhydrostatic)))
+        NF90(nf90_put_att(ncid, varid, 'nh_fnudge',nh_fnudge))
+        NF90(nf90_put_att(ncid, varid, 'nh_tstop',nh_tstop))
+        NF90(nf90_put_att(ncid, varid, 'nh_tol',nh_tol))
+        NF90(nf90_put_att(ncid, varid, 'nh_itermax',nh_itermax))
         !
         ! Domain
         !
@@ -4490,7 +1828,11 @@ contains
         NF90(nf90_put_att(ncid, varid, 'thdfile',thdfile))        
         NF90(nf90_put_att(ncid, varid, 'weirfile',weirfile))        
         NF90(nf90_put_att(ncid, varid, 'manningfile',manningfile))    
-        NF90(nf90_put_att(ncid, varid, 'drnfile',drnfile))    
+        NF90(nf90_put_att(ncid, varid, 'drnfile',drnfile))
+        NF90(nf90_put_att(ncid, varid, 'rugfile',rugfile))
+        NF90(nf90_put_att(ncid, varid, 'cstfile',cstfile))
+        NF90(nf90_put_att(ncid, varid, 'volfile',volfile))
+        NF90(nf90_put_att(ncid, varid, 'bcafile',bcafile))
         !
         ! Forcing
         !
@@ -4519,12 +1861,17 @@ contains
         NF90(nf90_put_att(ncid, varid, 'sefffile',sefffile)) 
         NF90(nf90_put_att(ncid, varid, 'ksfile',ksfile)) 
         NF90(nf90_put_att(ncid, varid, 'psifile',psifile)) 
-        NF90(nf90_put_att(ncid, varid, 'sigmafile',sigmafile)) 
+        NF90(nf90_put_att(ncid, varid, 'sigmafile',sigmafile))
         NF90(nf90_put_att(ncid, varid, 'f0file',f0file))
         NF90(nf90_put_att(ncid, varid, 'fcfile',fcfile))
         NF90(nf90_put_att(ncid, varid, 'kdfile',kdfile))
-        NF90(nf90_put_att(ncid, varid, 'z0lfile',z0lfile)) 
-        NF90(nf90_put_att(ncid, varid, 'wavemaker_wvmfile',wavemaker_wvmfile)) 
+        NF90(nf90_put_att(ncid, varid, 'z0lfile',z0lfile))
+        NF90(nf90_put_att(ncid, varid, 'wavemaker_wvmfile',wavemaker_wvmfile))
+        !
+        ! Infiltration configuration
+        !
+        NF90(nf90_put_att(ncid, varid, 'infiltration_file',infiltrationfile))
+        NF90(nf90_put_att(ncid, varid, 'infiltration_type',inftype))
         !
         ! Netcdf input
         NF90(nf90_put_att(ncid, varid, 'netbndbzsbzifile',netbndbzsbzifile))
@@ -4556,7 +1903,16 @@ contains
         NF90(nf90_put_att(ncid, varid, 'storemeteo',logical2int(store_meteo)))
         NF90(nf90_put_att(ncid, varid, 'storemaxwind',logical2int(store_wind_max))) 
         NF90(nf90_put_att(ncid, varid, 'storefw',logical2int(store_wave_forces)))         
-        NF90(nf90_put_att(ncid, varid, 'storewavdir', logical2int(store_wave_direction))) 
+        NF90(nf90_put_att(ncid, varid, 'storewavdir', logical2int(store_wave_direction)))
+        NF90(nf90_put_att(ncid, varid, 'storetzsmax',storetzsmax))
+        NF90(nf90_put_att(ncid, varid, 'storestoragevolume',storestoragevolume))
+        NF90(nf90_put_att(ncid, varid, 'storehmean',logical2int(store_hmean)))
+        NF90(nf90_put_att(ncid, varid, 'timestep_analysis',logical2int(timestep_analysis)))
+        NF90(nf90_put_att(ncid, varid, 'store_dynamic_bed_level',logical2int(store_dynamic_bed_level)))
+        NF90(nf90_put_att(ncid, varid, 'regular_output_on_mesh',logical2int(use_quadtree_output)))
+        NF90(nf90_put_att(ncid, varid, 'rugdepth',runup_gauge_depth))
+        NF90(nf90_put_att(ncid, varid, 'percentage_done',percdoneval))
+        NF90(nf90_put_att(ncid, varid, 'nc_deflate_level',nc_deflate_level))
         !
         NF90(nf90_put_att(ncid, varid, 'cdnrb', cd_nr))   
         NF90(nf90_put_att(ncid, varid, 'cdwnd', cd_wnd))        
@@ -4585,13 +1941,18 @@ contains
         NF90(nf90_put_att(ncid, varid, 'snapwave_dtheta',dtheta)) 
         NF90(nf90_put_att(ncid, varid, 'snapwave_crit',crit)) 
         NF90(nf90_put_att(ncid, varid, 'snapwave_nrsweeps',nr_sweeps)) 
-        NF90(nf90_put_att(ncid, varid, 'snapwave_baldock_exponent',baldock_exponent)) 
-        NF90(nf90_put_att(ncid, varid, 'snapwave_baldock_ratio',baldock_ratio)) 
+        NF90(nf90_put_att(ncid, varid, 'snapwave_baldock_exponent',baldock_exponent))
+        NF90(nf90_put_att(ncid, varid, 'snapwave_baldock_ratio',baldock_ratio))
         NF90(nf90_put_att(ncid, varid, 'snapwave_waveforces_ratio',waveforces_ratio))
+        NF90(nf90_put_att(ncid, varid, 'snapwave_sector',sector))
+        NF90(nf90_put_att(ncid, varid, 'snapwave_Tpini',Tpini))
+        NF90(nf90_put_att(ncid, varid, 'snapwave_fw_ratio',fwratio))
+        NF90(nf90_put_att(ncid, varid, 'snapwave_fwig_ratio',fwigratio))
         !
         ! SnapWave IG
         !
-        NF90(nf90_put_att(ncid, varid, 'snapwave_igwaves',igwaves_opt))         
+        NF90(nf90_put_att(ncid, varid, 'snapwave_jonswapgamma',jonswapgam))
+        NF90(nf90_put_att(ncid, varid, 'snapwave_igwaves',igwaves_opt))
         NF90(nf90_put_att(ncid, varid, 'snapwave_alpha_ig',alpha_ig)) 
         NF90(nf90_put_att(ncid, varid, 'snapwave_gammaig',gamma_ig))
         NF90(nf90_put_att(ncid, varid, 'snapwave_gamma_fac_br',gamma_fac_br))
@@ -4606,9 +1967,10 @@ contains
         !
         ! SnapWave input files
         !
-        NF90(nf90_put_att(ncid, varid, 'snapwave_jonswapfile',snapwave_jonswapfile)) 
-        NF90(nf90_put_att(ncid, varid, 'snapwave_encfile',snapwave_encfile)) 
-        NF90(nf90_put_att(ncid, varid, 'snapwave_upwfile',upwfile)) 
+        NF90(nf90_put_att(ncid, varid, 'snapwave_ncfile',gridfile))
+        NF90(nf90_put_att(ncid, varid, 'snapwave_jonswapfile',snapwave_jonswapfile))
+        NF90(nf90_put_att(ncid, varid, 'snapwave_encfile',snapwave_encfile))
+        NF90(nf90_put_att(ncid, varid, 'snapwave_upwfile',upwfile))
         NF90(nf90_put_att(ncid, varid, 'snapwave_bndfile',snapwave_bndfile))            
         NF90(nf90_put_att(ncid, varid, 'snapwave_bhsfile',snapwave_bhsfile)) 
         NF90(nf90_put_att(ncid, varid, 'snapwave_btpfile',snapwave_btpfile)) 
@@ -4616,109 +1978,5 @@ contains
         NF90(nf90_put_att(ncid, varid, 'snapwave_bdsfile',snapwave_bdsfile))         
         !
    end subroutine
-   !
-   !
-   !
-   subroutine compute_subgrid_mean_depth(z, hmean)
-   !
-   ! This subroutine cannot sit in sfincs_subgrid.f90 because that uses the same netcdf module
-   !
-   use sfincs_data
-   !
-   implicit none
-   !
-   real*4, intent(in)  :: z(np) ! max water level
-   real*4, intent(out) :: hmean(np) 
-   !
-   integer    :: nm, m, n, ivol, ilevel, ip
-   real*8     :: volume
-   real*4     :: dzvol
-   real*4     :: facint
-   real*4     :: one_minus_facint 
-   !
-   ! Compute volumes and mean depths
-   !
-   do nm = 1, np
-      !
-      if (z(nm) >= subgrid_z_zmax(nm)) then
-         !
-         ! Entire cell is wet, no interpolation from table needed
-         !
-         if (crsgeo) then
-            volume = subgrid_z_volmax(nm) + cell_area_m2(nm) * (z(nm) - max(subgrid_z_zmax(nm), -20.0))
-         else   
-            volume = subgrid_z_volmax(nm) + cell_area(z_flags_iref(nm)) * (z(nm) - max(subgrid_z_zmax(nm), -20.0))
-         endif
-         !
-      else   
-         !
-         ! Interpolation required
-         !
-         ivol = 1
-         do ilevel = 2, subgrid_nlevels
-            if (subgrid_z_dep(ilevel, nm) > z(nm)) then
-               ivol = ilevel - 1
-               exit
-            endif
-         enddo
-         !
-         dzvol  = subgrid_z_volmax(nm) / (subgrid_nlevels - 1)
-         facint = (z(nm) - subgrid_z_dep(ivol, nm)) / max(subgrid_z_dep(ivol + 1, nm) - subgrid_z_dep(ivol, nm), 0.001)
-         volume = (ivol - 1) * dzvol + facint * dzvol
-         !
-      endif
-      !
-      ! Compute mean depth in cell
-      !
-      if (crsgeo) then
-         !
-         hmean(nm) = volume / cell_area_m2(nm)
-         !
-      else   
-         !
-         hmean(nm) = volume / cell_area(z_flags_iref(nm))
-         !
-      endif
-      !
-   enddo
-   !
-   end subroutine
-   !   
-   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-   !   
-   subroutine handle_err(status,file,line)
-      !
-      integer, intent ( in)    :: status
-      character(*), intent(in) :: file
-      integer, intent ( in)    :: line
-      integer :: status2
-
-      if(status /= nf90_noerr) then
-         !UNIT=6 for stdout and UNIT=0 for stderr.
-         write(0,'("NETCDF ERROR: ",a,i6,":",a)') file,line,trim(nf90_strerror(status))
-         write(0,*) 'closing file'
-         status2 = nf90_close(map_file%ncid)
-         if (status2 /= nf90_noerr) then
-            write(0,*) 'NETCDF ERROR: ', __FILE__,__LINE__,trim(nf90_strerror(status2))
-         end if
-      end if
-   end subroutine handle_err
-   !
-   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-   !   
-   function logical2int(lgc) result (i)
-   !
-   implicit none
-   !
-   logical              :: lgc
-   integer              :: i
-   !
-   if (lgc) then
-      i = 1
-   else
-      i = 0
-   endif
-   !
-   end function   
    !
    end module

--- a/source/src/sfincs_ncoutput.F90
+++ b/source/src/sfincs_ncoutput.F90
@@ -411,6 +411,9 @@ contains
               standard_name='psi')
       elseif (inftype == 'hor') then
          call def_static_cell_float('qinf', map_file%qinf_varid, 'm', 'initial infiltration rate - Horton', standard_name='f0')
+      elseif (inftype == 'bkt') then
+         call def_static_cell_float('qinf', map_file%qinf_varid, 'mm', 'maximum bucket storage capacity', &
+              standard_name='bucket_capacity')
       else
          call def_static_cell_float('qinf', map_file%qinf_varid, 'mm h-1', 'infiltration rate - constant in time', &
               standard_name='qinf')
@@ -554,6 +557,11 @@ contains
    !
    if (store_cumulative_precipitation .and. infiltration) then
       call def_maxtime_cell_float('cuminf', map_file%cuminf_varid, 'm', 'cumulative_infiltration_depth', cell_methods='time: sum')
+   endif
+   !
+   if (store_cumulative_urban_drainage .and. urban_drainage) then
+      call def_maxtime_cell_float('urban_drainage_cumulative_depth', map_file%cumulative_urbdrain_varid, 'm', &
+           'cumulative_urban_drainage_depth', cell_methods='time: sum')
    endif
    !
    ! -------------------------------------------------------
@@ -756,8 +764,15 @@ contains
    if (infiltration) then
       if (inftype == 'con' .or. inftype == 'c2d') then
          call put_static_cell_float(map_file%ncid, map_file%qinf_varid, qinffield, FILL_VALUE, scale=3.6e6)
+      elseif (inftype == 'bkt') then
+         ! Bucket model: write the maximum storage capacity (m -> mm)
+         if (allocated(bucket_capacity)) then
+            call put_static_cell_float(map_file%ncid, map_file%qinf_varid, bucket_capacity, FILL_VALUE, scale=1000.0)
+         endif
       else
-         call put_static_cell_float(map_file%ncid, map_file%qinf_varid, qinffield, FILL_VALUE)
+         if (allocated(qinffield)) then
+            call put_static_cell_float(map_file%ncid, map_file%qinf_varid, qinffield, FILL_VALUE)
+         endif
       endif
    endif
    !
@@ -1062,9 +1077,29 @@ contains
            'm3 s-1', 'discharge', coordinates='crosssection_name')
    endif
    !
-   if (ndrn>0) then
+   if (nr_src_structures>0) then
+      !
       call ncdef_float_var(his_file%ncid, 'drainage_discharge', (/his_file%drain_dimid, his_file%time_dimid/), his_file%drain_varid, &
-           'm3 s-1', 'discharge through drainage structure')
+           'm3 s-1', 'discharge through drainage structure', coordinates='drainage_name')
+      !
+      if (any(src_struc_type == structure_dike_breach)) then
+         call ncdef_float_var(his_file%ncid, 'breach_width', (/his_file%drain_dimid, his_file%time_dimid/), his_file%breach_width_varid, &
+              'm', 'dike breach width', coordinates='drainage_name')
+      endif
+      !
+      call ncdef_float_var(his_file%ncid, 'drainage_fraction_open', (/his_file%drain_dimid, his_file%time_dimid/), his_file%drain_fraction_open_varid, &
+           '1', 'gate open fraction (1 = fully open, 0 = fully closed)', coordinates='drainage_name')
+      !
+   endif
+   !
+   if (nr_discharge_points>0 .and. store_river_discharge) then
+      call ncdef_float_var(his_file%ncid, 'river_discharge', (/his_file%river_dimid, his_file%time_dimid/), his_file%river_varid, &
+           'm3 s-1', 'river point discharge', coordinates='river_name')
+   endif
+   !
+   if (nr_urban_drainage_zones > 0 .and. store_urban_drainage_discharge) then
+      call ncdef_float_var(his_file%ncid, 'urban_drainage_discharge', (/his_file%urbdrain_dimid, his_file%time_dimid/), his_file%urbdrain_varid, &
+           'm3 s-1', 'urban drainage zone net outfall discharge', coordinates='urban_drainage_zone_name')
    endif
    !
    if (nr_runup_gauges > 0) then
@@ -1368,17 +1403,15 @@ contains
    !
    implicit none
    !
-   integer :: iobs, nm, idrn
+   integer :: iobs, nm
    integer :: nthisout
    real*8  :: t
    real*4, dimension(nobs) :: uobs, vobs, uvmag, uvdir
    real*4, dimension(nobs) :: twndmag, twnddir
-   real*4, dimension(ndrn) :: q_drain
    real*4, dimension(:), allocatable :: qq, zz
    !
    zobs    = FILL_VALUE
    hobs    = FILL_VALUE
-   q_drain = FILL_VALUE
    !
    do iobs = 1, nobs
       nm = nmindobs(iobs)
@@ -1509,15 +1542,14 @@ contains
    if (nr_discharge_points>0 .and. store_river_discharge) then
       !
       !$acc update host(qtsrc)
-      ! Get fluxes through drainage structure
       !
-      idrn = 0
-      do iobs = nsrc + 1, nsrcdrn, 2 !TL: as in sfincs_output.f90
-         idrn = idrn + 1
-         q_drain(idrn) = qtsrc(iobs)
-      enddo
+      NF90(nf90_put_var(his_file%ncid, his_file%river_varid, qtsrc, (/1, nthisout/))) ! write per-river-source discharge
       !
-      NF90(nf90_put_var(his_file%ncid, his_file%drain_varid, q_drain, (/1, nthisout/)))
+   endif
+   !
+   if (nr_urban_drainage_zones > 0 .and. store_urban_drainage_discharge) then
+      !
+      NF90(nf90_put_var(his_file%ncid, his_file%urbdrain_varid, urban_drainage_q_total, (/1, nthisout/))) ! write per-zone total discharge
       !
    endif
    !
@@ -1552,6 +1584,7 @@ contains
    real*8                            :: t
    integer                           :: ntmaxout, nm
    real*4, dimension(:), allocatable :: hmax_out, hmean
+   real*4, dimension(:), allocatable :: urbdrain_depth
    !
    ! Scalar time of this max-record (defined only when store_maximum_waterlevel)
    if (store_maximum_waterlevel) then
@@ -1603,6 +1636,20 @@ contains
       if (infiltration) then
          call write_cell_var(map_file%ncid, map_file%cuminf_varid, cuminf, ntmaxout, check_kcs=.true.)
       endif
+   endif
+   !
+   ! Cumulative urban drainage depth (drained volume / cell area)
+   if (store_cumulative_urban_drainage .and. urban_drainage) then
+      allocate(urbdrain_depth(np))
+      do nm = 1, np
+         if (crsgeo) then
+            urbdrain_depth(nm) = urban_drainage_cumulative_volume(nm) / cell_area_m2(nm)
+         else
+            urbdrain_depth(nm) = urban_drainage_cumulative_volume(nm) / cell_area(z_flags_iref(nm))
+         endif
+      enddo
+      call write_cell_var(map_file%ncid, map_file%cumulative_urbdrain_varid, urbdrain_depth, ntmaxout)
+      deallocate(urbdrain_depth)
    endif
    !
    ! Maximum flow velocity / flux
@@ -1667,21 +1714,18 @@ contains
    ! Add total runtime, dtavg to file and close
    !
    use sfincs_data
-   !   
-   implicit none   
-   !   
-   ! Mirror the early-return condition from ncoutput_his_init exactly: if
-   ! none of these are present, no his file was created. (Note: thindams
-   ! alone do NOT trigger his-file creation in init, so they're not in
-   ! this list either.)
-   if (nobs==0 .and. nrcrosssections==0 .and. nrstructures==0 .and. ndrn==0 .and. nr_runup_gauges==0) then
-      return
-   endif
+   use sfincs_src_structures, only: nr_src_structures
+   use sfincs_discharges,     only: nr_discharge_points
+   use sfincs_urban_drainage, only: nr_urban_drainage_zones
    !
    implicit none
    !
-   if (nobs==0 .and. nrcrosssections==0 .and. nrstructures==0 .and. nrthindams==0 .and. nr_src_structures==0 .and. .not. (nr_discharge_points>0 .and. store_river_discharge) .and. .not. (nr_urban_drainage_zones>0 .and. store_urban_drainage_discharge)) then ! If no observation points, cross-sections, structures (weir or thin dam), drains, river sources or urban drainage zones; hisfile
-        return
+   ! Mirror the early-return condition from ncoutput_his_init exactly: if
+   ! none of these are present, no his file was created. (Note: thindams
+   ! alone do NOT trigger his-file creation in init, so they are not in
+   ! this list either.)
+   if (nobs==0 .and. nrcrosssections==0 .and. nrstructures==0 .and. nr_src_structures==0 .and. .not. (nr_discharge_points>0 .and. store_river_discharge) .and. .not. (nr_urban_drainage_zones>0 .and. store_urban_drainage_discharge) .and. nr_runup_gauges==0) then
+      return
    endif
    !
    NF90(nf90_put_var(his_file%ncid, his_file%total_runtime_varid, tfinish_all - tstart_all))

--- a/source/src/sfincs_ncoutput_helpers.F90
+++ b/source/src/sfincs_ncoutput_helpers.F90
@@ -1,0 +1,1031 @@
+#define NF90(nf90call) call handle_err(nf90call,__FILE__,__LINE__)
+!
+! ============================================================================
+! sfincs_ncoutput_helpers — shared types, state and helper subroutines for
+! the SFINCS NetCDF output layer.
+!
+! This module owns:
+!   - map_type / his_type derived types and their instances (map_file / his_file)
+!   - Fill-value constants FILL_VALUE / FILL_VALUE_INT
+!   - Dimension-context module variables set once by ncoutput_map_init before
+!     any def_* calls: nsd, dims_s, dims_st, dims_sm, coord_str
+!   - pt_coord parameter used by def_time_point_float / def_his_point_coord
+!   - Map-output writers: write_cell_var, write_cell_var_wet, write_cell_var_depth,
+!       put_static_cell_float, put_static_cell_mask
+!   - Map-init def wrappers: def_static_cell_float, def_static_cell_int,
+!       def_time_cell_float, def_maxtime_cell_float, add_ugrid_face_attrs,
+!       def_mesh2d_node_coord, def_grid_axis_coord, put_2d
+!   - His-init def wrappers: def_time_point_float, def_his_point_coord
+!   - His-update writer: write_point_var
+!   - His-update precompute: compute_uv_at_obs_points, compute_wind_at_obs_points
+!   - Map-update precompute: compute_uv_at_cell_centers, compute_pnh_unwrapped,
+!       compute_subgrid_mean_depth
+!   - Finalize helpers: ncoutput_write_timestep_analysis,
+!       ncoutput_write_tsunami_arrival_time
+!   - Generic NetCDF wrappers: ncdef_float_var, ncdef_int_var, logical2int,
+!       handle_err
+!
+! sfincs_ncoutput uses this module and supplies the public init/update/finalize
+! subroutines.
+! ============================================================================
+module sfincs_ncoutput_helpers
+   !
+   use netcdf
+   !
+   implicit none
+   !
+   type map_type
+      !
+      integer :: ncid
+      integer :: n_dimid, m_dimid, corner_n_dimid, corner_m_dimid
+      integer :: time_dimid
+      integer :: timemax_dimid
+      integer :: runtime_dimid
+      integer :: corner_x_varid, corner_y_varid, face_x_varid, face_y_varid, crs_varid, grid_varid
+      integer :: zb_varid, msk_varid, qinf_varid
+      integer :: time_varid, timemax_varid
+      integer :: zs_varid, zsmax_varid, h_varid, u_varid, v_varid, tmax_varid, infstate_varid, t_zsmax_varid
+      integer :: zvolume_varid, storagevolume_varid
+      integer :: hmax_varid, vmax_varid, qmax_varid, cumprcp_varid, cuminf_varid, windmax_varid
+      integer :: patm_varid, wind_u_varid, wind_v_varid, precip_varid
+      integer :: hm0_varid, hm0ig_varid, snapwavemsk_varid, tp_varid, tpig_varid, wavdir_varid
+      integer :: fwx_varid, fwy_varid, beta_varid, snapwavedepth_varid
+      integer :: zsm_varid, tsunami_arrival_time_varid, average_required_timestep_varid, percentage_limiting_varid
+      integer :: inp_varid, total_runtime_varid, average_dt_varid, status_varid
+      integer :: manning_varid
+      integer :: pnonh_varid
+      integer :: subgridslope_varid
+      ! Vegetation
+      integer :: nsec_dimid
+      integer :: veg_cd_varid, veg_ah_varid, veg_bstems_varid, veg_Nstems_varid
+      !
+      integer :: mesh2d_varid
+      integer :: mesh2d_node_x_varid, mesh2d_node_y_varid
+      integer :: mesh2d_face_x_varid, mesh2d_face_y_varid
+      integer :: mesh2d_face_nodes_varid
+      integer :: nmesh2d_node_dimid
+      integer :: nmesh2d_face_dimid
+      integer :: max_nmesh2d_face_nodes_dimid
+      !
+   end type
+   !
+   type his_type
+      !
+      integer :: ncid
+      integer :: time_dimid
+      integer :: points_dimid, pointnamelength_dimid
+      integer :: crosssections_dimid, structures_dimid, thindams_dimid, drain_dimid, runup_gauges_dimid
+      integer :: runtime_dimid
+      integer :: point_x_varid, point_y_varid, station_x_varid, station_y_varid, crs_varid, qinf_varid, S_varid
+      integer :: station_id_varid, station_name_varid
+      integer :: crosssection_name_varid
+      integer :: structure_height_varid, structure_x_varid, structure_y_varid
+      integer :: thindam_x_varid, thindam_y_varid
+      integer :: drain_varid
+      integer :: zb_varid
+      integer :: time_varid
+      integer :: zs_varid, h_varid, u_varid, v_varid, prcp_varid, cumprcp_varid, discharge_varid, uvmag_varid, uvdir_varid
+      integer :: patm_varid, wind_speed_varid, wind_dir_varid
+      integer :: inp_varid, total_runtime_varid, average_dt_varid, status_varid
+      integer :: hm0_varid, hm0ig_varid, zsm_varid, tp_varid, tpig_varid, wavdir_varid
+      integer :: dw_varid, df_varid, dwig_varid, dfig_varid, cg_varid, beta_varid, srcig_varid, alphaig_varid
+      integer :: runup_gauge_name_varid, runup_gauge_zs_varid
+      !
+   end type
+   !
+   type(map_type) :: map_file
+   type(his_type) :: his_file
+   !
+   real*4,  parameter :: FILL_VALUE     = -99999.0
+   integer, parameter :: FILL_VALUE_INT = -999
+   !
+   ! pt_coord: coordinate attribute used by his-file point-variable def helpers.
+   character(*), parameter :: pt_coord = 'station_id station_name point_x point_y'
+   !
+   ! Dimension context written once by ncoutput_map_init (before any def_* calls)
+   ! and read by the def_* wrappers below.
+   integer      :: nsd
+   integer      :: dims_s(3), dims_st(3), dims_sm(3)
+   character(4) :: coord_str
+
+contains
+
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+   !
+   ! Cell-variable writers
+   !
+   ! These hide the use_quadtree branch and the scatter/gather pattern
+   ! from ncoutput_update_map / ncoutput_update_max. A new time-varying
+   ! cell-centered map variable becomes a one-line call.
+   !
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+   subroutine write_cell_var(ncid, varid, source, nt, use_sw_index, check_kcs, scale, min_value)
+      !
+      ! Scatter SFINCS cell-centered source(:) into the file-shaped buffer
+      ! and put it to the NetCDF variable at timestep nt.
+      !   use_sw_index=.true. -> quadtree gather uses index_sw_in_qt (snapwave)
+      !   check_kcs=.true.    -> quadtree skips cells with kcs<=0 (max-file style)
+      !   scale               -> multiply source by scale on write (unit conversions)
+      !   min_value           -> only write cells where source(nm) > min_value
+      !                          (used for t_zsmax to mask never-reached cells)
+      !
+      use sfincs_data
+      use sfincs_snapwave, only: index_sw_in_qt, index_snapwave_in_sfincs
+      use quadtree
+      !
+      integer, intent(in)           :: ncid, varid, nt
+      real*4,  intent(in)           :: source(:)
+      logical, intent(in), optional :: use_sw_index, check_kcs
+      real*4,  intent(in), optional :: scale, min_value
+      !
+      real*4,  allocatable :: buf_q(:), buf_r(:,:)
+      logical :: use_sw, filt_kcs, filt_min
+      real*4  :: fac, vmin
+      integer :: nm, nmq, nms
+      !
+      use_sw   = .false.; if (present(use_sw_index)) use_sw   = use_sw_index
+      filt_kcs = .false.; if (present(check_kcs))    filt_kcs = check_kcs
+      filt_min = .false.; if (present(min_value))    filt_min = .true.
+      fac      = 1.0;     if (present(scale))        fac      = scale
+      vmin     = 0.0;     if (present(min_value))    vmin     = min_value
+      !
+      if (use_quadtree) then
+         allocate(buf_q(quadtree_nr_points))
+         buf_q = FILL_VALUE
+         do nmq = 1, quadtree_nr_points
+            if (use_sw) then
+               nm = index_sw_in_qt(nmq)
+            else
+               nm = index_sfincs_in_quadtree(nmq)
+            endif
+            if (nm <= 0) cycle
+            if (filt_kcs .and. kcs(nm) <= 0) cycle
+            if (filt_min .and. source(nm) <= vmin) cycle
+            buf_q(nmq) = fac * source(nm)
+         enddo
+         NF90(nf90_put_var(ncid, varid, buf_q, (/1, nt/)))
+      else
+         allocate(buf_r(mmax, nmax))
+         buf_r = FILL_VALUE
+         do nm = 1, np
+            if (use_sw) then
+               nms = index_snapwave_in_sfincs(nm)
+            else
+               nms = nm
+            endif
+            if (nms <= 0) cycle
+            if (filt_kcs .and. kcs(nm) <= 0) cycle
+            if (filt_min .and. source(nms) <= vmin) cycle
+            buf_r(z_index_z_m(nm), z_index_z_n(nm)) = fac * source(nms)
+         enddo
+         NF90(nf90_put_var(ncid, varid, buf_r, (/1, 1, nt/)))
+      endif
+   end subroutine write_cell_var
+
+   subroutine write_cell_var_wet(ncid, varid, source, zref, nt, check_wet)
+      !
+      ! Wet-cell filtered writer for a cell variable (e.g. zs / zsmax).
+      ! On quadtree: skips kcs<=0 cells. On both grids: when check_wet (default
+      ! .true.), only writes cells where (source-zref) > huthresh, i.e. the cell
+      ! is wet. To write the depth (source-zref) itself, use write_cell_var_depth.
+      !
+      use sfincs_data
+      use quadtree
+      !
+      integer, intent(in)           :: ncid, varid, nt
+      real*4,  intent(in)           :: source(:), zref(:)
+      logical, intent(in), optional :: check_wet
+      !
+      real*4,  allocatable :: buf_q(:), buf_r(:,:)
+      logical :: filt_wet
+      integer :: nm, nmq
+      !
+      filt_wet = .true.; if (present(check_wet)) filt_wet = check_wet
+      !
+      if (use_quadtree) then
+         allocate(buf_q(quadtree_nr_points))
+         buf_q = FILL_VALUE
+         do nmq = 1, quadtree_nr_points
+            nm = index_sfincs_in_quadtree(nmq)
+            if (nm > 0) then
+               if (kcs(nm) > 0) then
+                  if (.not. filt_wet .or. (source(nm) - zref(nm)) > huthresh) then
+                     buf_q(nmq) = source(nm)
+                  endif
+               endif
+            endif
+         enddo
+         NF90(nf90_put_var(ncid, varid, buf_q, (/1, nt/)))
+      else
+         allocate(buf_r(mmax, nmax))
+         buf_r = FILL_VALUE
+         do nm = 1, np
+            if (.not. filt_wet .or. (source(nm) - zref(nm)) > huthresh) then
+               buf_r(z_index_z_m(nm), z_index_z_n(nm)) = source(nm)
+            endif
+         enddo
+         NF90(nf90_put_var(ncid, varid, buf_r, (/1, 1, nt/)))
+      endif
+   end subroutine write_cell_var_wet
+
+   subroutine write_cell_var_depth(ncid, varid, water_level, bed_level, nt, check_wet)
+      !
+      ! Wet-cell filtered writer for the water depth (h).
+      ! Writes depth = water_level - bed_level, only in cells that are wet, i.e.
+      ! where that depth exceeds huthresh. When check_wet is .false. the depth
+      ! test is skipped and the depth is written in every cell.
+      ! On quadtree: additionally skips kcs<=0 cells.
+      !
+      use sfincs_data
+      use quadtree
+      !
+      integer, intent(in)           :: ncid, varid, nt
+      real*4,  intent(in)           :: water_level(:), bed_level(:)
+      logical, intent(in), optional :: check_wet
+      !
+      real*4,  allocatable :: buf_q(:), buf_r(:,:)
+      logical :: filt_wet
+      integer :: nm, nmq
+      real*4  :: depth
+      !
+      filt_wet = .true.; if (present(check_wet)) filt_wet = check_wet
+      !
+      if (use_quadtree) then
+         allocate(buf_q(quadtree_nr_points))
+         buf_q = FILL_VALUE
+         do nmq = 1, quadtree_nr_points
+            nm = index_sfincs_in_quadtree(nmq)
+            if (nm > 0) then
+               if (kcs(nm) > 0) then
+                  depth = water_level(nm) - bed_level(nm)
+                  if (.not. filt_wet .or. depth > huthresh) then
+                     buf_q(nmq) = depth
+                  endif
+               endif
+            endif
+         enddo
+         NF90(nf90_put_var(ncid, varid, buf_q, (/1, nt/)))
+      else
+         allocate(buf_r(mmax, nmax))
+         buf_r = FILL_VALUE
+         do nm = 1, np
+            depth = water_level(nm) - bed_level(nm)
+            if (.not. filt_wet .or. depth > huthresh) then
+               buf_r(z_index_z_m(nm), z_index_z_n(nm)) = depth
+            endif
+         enddo
+         NF90(nf90_put_var(ncid, varid, buf_r, (/1, 1, nt/)))
+      endif
+   end subroutine write_cell_var_depth
+
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+   !
+   ! Static-cell write helpers
+   !
+   ! Gather a SFINCS-indexed source array into the right per-grid buffer
+   ! (1D for quadtree, 2D for regular) and write it via nf90_put_var.
+   ! Hides the use_quadtree branch, the index-map choice and the buffer
+   ! allocation. Used by ncoutput_map_init (static map fields),
+   ! ncoutput_write_tsunami_arrival_time, and ncoutput_write_timestep_analysis.
+   !
+   !   put_static_cell_float : real*4 source, optional scale,
+   !                           optional sw_index for snapwave-indexed sources
+   !   put_static_cell_mask  : real*4 source written to NF90_INT (quadtree)
+   !                           or NF90_FLOAT (regular); cast int*1 sources
+   !                           via real(.,4) at the call site
+   !
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+   subroutine put_static_cell_float(ncid, varid, source, fill, scale, sw_index, min_value)
+      use sfincs_data
+      use sfincs_snapwave, only: index_sw_in_qt
+      use quadtree
+      !
+      integer, intent(in)           :: ncid, varid
+      real*4,  intent(in)           :: source(:)
+      real*4,  intent(in)           :: fill
+      real*4,  intent(in), optional :: scale     ! default: 1.0
+      logical, intent(in), optional :: sw_index  ! default: .false. (use sfincs index)
+      real*4,  intent(in), optional :: min_value ! only write cells where source(nm) > min_value
+      !
+      real*4, allocatable :: buf_q(:), buf_r(:,:)
+      real*4  :: sc, vmin
+      logical :: usesw, filt_min
+      integer :: nmq, nm
+      !
+      sc = 1.0;       if (present(scale))     sc       = scale
+      usesw = .false.; if (present(sw_index)) usesw    = sw_index
+      filt_min = .false.; if (present(min_value)) filt_min = .true.
+      vmin = 0.0;     if (present(min_value)) vmin     = min_value
+      !
+      if (use_quadtree) then
+         allocate(buf_q(quadtree_nr_points))
+         buf_q = fill
+         do nmq = 1, quadtree_nr_points
+            if (usesw) then
+               nm = index_sw_in_qt(nmq)
+            else
+               nm = index_sfincs_in_quadtree(nmq)
+            endif
+            if (nm <= 0) cycle
+            if (filt_min .and. source(nm) <= vmin) cycle
+            buf_q(nmq) = source(nm) * sc
+         enddo
+         NF90(nf90_put_var(ncid, varid, buf_q))
+      else
+         allocate(buf_r(mmax, nmax))
+         buf_r = fill
+         do nm = 1, np
+            if (filt_min .and. source(nm) <= vmin) cycle
+            buf_r(z_index_z_m(nm), z_index_z_n(nm)) = source(nm) * sc
+         enddo
+         NF90(nf90_put_var(ncid, varid, buf_r, (/1, 1/)))
+      endif
+   end subroutine put_static_cell_float
+
+   subroutine put_static_veg_float(ncid, varid, source, nsec, fill)
+      ! 2D static write: face x nsec (vegetation stem properties).
+      ! source is (nm, isec) on the SFINCS cell index. 1D `face` on quadtree,
+      ! 2D `(m, n)` on regular, both with a trailing nsec dimension.
+      use sfincs_data
+      use quadtree
+      !
+      integer, intent(in) :: ncid, varid, nsec
+      real*4,  intent(in) :: source(:,:)
+      real*4,  intent(in) :: fill
+      !
+      real*4, allocatable :: buf_q(:,:), buf_r(:,:,:)
+      integer :: nmq, nm, isec
+      !
+      if (use_quadtree) then
+         allocate(buf_q(quadtree_nr_points, nsec))
+         buf_q = fill
+         do nmq = 1, quadtree_nr_points
+            nm = index_sfincs_in_quadtree(nmq)
+            if (nm <= 0) cycle
+            do isec = 1, nsec
+               buf_q(nmq, isec) = source(nm, isec)
+            enddo
+         enddo
+         NF90(nf90_put_var(ncid, varid, buf_q))
+      else
+         allocate(buf_r(mmax, nmax, nsec))
+         buf_r = fill
+         do nm = 1, np
+            do isec = 1, nsec
+               buf_r(z_index_z_m(nm), z_index_z_n(nm), isec) = source(nm, isec)
+            enddo
+         enddo
+         NF90(nf90_put_var(ncid, varid, buf_r, (/1, 1, 1/)))
+      endif
+   end subroutine put_static_veg_float
+
+   subroutine put_static_cell_mask(ncid, varid, source, sw_index)
+      ! Mask-style write: NF90_INT on both grid types — 1D `face` on quadtree,
+      ! 2D `(m, n)` on regular. Source is real*4 — callers pass real(kcs, 4)
+      ! for int*1 masks (kcs) or snapwave_mask directly (already real*4).
+      use sfincs_data
+      use sfincs_snapwave, only: index_sw_in_qt
+      use quadtree
+      !
+      integer, intent(in)           :: ncid, varid
+      real*4,  intent(in)           :: source(:)
+      logical, intent(in), optional :: sw_index
+      !
+      integer*4, allocatable :: buf_qi(:)
+      integer*4, allocatable :: buf_ri(:,:)
+      logical :: usesw
+      integer :: nmq, nm
+      !
+      usesw = .false.
+      if (present(sw_index)) usesw = sw_index
+      !
+      ! Source is real*4 — int() truncates toward zero. Used only for mask
+      ! vars (kcs, snapwave_mask) whose values are small non-negative
+      ! integers, so truncation is exact.
+      if (use_quadtree) then
+         allocate(buf_qi(quadtree_nr_points))
+         buf_qi = 0
+         do nmq = 1, quadtree_nr_points
+            if (usesw) then
+               nm = index_sw_in_qt(nmq)
+            else
+               nm = index_sfincs_in_quadtree(nmq)
+            endif
+            if (nm > 0) buf_qi(nmq) = int(source(nm), 4)
+         enddo
+         NF90(nf90_put_var(ncid, varid, buf_qi))
+      else
+         allocate(buf_ri(mmax, nmax))
+         ! Initialise to FILL_VALUE_INT so cells outside np (the active SFINCS
+         ! domain) read as fill, not as a valid mask=0. Cells with kcs(nm)==0
+         ! inside np are still written as 0 (a valid inactive-but-present marker).
+         buf_ri = FILL_VALUE_INT
+         do nm = 1, np
+            buf_ri(z_index_z_m(nm), z_index_z_n(nm)) = int(source(nm), 4)
+         enddo
+         NF90(nf90_put_var(ncid, varid, buf_ri, (/1, 1/)))
+      endif
+   end subroutine put_static_cell_mask
+
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+   !
+   ! Map-init def wrappers
+   !
+   ! These read the dimension-context module variables (nsd, dims_*, coord_str)
+   ! set at the top of ncoutput_map_init, so call sites carry only var-specific
+   ! info (name, varid, units, long_name, optional attrs).
+   !
+   ! def_static_cell_float   : dims_s(1:nsd)    + coord_str
+   ! def_static_cell_int     : dims_s(1:nsd)    (no coord)
+   ! def_time_cell_float     : dims_st(1:nsd+1) + coord_str
+   ! def_maxtime_cell_float  : dims_sm(1:nsd+1) + coord_str
+   ! add_ugrid_face_attrs    : mesh/location on quadtree cell vars
+   ! def_mesh2d_node_coord   : UGRID node coord (float geo / double projected)
+   ! def_grid_axis_coord     : SGRID face/corner coord (always float)
+   ! put_2d                  : nf90_put_var with (/1, 1/) start
+   !
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+   subroutine def_static_cell_float(name, varid, units, long_name, &
+                                     standard_name, cell_methods, description)
+      use sfincs_data, only: nc_deflate_level
+      character(*), intent(in)           :: name
+      integer,      intent(out)          :: varid
+      character(*), intent(in)           :: units, long_name
+      character(*), intent(in), optional :: standard_name, cell_methods, description
+      call ncdef_float_var(map_file%ncid, name, dims_s(1:nsd), varid, units, long_name, &
+           standard_name=standard_name, coordinates=coord_str,                          &
+           cell_methods=cell_methods, description=description,                          &
+           deflate_level=nc_deflate_level)
+      call add_ugrid_face_attrs(varid)
+   end subroutine def_static_cell_float
+
+   subroutine def_static_veg_float(name, varid, units, long_name, nsec_dimid, &
+                                    standard_name)
+      ! Static 2D face variable with a trailing nsec (vegetation section) dim.
+      use sfincs_data, only: nc_deflate_level
+      character(*), intent(in)           :: name
+      integer,      intent(out)          :: varid
+      character(*), intent(in)           :: units, long_name
+      integer,      intent(in)           :: nsec_dimid
+      character(*), intent(in), optional :: standard_name
+      integer :: vdims(3)
+      vdims(1:nsd) = dims_s(1:nsd)
+      vdims(nsd+1) = nsec_dimid
+      call ncdef_float_var(map_file%ncid, name, vdims(1:nsd+1), varid, units, long_name, &
+           standard_name=standard_name, coordinates=coord_str,                          &
+           deflate_level=nc_deflate_level)
+      call add_ugrid_face_attrs(varid)
+   end subroutine def_static_veg_float
+
+   subroutine def_static_cell_int(name, varid, long_name, &
+                                   units, standard_name, fill_value, description, &
+                                   flag_values, flag_meanings)
+      use sfincs_data, only: nc_deflate_level
+      character(*), intent(in)           :: name
+      integer,      intent(out)          :: varid
+      character(*), intent(in)           :: long_name
+      character(*), intent(in), optional :: units, standard_name
+      integer,      intent(in), optional :: fill_value
+      character(*), intent(in), optional :: description
+      integer,      intent(in), optional :: flag_values(:)
+      character(*), intent(in), optional :: flag_meanings
+      call ncdef_int_var(map_file%ncid, name, dims_s(1:nsd), varid, long_name, &
+           fill_value=fill_value, description=description,                     &
+           deflate_level=nc_deflate_level)
+      if (present(units)) then
+         if (len_trim(units) > 0) NF90(nf90_put_att(map_file%ncid, varid, 'units', trim(units)))
+      endif
+      if (present(standard_name)) then
+         if (len_trim(standard_name) > 0) NF90(nf90_put_att(map_file%ncid, varid, 'standard_name', trim(standard_name)))
+      endif
+      ! coordinates attribute: empty on quadtree (UGRID uses mesh="mesh2d"
+      ! / location="face" instead, added below), 'x y' on SGRID regular grid.
+      if (len_trim(coord_str) > 0) then
+         NF90(nf90_put_att(map_file%ncid, varid, 'coordinates', trim(coord_str)))
+      endif
+      ! CF flag-variable convention: flag_values + flag_meanings together
+      ! describe the categorical values of the variable.
+      if (present(flag_values)) then
+         NF90(nf90_put_att(map_file%ncid, varid, 'flag_values', flag_values))
+      endif
+      if (present(flag_meanings)) then
+         if (len_trim(flag_meanings) > 0) then
+            NF90(nf90_put_att(map_file%ncid, varid, 'flag_meanings', trim(flag_meanings)))
+         endif
+      endif
+      call add_ugrid_face_attrs(varid)
+   end subroutine def_static_cell_int
+
+   subroutine def_time_cell_float(name, varid, units, long_name, &
+                                   standard_name, cell_methods, description)
+      use sfincs_data, only: nc_deflate_level
+      character(*), intent(in)           :: name
+      integer,      intent(out)          :: varid
+      character(*), intent(in)           :: units, long_name
+      character(*), intent(in), optional :: standard_name, cell_methods, description
+      call ncdef_float_var(map_file%ncid, name, dims_st(1:nsd+1), varid, units, long_name, &
+           standard_name=standard_name, coordinates=coord_str,                             &
+           cell_methods=cell_methods, description=description,                             &
+           deflate_level=nc_deflate_level)
+      call add_ugrid_face_attrs(varid)
+   end subroutine def_time_cell_float
+
+   subroutine def_maxtime_cell_float(name, varid, units, long_name, &
+                                      standard_name, cell_methods, description)
+      use sfincs_data, only: nc_deflate_level
+      character(*), intent(in)           :: name
+      integer,      intent(out)          :: varid
+      character(*), intent(in)           :: units, long_name
+      character(*), intent(in), optional :: standard_name, cell_methods, description
+      call ncdef_float_var(map_file%ncid, name, dims_sm(1:nsd+1), varid, units, long_name, &
+           standard_name=standard_name, coordinates=coord_str,                             &
+           cell_methods=cell_methods, description=description,                             &
+           deflate_level=nc_deflate_level)
+      call add_ugrid_face_attrs(varid)
+   end subroutine def_maxtime_cell_float
+
+   subroutine add_ugrid_face_attrs(varid)
+      ! On quadtree (UGRID) output, every cell-centred data variable must
+      ! carry mesh="mesh2d" and location="face". On regular grid (SGRID) the
+      ! topology var declares the grid; cell vars use coordinates='x y' (set
+      ! elsewhere) and these attributes are not used.
+      use sfincs_data, only: use_quadtree
+      integer, intent(in) :: varid
+      if (use_quadtree) then
+         NF90(nf90_put_att(map_file%ncid, varid, 'mesh',     'mesh2d'))
+         NF90(nf90_put_att(map_file%ncid, varid, 'location', 'face'))
+      endif
+   end subroutine add_ugrid_face_attrs
+
+   subroutine def_mesh2d_node_coord(axis, varid)
+      ! Define mesh2d_node_x / mesh2d_node_y for UGRID quadtree topology.
+      ! Picks NF90_FLOAT+degrees (geographic) or NF90_DOUBLE+m (projected) via crsgeo.
+      use sfincs_data, only: crsgeo, nc_deflate_level
+      character(len=*), intent(in)  :: axis   ! 'x' or 'y'
+      integer,          intent(out) :: varid
+      character(len=64) :: vname
+      character(len=32) :: std_name, long_name, units
+      integer           :: nctype
+      !
+      vname = 'mesh2d_node_' // axis
+      if (crsgeo) then
+         nctype = NF90_FLOAT
+         if (axis == 'x') then
+            units     = 'degrees_east'
+            std_name  = 'longitude'
+            long_name = 'longitude'
+         else
+            units     = 'degrees_north'
+            std_name  = 'latitude'
+            long_name = 'latitude'
+         endif
+      else
+         nctype = NF90_DOUBLE
+         units  = 'm'
+         if (axis == 'x') then
+            std_name  = 'projection_x_coordinate'
+            long_name = 'x-coordinate of mesh nodes'
+         else
+            std_name  = 'projection_y_coordinate'
+            long_name = 'y-coordinate of mesh nodes'
+         endif
+      endif
+      NF90(nf90_def_var(map_file%ncid, trim(vname), nctype, (/map_file%nmesh2d_node_dimid/), varid))
+      NF90(nf90_def_var_deflate(map_file%ncid, varid, 1, 1, nc_deflate_level))
+      NF90(nf90_put_att(map_file%ncid, varid, 'units',         trim(units)))
+      NF90(nf90_put_att(map_file%ncid, varid, 'standard_name', trim(std_name)))
+      NF90(nf90_put_att(map_file%ncid, varid, 'long_name',     trim(long_name)))
+      NF90(nf90_put_att(map_file%ncid, varid, 'grid_mapping',  'crs'))
+      NF90(nf90_put_att(map_file%ncid, varid, 'mesh',          'mesh2d'))
+      NF90(nf90_put_att(map_file%ncid, varid, 'location',      'node'))
+   end subroutine def_mesh2d_node_coord
+
+   subroutine def_grid_axis_coord(name, axis, dimids, varid, long_name)
+      ! Define a regular-grid coordinate axis variable (face_x/face_y/corner_x/
+      ! corner_y) with the right CF attributes:
+      !   crsgeo  : NF90_FLOAT, units='degrees', standard_name=longitude/latitude
+      !   else    : NF90_FLOAT, units='m',       standard_name=projection_{x,y}_coordinate
+      use sfincs_data, only: crsgeo, nc_deflate_level
+      character(len=*), intent(in)  :: name
+      character(len=*), intent(in)  :: axis   ! 'x' or 'y'
+      integer,          intent(in)  :: dimids(:)
+      integer,          intent(out) :: varid
+      character(len=*), intent(in)  :: long_name
+      character(len=32) :: units, std_name
+      !
+      if (crsgeo) then
+         units = 'degrees'
+         if (axis == 'x') then
+            std_name = 'longitude'
+         else
+            std_name = 'latitude'
+         endif
+      else
+         units = 'm'
+         if (axis == 'x') then
+            std_name = 'projection_x_coordinate'
+         else
+            std_name = 'projection_y_coordinate'
+         endif
+      endif
+      NF90(nf90_def_var(map_file%ncid, name, NF90_FLOAT, dimids, varid))
+      NF90(nf90_def_var_deflate(map_file%ncid, varid, 1, 1, nc_deflate_level))
+      NF90(nf90_put_att(map_file%ncid, varid, '_FillValue',    FILL_VALUE))
+      NF90(nf90_put_att(map_file%ncid, varid, 'units',         trim(units)))
+      NF90(nf90_put_att(map_file%ncid, varid, 'standard_name', trim(std_name)))
+      NF90(nf90_put_att(map_file%ncid, varid, 'long_name',     long_name))
+      NF90(nf90_put_att(map_file%ncid, varid, 'grid_mapping',  'crs'))
+      NF90(nf90_put_att(map_file%ncid, varid, 'grid',          'sfincsgrid'))
+   end subroutine def_grid_axis_coord
+
+   subroutine put_2d(varid, arr)
+      ! nf90_put_var for a 2D real*4 array (face/corner coords).
+      ! Hides the (/1, 1/) start-index boilerplate.
+      integer, intent(in) :: varid
+      real*4,  intent(in) :: arr(:,:)
+      NF90(nf90_put_var(map_file%ncid, varid, arr, (/1, 1/)))
+   end subroutine put_2d
+
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+   !
+   ! His-init def wrappers
+   !
+   ! def_time_point_float : (/points_dimid, time_dimid/) + pt_coord
+   ! def_his_point_coord  : CRS-aware station coordinate variable
+   !
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+   subroutine def_time_point_float(name, varid, units, long_name, &
+                                    standard_name, cell_methods, description)
+      use sfincs_data, only: nc_deflate_level
+      character(*), intent(in)           :: name
+      integer,      intent(out)          :: varid
+      character(*), intent(in)           :: units, long_name
+      character(*), intent(in), optional :: standard_name, cell_methods, description
+      call ncdef_float_var(his_file%ncid, name,                           &
+           (/his_file%points_dimid, his_file%time_dimid/), varid,         &
+           units, long_name,                                              &
+           standard_name=standard_name, coordinates=pt_coord,             &
+           cell_methods=cell_methods, description=description,            &
+           deflate_level=nc_deflate_level)
+   end subroutine def_time_point_float
+
+   subroutine def_his_point_coord(name, axis, varid, long_name)
+      ! Define a his-file station coordinate variable with CRS-aware attrs.
+      use sfincs_data, only: crsgeo
+      character(len=*), intent(in)  :: name      ! 'station_x', 'point_y', etc.
+      character(len=*), intent(in)  :: axis      ! 'x' or 'y'
+      integer,          intent(out) :: varid
+      character(len=*), intent(in)  :: long_name
+      character(len=32) :: units, std_name
+      !
+      if (crsgeo) then
+         units = 'degrees'
+         if (axis == 'x') then
+            std_name = 'longitude'
+         else
+            std_name = 'latitude'
+         endif
+      else
+         units = 'm'
+         if (axis == 'x') then
+            std_name = 'projection_x_coordinate'
+         else
+            std_name = 'projection_y_coordinate'
+         endif
+      endif
+      NF90(nf90_def_var(his_file%ncid, name, NF90_FLOAT, (/his_file%points_dimid/), varid))
+      NF90(nf90_put_att(his_file%ncid, varid, 'units',         trim(units)))
+      NF90(nf90_put_att(his_file%ncid, varid, 'standard_name', trim(std_name)))
+      NF90(nf90_put_att(his_file%ncid, varid, 'long_name',     long_name))
+      NF90(nf90_put_att(his_file%ncid, varid, 'grid_mapping',  'crs'))
+   end subroutine def_his_point_coord
+
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+   !
+   ! His-update point writer
+   !
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+   subroutine write_point_var(varid, source, nt, scale, use_sw_index)
+   ! Gathers source(nmindobs(iobs)) for each obs point and writes to his_file.
+   ! Optional scale is applied only to non-fill values.
+   !   use_sw_index=.true. -> source is snapwave-indexed; map the obs cell to its
+   !                          snapwave node via index_snapwave_in_sfincs first.
+      use sfincs_data, only: nobs, nmindobs
+      use sfincs_snapwave, only: index_snapwave_in_sfincs
+      integer, intent(in)           :: varid
+      real*4,  intent(in)           :: source(:)
+      integer, intent(in)           :: nt
+      real*4,  intent(in), optional :: scale
+      logical, intent(in), optional :: use_sw_index
+      real*4  :: obs(nobs)
+      integer :: iobs, nm
+      logical :: use_sw
+      use_sw = .false.; if (present(use_sw_index)) use_sw = use_sw_index
+      obs = FILL_VALUE
+      do iobs = 1, nobs
+         nm = nmindobs(iobs)
+         if (nm <= 0) cycle
+         if (use_sw) then
+            nm = index_snapwave_in_sfincs(nm)
+            if (nm <= 0) cycle
+         endif
+         obs(iobs) = source(nm)
+      enddo
+      if (present(scale)) then
+         where (obs /= FILL_VALUE) obs = obs * scale
+      endif
+      NF90(nf90_put_var(his_file%ncid, varid, obs, (/1, nt/)))
+   end subroutine write_point_var
+
+   subroutine compute_uv_at_obs_points(uobs, vobs, uvmag, uvdir)
+   ! Face-averaged, rotated (u,v) and derived magnitude/direction at obs points.
+      use sfincs_data, only: nobs, nmindobs, z_index_uv_md, z_index_uv_mu, &
+                             z_index_uv_nd, z_index_uv_nu, uv, cosrot, sinrot, pi
+      real*4, intent(out) :: uobs(:), vobs(:), uvmag(:), uvdir(:)
+      integer :: iobs, nm, nmd1, nmu1, ndm1, num1
+      real*4  :: uz, vz
+      uobs  = FILL_VALUE
+      vobs  = FILL_VALUE
+      uvmag = FILL_VALUE
+      uvdir = FILL_VALUE
+      do iobs = 1, nobs
+         nm = nmindobs(iobs)
+         if (nm > 0) then
+            nmd1 = z_index_uv_md(nm)
+            nmu1 = z_index_uv_mu(nm)
+            ndm1 = z_index_uv_nd(nm)
+            num1 = z_index_uv_nu(nm)
+            uz = 0.5 * (uv(nmd1) + uv(nmu1))
+            vz = 0.5 * (uv(ndm1) + uv(num1))
+            uobs(iobs)  = cosrot * uz - sinrot * vz
+            vobs(iobs)  = sinrot * uz + cosrot * vz
+            uvmag(iobs) = sqrt(uobs(iobs)**2 + vobs(iobs)**2)
+            uvdir(iobs) = atan2(vobs(iobs), uobs(iobs)) * 180 / pi
+         endif
+      enddo
+   end subroutine compute_uv_at_obs_points
+
+   subroutine compute_wind_at_obs_points(wmag, wdir)
+   ! Wind speed and meteorological direction (270 - math angle) at obs points.
+      use sfincs_data, only: nobs, nmindobs, windu, windv, pi
+      real*4, intent(out) :: wmag(:), wdir(:)
+      integer :: iobs, nm
+      wmag = FILL_VALUE
+      wdir = FILL_VALUE
+      do iobs = 1, nobs
+         nm = nmindobs(iobs)
+         if (nm > 0) then
+            wmag(iobs) = sqrt(windu(nm)**2 + windv(nm)**2)
+            wdir(iobs) = 270.0 - atan2(windv(nm), windu(nm)) * 180 / pi
+            if (wdir(iobs) < 0.0)   wdir(iobs) = wdir(iobs) + 360.0
+            if (wdir(iobs) > 360.0) wdir(iobs) = wdir(iobs) - 360.0
+         endif
+      enddo
+   end subroutine compute_wind_at_obs_points
+
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+   !
+   ! Update-map precompute helpers
+   !
+   ! Produce SFINCS-indexed (np-shaped) source arrays so that grid-type-aware
+   ! write_cell_var handles the gather/put.
+   !
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+   subroutine compute_uv_at_cell_centers(uxy, vxy)
+      ! Cell-centered (u, v) by averaging the 4 surrounding UV faces.
+      ! Boundary cells contribute half (when one of nmd1/nmu1/ndm1/num1 is 0).
+      use sfincs_data
+      real*4, intent(out) :: uxy(:), vxy(:)
+      integer :: nm, nmd1, nmu1, ndm1, num1
+      real*4  :: uz, vz
+      uxy = FILL_VALUE
+      vxy = FILL_VALUE
+      do nm = 1, np
+         nmd1 = z_index_uv_md(nm)
+         nmu1 = z_index_uv_mu(nm)
+         ndm1 = z_index_uv_nd(nm)
+         num1 = z_index_uv_nu(nm)
+         uz = 0.0
+         if (nmd1 > 0) uz = uz + 0.5*uv(nmd1)
+         if (nmu1 > 0) uz = uz + 0.5*uv(nmu1)
+         vz = 0.0
+         if (ndm1 > 0) vz = vz + 0.5*uv(ndm1)
+         if (num1 > 0) vz = vz + 0.5*uv(num1)
+         uxy(nm) = cosrot*uz - sinrot*vz
+         vxy(nm) = sinrot*uz + cosrot*vz
+      enddo
+   end subroutine compute_uv_at_cell_centers
+
+   subroutine compute_pnh_unwrapped(pnh_full)
+      ! Map row-indexed nonhydrostatic pressure to SFINCS-indexed array.
+      use sfincs_data, only: np
+      use sfincs_nonhydrostatic, only: pnh, row_index_of_nm
+      real*4, intent(out) :: pnh_full(:)
+      integer :: nm
+      pnh_full = FILL_VALUE
+      do nm = 1, np
+         if (row_index_of_nm(nm) > 0) pnh_full(nm) = pnh(row_index_of_nm(nm))
+      enddo
+   end subroutine compute_pnh_unwrapped
+
+   subroutine compute_subgrid_mean_depth(z, hmean)
+   ! Converts subgrid water level to mean cell depth via the volume table.
+   ! Output-layer concern; lives here to keep sfincs_subgrid focused on table I/O.
+      use sfincs_data
+      implicit none
+      real*4, intent(in)  :: z(np)
+      real*4, intent(out) :: hmean(np)
+      integer :: nm, ivol, ilevel
+      real*8  :: volume
+      real*4  :: dzvol, facint
+      do nm = 1, np
+         if (z(nm) >= subgrid_z_zmax(nm)) then
+            ! Entire cell is wet — extend volume linearly above table maximum
+            if (crsgeo) then
+               volume = subgrid_z_volmax(nm) + cell_area_m2(nm)            * (z(nm) - max(subgrid_z_zmax(nm), -20.0))
+            else
+               volume = subgrid_z_volmax(nm) + cell_area(z_flags_iref(nm)) * (z(nm) - max(subgrid_z_zmax(nm), -20.0))
+            endif
+         else
+            ! Interpolation within the volume table
+            ivol = 1
+            do ilevel = 2, subgrid_nlevels
+               if (subgrid_z_dep(ilevel, nm) > z(nm)) then
+                  ivol = ilevel - 1
+                  exit
+               endif
+            enddo
+            dzvol  = subgrid_z_volmax(nm) / (subgrid_nlevels - 1)
+            facint = (z(nm) - subgrid_z_dep(ivol, nm)) / &
+                     max(subgrid_z_dep(ivol + 1, nm) - subgrid_z_dep(ivol, nm), 0.001)
+            volume = (ivol - 1) * dzvol + facint * dzvol
+         endif
+         if (crsgeo) then
+            hmean(nm) = volume / cell_area_m2(nm)
+         else
+            hmean(nm) = volume / cell_area(z_flags_iref(nm))
+         endif
+      enddo
+   end subroutine compute_subgrid_mean_depth
+
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+   !
+   ! Finalize-time single-write helpers
+   !
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+   subroutine ncoutput_write_timestep_analysis()
+   !
+   ! Write per-cell timestep statistics once at the end of simulation
+   ! (no time dimension).
+   !
+   use sfincs_data
+   !
+   implicit none
+   !
+   call put_static_cell_float(map_file%ncid, map_file%average_required_timestep_varid, &
+        timestep_analysis_average_required_timestep_per_cell, FILL_VALUE, min_value=0.0)
+   call put_static_cell_float(map_file%ncid, map_file%percentage_limiting_varid, &
+        timestep_analysis_percentage_limiting_per_cell, FILL_VALUE)
+   !
+   end subroutine ncoutput_write_timestep_analysis
+
+   subroutine ncoutput_write_tsunami_arrival_time()
+   ! Write tsunami_arrival_time once at finalize.
+   ! min_value=0.0 -> cells the tsunami never reached are written as
+   ! _FillValue, not 0 (which would otherwise read as "arrived at t=0").
+   use sfincs_data
+   !
+   implicit none
+   !
+   call put_static_cell_float(map_file%ncid, map_file%tsunami_arrival_time_varid, tsunami_arrival_time, &
+        FILL_VALUE, min_value=0.0)
+   !
+   end subroutine ncoutput_write_tsunami_arrival_time
+
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+   !
+   ! Generic NetCDF variable definition helpers.
+   ! ncdef_float_var / ncdef_int_var replace the 6-7 line def_var boilerplate
+   ! that repeats across ncoutput_map_init and ncoutput_his_init.
+   !
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+   subroutine ncdef_float_var(ncid, varname, dimids, varid, &
+                               units, long_name,             &
+                               standard_name, coordinates,   &
+                               cell_methods, description,    &
+                               deflate_level)
+      !
+      ! Define a NF90_FLOAT variable and set standard attributes in one call.
+      ! Optional attributes are only written when present and non-empty.
+      !
+      integer,      intent(in)           :: ncid
+      character(*), intent(in)           :: varname
+      integer,      intent(in)           :: dimids(:)
+      integer,      intent(out)          :: varid
+      character(*), intent(in)           :: units
+      character(*), intent(in)           :: long_name
+      character(*), intent(in), optional :: standard_name
+      character(*), intent(in), optional :: coordinates
+      character(*), intent(in), optional :: cell_methods
+      character(*), intent(in), optional :: description
+      integer,      intent(in), optional :: deflate_level
+      !
+      integer :: nc_deflate
+      !
+      nc_deflate = 6
+      if (present(deflate_level)) nc_deflate = deflate_level
+      !
+      NF90(nf90_def_var(ncid, trim(varname), NF90_FLOAT, dimids, varid))
+      NF90(nf90_def_var_deflate(ncid, varid, 1, 1, nc_deflate))
+      NF90(nf90_put_att(ncid, varid, '_FillValue', FILL_VALUE))
+      NF90(nf90_put_att(ncid, varid, 'units', trim(units)))
+      if (present(standard_name)) then
+         if (len_trim(standard_name) > 0) then
+            NF90(nf90_put_att(ncid, varid, 'standard_name', trim(standard_name)))
+         endif
+      endif
+      NF90(nf90_put_att(ncid, varid, 'long_name', trim(long_name)))
+      if (present(coordinates)) then
+         if (len_trim(coordinates) > 0) then
+            NF90(nf90_put_att(ncid, varid, 'coordinates', trim(coordinates)))
+         endif
+      endif
+      if (present(cell_methods)) then
+         if (len_trim(cell_methods) > 0) then
+            NF90(nf90_put_att(ncid, varid, 'cell_methods', trim(cell_methods)))
+         endif
+      endif
+      if (present(description)) then
+         if (len_trim(description) > 0) then
+            NF90(nf90_put_att(ncid, varid, 'description', trim(description)))
+         endif
+      endif
+      !
+   end subroutine ncdef_float_var
+
+   subroutine ncdef_int_var(ncid, varname, dimids, varid, &
+                             long_name,                    &
+                             fill_value, description,      &
+                             deflate_level)
+      !
+      ! Define a NF90_INT variable and set standard attributes in one call.
+      ! Topology variables with many unique attributes (mesh2d, crs, sfincsgrid,
+      ! mesh2d_face_nodes) should still be defined manually.
+      !
+      integer,      intent(in)           :: ncid
+      character(*), intent(in)           :: varname
+      integer,      intent(in)           :: dimids(:)
+      integer,      intent(out)          :: varid
+      character(*), intent(in)           :: long_name
+      integer,      intent(in), optional :: fill_value    ! default: FILL_VALUE_INT (-999)
+      character(*), intent(in), optional :: description
+      integer,      intent(in), optional :: deflate_level ! default: 6
+      !
+      integer :: nc_deflate, nc_fill
+      !
+      nc_deflate = 6
+      if (present(deflate_level)) nc_deflate = deflate_level
+      nc_fill = FILL_VALUE_INT
+      if (present(fill_value)) nc_fill = fill_value
+      !
+      NF90(nf90_def_var(ncid, trim(varname), NF90_INT, dimids, varid))
+      NF90(nf90_def_var_deflate(ncid, varid, 1, 1, nc_deflate))
+      NF90(nf90_put_att(ncid, varid, '_FillValue', nc_fill))
+      NF90(nf90_put_att(ncid, varid, 'long_name', trim(long_name)))
+      if (present(description)) then
+         if (len_trim(description) > 0) then
+            NF90(nf90_put_att(ncid, varid, 'description', trim(description)))
+         endif
+      endif
+      !
+   end subroutine ncdef_int_var
+
+   integer function logical2int(lgc)
+   ! Returns 1 for .true., 0 for .false. — used by ncoutput_add_params for
+   ! integer-typed NetCDF attributes that encode Fortran logical flags.
+      logical, intent(in) :: lgc
+      logical2int = merge(1, 0, lgc)
+   end function logical2int
+
+   subroutine handle_err(status,file,line)
+      ! Reports NetCDF errors to stderr. Does NOT close any file (the failing
+      ! call could have been on either map_file%ncid or his_file%ncid; closing
+      ! map_file unconditionally was misleading and pre-existing). Both files
+      ! are closed by their respective finalize routines on normal shutdown.
+      integer,      intent(in) :: status
+      character(*), intent(in) :: file
+      integer,      intent(in) :: line
+      if (status /= nf90_noerr) then
+         write(0,'("NETCDF ERROR: ",a,i6,":",a)') file, line, trim(nf90_strerror(status))
+      end if
+   end subroutine handle_err
+
+end module sfincs_ncoutput_helpers

--- a/source/src/sfincs_ncoutput_helpers.F90
+++ b/source/src/sfincs_ncoutput_helpers.F90
@@ -47,6 +47,7 @@ module sfincs_ncoutput_helpers
       integer :: zs_varid, zsmax_varid, h_varid, u_varid, v_varid, tmax_varid, infstate_varid, t_zsmax_varid
       integer :: zvolume_varid, storagevolume_varid
       integer :: hmax_varid, vmax_varid, qmax_varid, cumprcp_varid, cuminf_varid, windmax_varid
+      integer :: cumulative_urbdrain_varid
       integer :: patm_varid, wind_u_varid, wind_v_varid, precip_varid
       integer :: hm0_varid, hm0ig_varid, snapwavemsk_varid, tp_varid, tpig_varid, wavdir_varid
       integer :: fwx_varid, fwy_varid, beta_varid, snapwavedepth_varid
@@ -74,14 +75,17 @@ module sfincs_ncoutput_helpers
       integer :: ncid
       integer :: time_dimid
       integer :: points_dimid, pointnamelength_dimid
-      integer :: crosssections_dimid, structures_dimid, thindams_dimid, drain_dimid, runup_gauges_dimid
+      integer :: crosssections_dimid, structures_dimid, thindams_dimid, drain_dimid, runup_gauges_dimid, river_dimid
+      integer :: urbdrain_dimid
       integer :: runtime_dimid
       integer :: point_x_varid, point_y_varid, station_x_varid, station_y_varid, crs_varid, qinf_varid, S_varid
       integer :: station_id_varid, station_name_varid
       integer :: crosssection_name_varid
       integer :: structure_height_varid, structure_x_varid, structure_y_varid
       integer :: thindam_x_varid, thindam_y_varid
-      integer :: drain_varid
+      integer :: drain_varid, drain_name_varid, breach_width_varid, drain_fraction_open_varid
+      integer :: river_varid, river_name_varid
+      integer :: urbdrain_varid, urbdrain_name_varid
       integer :: zb_varid
       integer :: time_varid
       integer :: zs_varid, h_varid, u_varid, v_varid, prcp_varid, cumprcp_varid, discharge_varid, uvmag_varid, uvdir_varid

--- a/source/src/sfincs_openacc.f90
+++ b/source/src/sfincs_openacc.f90
@@ -1,6 +1,17 @@
 module sfincs_openacc
    !
    use sfincs_data
+   use sfincs_src_structures
+   use sfincs_discharges,      only: qtsrc, nmindsrc
+   use sfincs_rule_expression, only: rule_opcode, rule_atom, rule_cmp, rule_threshold, &
+                                     rule_start, rule_length
+   use sfincs_urban_drainage,  only: urban_drainage_zone_indices, urban_drainage_outfall_index, &
+                                     urban_drainage_qmax, urban_drainage_backflow_coef, &
+                                     urban_drainage_q_total, urban_drainage_cumulative_volume, &
+                                     urb_zone_type_id, urb_zone_injection_rate, urb_zone_maximum_capacity, &
+                                     urb_zone_cumulative_injection, &
+                                     urb_zone_h_threshold, urb_zone_check_valve, &
+                                     urb_zone_dh_design_min
    !
    implicit none
    !
@@ -21,7 +32,21 @@ contains
    !$acc               z_index_uv_md, z_index_uv_nd, z_index_uv_mu, z_index_uv_nu, &
    !$acc               uv_index_z_nm, uv_index_z_nmu, uv_index_u_nmd, uv_index_u_nmu, uv_index_u_ndm, uv_index_u_num, &
    !$acc               uv_index_v_ndm, uv_index_v_ndmu, uv_index_v_nm, uv_index_v_nmu, &
-   !$acc               nmindsrc, qtsrc, drainage_type, drainage_params, &
+   !$acc               qsrc, qtsrc, src_struc_q_now, nmindsrc, src_struc_nm_s1, src_struc_nm_s2, src_struc_type, &
+   !$acc               src_struc_direction, &
+   !$acc               src_struc_nm_o1, src_struc_nm_o2, &
+   !$acc               src_struc_q, src_struc_flow_coef, &
+   !$acc               src_struc_width, src_struc_sill_elevation, src_struc_mannings_n, &
+   !$acc               src_struc_opening_duration, src_struc_closing_duration, &
+   !$acc               src_struc_height, &
+   !$acc               src_struc_invert_1, src_struc_invert_2, &
+   !$acc               src_struc_submergence_ratio, &
+   !$acc               src_struc_z_crest, src_struc_t_breach, src_struc_z_min, &
+   !$acc               src_struc_B0, src_struc_t0, src_struc_dike_core, &
+   !$acc               src_struc_breach_width, src_struc_breach_level, &
+   !$acc               src_struc_distance, src_struc_fraction_open, &
+   !$acc               src_struc_rule_start, src_struc_rule_count, rule_list_op, rule_list_id, &
+   !$acc               rule_opcode, rule_atom, rule_cmp, rule_threshold, rule_start, rule_length, &
    !$acc               z_index_wavemaker, wavemaker_uvmean, wavemaker_nmd, wavemaker_nmu, wavemaker_ndm, wavemaker_num, &
    !$acc               wavemaker_index_uv, wavemaker_index_nmi, wavemaker_index_nmb, &
    !$acc               wavemaker_idir, wavemaker_angfac, wavemaker_uvtrend, &
@@ -40,7 +65,13 @@ contains
    !$acc               gnapp2, &
    !$acc               timestep_analysis_required_timestep, timestep_analysis_average_required_timestep, timestep_analysis_times_wet, timestep_analysis_times_limiting, &
    !$acc               qinffield, qinfmap, cuminf, scs_rain, scs_Se, scs_P1, scs_F1, scs_S1, rain_T1, &
-   !$acc               ksfield, GA_head, GA_sigma, GA_sigma_max, GA_F, GA_Lu, inf_kr, horton_kd, horton_fc, horton_f0 )
+   !$acc               ksfield, GA_head, GA_sigma, GA_sigma_max, GA_F, GA_Lu, inf_kr, horton_kd, horton_fc, horton_f0, &
+   !$acc               bucket_volume, bucket_capacity, bucket_k, bucket_drain_rate, bucket_loss, bucket_runoff, &
+   !$acc               urban_drainage_zone_indices, urban_drainage_outfall_index, urban_drainage_qmax, urban_drainage_backflow_coef, &
+   !$acc               urban_drainage_q_total, urban_drainage_cumulative_volume, &
+   !$acc               urb_zone_type_id, urb_zone_injection_rate, urb_zone_maximum_capacity, &
+   !$acc               urb_zone_cumulative_injection, &
+   !$acc               urb_zone_h_threshold, urb_zone_check_valve, urb_zone_dh_design_min )
    !
    end subroutine
    !
@@ -55,7 +86,21 @@ contains
    !$acc               z_index_uv_md, z_index_uv_nd, z_index_uv_mu, z_index_uv_nu, &
    !$acc               uv_index_z_nm, uv_index_z_nmu, uv_index_u_nmd, uv_index_u_nmu, uv_index_u_ndm, uv_index_u_num, &
    !$acc               uv_index_v_ndm, uv_index_v_ndmu, uv_index_v_nm, uv_index_v_nmu, &
-   !$acc               nmindsrc, qtsrc, drainage_type, drainage_params, &
+   !$acc               qsrc, qtsrc, src_struc_q_now, nmindsrc, src_struc_nm_s1, src_struc_nm_s2, src_struc_type, &
+   !$acc               src_struc_direction, &
+   !$acc               src_struc_nm_o1, src_struc_nm_o2, &
+   !$acc               src_struc_q, src_struc_flow_coef, &
+   !$acc               src_struc_width, src_struc_sill_elevation, src_struc_mannings_n, &
+   !$acc               src_struc_opening_duration, src_struc_closing_duration, &
+   !$acc               src_struc_height, &
+   !$acc               src_struc_invert_1, src_struc_invert_2, &
+   !$acc               src_struc_submergence_ratio, &
+   !$acc               src_struc_z_crest, src_struc_t_breach, src_struc_z_min, &
+   !$acc               src_struc_B0, src_struc_t0, src_struc_dike_core, &
+   !$acc               src_struc_breach_width, src_struc_breach_level, &
+   !$acc               src_struc_distance, src_struc_fraction_open, &
+   !$acc               src_struc_rule_start, src_struc_rule_count, rule_list_op, rule_list_id, &
+   !$acc               rule_opcode, rule_atom, rule_cmp, rule_threshold, rule_start, rule_length, &
    !$acc               z_index_wavemaker, wavemaker_uvmean, wavemaker_nmd, wavemaker_nmu, wavemaker_ndm, wavemaker_num, &
    !$acc               wavemaker_index_uv, wavemaker_index_nmi, wavemaker_index_nmb, &
    !$acc               wavemaker_idir, wavemaker_angfac, wavemaker_uvtrend, &
@@ -66,7 +111,7 @@ contains
    !$acc               tauwu, tauwv, tauwu0, tauwv0, tauwu1, tauwv1, &
    !$acc               windu, windv, windu0, windv0, windu1, windv1, windmax, &
    !$acc               patm, patm0, patm1, patmb, nmindbnd, &
-   !$acc               prcp, prcp0, prcp1, cumprcp, netprcp, prcp, qext, &
+   !$acc               prcp, prcp0, prcp1, cumprcp, qext, &
    !$acc               dxminv, dxrinv, dyrinv, dxm2inv, dxr2inv, dyr2inv, dxrinvc, dxm, dxrm, dyrm, cell_area_m2, cell_area, &
    !$acc               gn2uv, fcorio2d, storage_volume, nuvisc, &
    !$acc               cuv_index_uv, cuv_index_uv1, cuv_index_uv2, &
@@ -74,8 +119,14 @@ contains
    !$acc               gnapp2, &
    !$acc               timestep_analysis_required_timestep, timestep_analysis_average_required_timestep, timestep_analysis_times_wet, timestep_analysis_times_limiting, &   
    !$acc               qinffield, qinfmap, cuminf, scs_rain, scs_Se, scs_P1, scs_F1, scs_S1, rain_T1, &
-   !$acc               ksfield, GA_head, GA_sigma, GA_sigma_max, GA_F, GA_Lu, inf_kr, horton_kd, horton_fc, horton_f0 )
+   !$acc               ksfield, GA_head, GA_sigma, GA_sigma_max, GA_F, GA_Lu, inf_kr, horton_kd, horton_fc, horton_f0, &
+   !$acc               bucket_volume, bucket_capacity, bucket_k, bucket_drain_rate, bucket_loss, bucket_runoff, &
+   !$acc               urban_drainage_zone_indices, urban_drainage_outfall_index, urban_drainage_qmax, urban_drainage_backflow_coef, &
+   !$acc               urban_drainage_q_total, urban_drainage_cumulative_volume, &
+   !$acc               urb_zone_type_id, urb_zone_injection_rate, urb_zone_maximum_capacity, &
+   !$acc               urb_zone_cumulative_injection, &
+   !$acc               urb_zone_h_threshold, urb_zone_check_valve, urb_zone_dh_design_min )
    !
-   end subroutine finalize_openacc
+   end
    !
 end module

--- a/source/src/sfincs_output.f90
+++ b/source/src/sfincs_output.f90
@@ -20,11 +20,7 @@ module sfincs_output
    if (dtmapout>1.0e-6) then
       tmapout     = t0out
       if (outputtype_map == 'net') then
-         if (use_quadtree) then
-            call ncoutput_quadtree_map_init()
-         else
-            call ncoutput_regular_map_init()
-         endif         
+         call ncoutput_map_init()
       else    
          call open_map_output()       
       endif      
@@ -149,11 +145,7 @@ module sfincs_output
       !
       if (outputtype_map == 'net') then
          !
-         if (use_quadtree) then
-            call ncoutput_update_quadtree_map(t, ntmapout)
-         else
-            call ncoutput_update_regular_map(t, ntmapout)
-         endif
+         call ncoutput_update_map(t, ntmapout)
          !
       else
          !
@@ -198,11 +190,7 @@ module sfincs_output
       !
       if (outputtype_map == 'net') then
          !
-         if (use_quadtree) then
-            call ncoutput_update_quadtree_max(t, ntmaxout)
-         else   
-            call ncoutput_update_max(t, ntmaxout)
-         endif   
+         call ncoutput_update_max(t, ntmaxout)
          !      
       else
          !      

--- a/source/src/sfincs_output.f90
+++ b/source/src/sfincs_output.f90
@@ -8,6 +8,7 @@ module sfincs_output
    subroutine initialize_output(tmapout,tmaxout,thisout, trstout)
    !
    use sfincs_data
+   use sfincs_src_structures, only: nr_src_structures
    !
    implicit none
    !
@@ -62,7 +63,7 @@ module sfincs_output
    !
    ! Create his file if either observation points, cross-sections, structures or drains present
    !
-   if (dthisout>1.0e-6 .and. (nobs>0 .or. nrcrosssections>0 .or. nrstructures>0 .or. nrthindams>0 .or. ndrn>0 .or. nr_runup_gauges>0 )) then
+   if (dthisout>1.0e-6 .and. (nobs>0 .or. nrcrosssections>0 .or. nrstructures>0 .or. nrthindams>0 .or. nr_src_structures>0 .or. nr_runup_gauges>0 )) then
       !
       thisout     = t0
       !
@@ -84,25 +85,26 @@ module sfincs_output
    subroutine write_output(t,write_map,write_his,write_max,write_rst,ntmapout,ntmaxout,nthisout,tloop)
    !
    use sfincs_data
+   use sfincs_src_structures, only: nr_src_structures
    !
    implicit none
+   !
+   logical  :: write_map
+   logical  :: write_max
+   logical  :: write_his
+   logical  :: write_rst
+   !
+   integer  :: ntmapout
+   integer  :: ntmaxout
+   integer  :: nthisout
+   !
+   real*8   :: t
+   real     :: tloop
    !
    integer  :: count0
    integer  :: count1
    integer  :: count_rate
    integer  :: count_max
-   real     :: tloop
-   !
-   logical  :: write_map   
-   logical  :: write_max
-   logical  :: write_his   
-   logical  :: write_rst   
-   !
-   integer  :: ntmapout 
-   integer  :: ntmaxout
-   integer  :: nthisout      
-   !
-   real*8   :: t
    !
    call system_clock(count0, count_rate, count_max)
    !
@@ -250,7 +252,7 @@ module sfincs_output
    !      
    ! Water level time series
    !
-   if (write_his .and. (nobs>0 .or. nrcrosssections>0 .or. nr_runup_gauges>0)) then
+   if (write_his .and. (nobs>0 .or. nrcrosssections>0 .or. nr_src_structures>0 .or. nr_runup_gauges>0)) then
       !      
       if (outputtype_his == 'net') then
          !      
@@ -266,10 +268,10 @@ module sfincs_output
    !
    call system_clock(count1, count_rate, count_max)
    tloop = tloop + 1.0*(count1 - count0)/count_rate
-   !   
+   !
    end subroutine
-   
-   subroutine finalize_output(t, ntmaxout, tloopoutput, tmaxout)
+
+   subroutine finalize_output(t, ntmaxout, tloop, tmaxout)
    !
    use sfincs_data
    !
@@ -277,17 +279,17 @@ module sfincs_output
    !
    integer  :: ntmaxout
    real*8   :: t, t2
-   real     :: tloopoutput 
-   real*8   :: tmaxout   
-   !   
-   if (dtmaxout>1.e-6 .and. ntmaxout == 0) then 
-       !write dtmax output if 1) value for dtmaxout wasn't achieved yet, 
+   real*8   :: tmaxout
+   real     :: tloop
+   !
+   if (dtmaxout>1.e-6 .and. ntmaxout == 0) then
+       !write dtmax output if 1) value for dtmaxout wasn't achieved yet,
        !or 2) in the last timeinterval, the full 'dtmaxout' wasn't achieved yet, but we still want the max over this interval
-      ! 
+      !
       call write_log('', 1)
       call write_log('Info : Write maximum values at final timestep since t=dtmaxout was not reached yet...', 1)
       ntmaxout = 1
-      call write_output(t,.false.,.false.,.true.,.false.,0,ntmaxout,0,tloopoutput)
+      call write_output(t,.false.,.false.,.true.,.false.,0,ntmaxout,0,tloop)
       !
    elseif (dtmaxout>1.e-6 .and. ntmaxout>0 .and. t < tmaxout) then
       !
@@ -298,7 +300,7 @@ module sfincs_output
       ! Write 'tstop' as timemax instead of actual (unrounded) 't'
       t2 = t1
       !
-      call write_output(t2,.false.,.false.,.true.,.false.,0,ntmaxout,0,tloopoutput)       
+      call write_output(t2,.false.,.false.,.true.,.false.,0,ntmaxout,0,tloop)
       !
    endif
    !
@@ -579,6 +581,8 @@ module sfincs_output
    subroutine open_his_output()
    !
    use sfincs_data
+   use sfincs_src_structures, only: nr_src_structures
+   use sfincs_discharges,     only: nr_discharge_points
    !
    implicit none
    !
@@ -592,7 +596,11 @@ module sfincs_output
       open(unit = 966, file = trim('qt.txt'))
       close(unit = 966 ,status='delete')
    endif
-   if (nsrcdrn>0) then
+   if (nr_discharge_points>0) then
+      open(unit = 969, file = trim('qriver.txt'))
+      close(unit = 969 ,status='delete')
+   endif
+   if (nr_src_structures>0) then
       open(unit = 970, file = trim('qdrain.txt'))
       close(unit = 970 ,status='delete')
    endif
@@ -606,6 +614,8 @@ module sfincs_output
    !
    use sfincs_data
    use sfincs_crosssections
+   use sfincs_src_structures, only: nr_src_structures, src_struc_q_now
+   use sfincs_discharges,     only: qtsrc, nr_discharge_points
    !
    implicit none
    !
@@ -657,10 +667,17 @@ module sfincs_output
       !
    endif
    !
-   if (ndrn>0 .and. store_qdrain) then
+   if (nr_discharge_points>0) then
       !$acc update host(qtsrc)
+      open(unit = 969, file = trim('qriver.txt'), access='append')
+      write(969,'(f12.1,10000f9.3)')t,(qtsrc(iobs), iobs = 1, nr_discharge_points)
+      close(969)
+   endif
+   !
+   if (nr_src_structures>0 .and. store_qdrain) then
+      !$acc update host(src_struc_q_now)
       open(unit = 970, file = trim('qdrain.txt'), access='append')
-      write(970,'(f12.1,10000f9.3)')t,(qtsrc(iobs), iobs = nsrc + 1, nsrcdrn, 2)
+      write(970,'(f12.1,10000f9.3)')t,(src_struc_q_now(iobs), iobs = 1, nr_src_structures)
       close(970)
    endif
    !

--- a/source/src/sfincs_rule_expression.f90
+++ b/source/src/sfincs_rule_expression.f90
@@ -1,0 +1,1187 @@
+module sfincs_rule_expression
+   !
+   ! Boolean rule mini-language used by gate-like src_structures to decide
+   ! when to open or close. The grammar is:
+   !
+   !    expr     := or_expr
+   !    or_expr  := and_expr ( '|' and_expr )*
+   !    and_expr := comp     ( '&' comp     )*
+   !    comp     := '(' expr ')' | atom cmp_op number
+   !    atom     := 'z1' | 'z2' | 'z2-z1' | 'z1-z2'  (case-insensitive)
+   !    cmp_op   := '<' | '>' | '<=' | '>=' | '=' | '=='
+   !    number   := real literal
+   !
+   ! Precedence: paren > comp > '&' > '|'. Left-associative.
+   !
+   ! Each rule is compiled to a reverse-polish bytecode stream in four
+   ! parallel module-level arrays (opcode / atom / cmp / threshold) and
+   ! registered in a small parallel (start, length) registry indexed by
+   ! integer rule_id. Callers keep only that rule_id per-structure; the
+   ! module owns both the op stream (so all rules across all structures
+   ! concatenate into one buffer) and the registry.
+   !
+   ! The evaluator is a small fixed-depth logical stack machine that is
+   ! ACC-safe (no allocations, no strings, no I/O).
+   !
+   implicit none
+   !
+   private
+   !
+   ! Public bytecode storage. These four parallel arrays hold the
+   ! concatenated op streams for every rule that has been parsed. They
+   ! are public so sfincs_openacc can name them in !$acc directives.
+   !
+   public :: rule_opcode, rule_atom, rule_cmp, rule_threshold, rule_n_ops
+   !
+   ! Public rule registry. rule_start(id) / rule_length(id) index into
+   ! the op streams above. n_rules is the highest rule_id currently
+   ! allocated; entries at index 0 are not used (rule_id == 0 is the
+   ! "no rule" sentinel).
+   !
+   public :: rule_start, rule_length, n_rules
+   !
+   ! Public API.
+   !
+   public :: add_rule, evaluate_rule, finalize_rule_storage
+   !
+   ! ---------------------------------------------------------------
+   ! Opcodes.
+   !
+   integer, parameter :: op_cmp               = 1
+   integer, parameter :: op_and               = 2
+   integer, parameter :: op_or                = 3
+   !
+   ! Atom codes (the z value being compared).
+   !
+   integer, parameter :: atom_z1              = 1
+   integer, parameter :: atom_z2              = 2
+   integer, parameter :: atom_z2_minus_z1     = 3
+   integer, parameter :: atom_z1_minus_z2     = 4
+   !
+   ! Comparator codes.
+   !
+   integer, parameter :: cmp_lt               = 1
+   integer, parameter :: cmp_gt               = 2
+   integer, parameter :: cmp_le               = 3
+   integer, parameter :: cmp_ge               = 4
+   integer, parameter :: cmp_eq               = 5
+   !
+   ! Parser / evaluator capacity limits.
+   !
+   integer, parameter :: expr_stack_max        = 16   ! evaluator logical-stack depth
+   integer, parameter :: expr_ops_max_per_rule = 64   ! max bytecode length per rule (parser rejects longer)
+   integer, parameter :: expr_tokens_max       = 128  ! max tokens in a single rule string
+   !
+   ! ---------------------------------------------------------------
+   ! Shared bytecode storage.
+   !
+   ! add_rule appends into these arrays and auto-grows them. Handles
+   ! (rule_start, rule_length) in the registry index into them.
+   !
+   integer, allocatable, save :: rule_opcode(:)
+   integer, allocatable, save :: rule_atom(:)
+   integer, allocatable, save :: rule_cmp(:)
+   real,    allocatable, save :: rule_threshold(:)
+   integer,              save :: rule_n_ops    = 0
+   integer,              save :: rule_capacity = 0
+   !
+   ! Rule registry. Indexed by rule_id in [1 .. n_rules]. rule_id == 0
+   ! is the "never fires" sentinel and has no registry entry.
+   !
+   integer, allocatable, save :: rule_start(:)
+   integer, allocatable, save :: rule_length(:)
+   integer,              save :: n_rules                = 0
+   integer,              save :: rule_registry_capacity = 0
+   !
+   integer, parameter :: initial_capacity          = 256
+   integer, parameter :: initial_registry_capacity = 16
+   !
+contains
+   !
+   !
+   subroutine add_rule(src, rule_id, ierr, errmsg)
+   !
+   ! Parse the boolean expression in src, append its bytecode to the
+   ! module-level rule_* arrays, and register a new rule entry that
+   ! points at it. Returns the new rule_id. An empty or whitespace-only
+   ! src returns rule_id = 0 (the "never fires" sentinel; no registry
+   ! entry is created). On parse failure ierr /= 0, rule_id = 0, and
+   ! errmsg carries the diagnostic.
+   !
+   implicit none
+   !
+   character(len=*),           intent(in)  :: src
+   integer,                    intent(out) :: rule_id
+   integer,                    intent(out) :: ierr
+   character(len=*), optional, intent(out) :: errmsg
+   !
+   ! Per-call scratch buffers for the parsed bytecode; sized to the
+   ! parser's per-rule cap. Copied into the module storage on success.
+   !
+   integer           :: ops_buf   (expr_ops_max_per_rule)
+   integer           :: atoms_buf (expr_ops_max_per_rule)
+   integer           :: cmps_buf  (expr_ops_max_per_rule)
+   real              :: thr_buf   (expr_ops_max_per_rule)
+   integer           :: nops, new_start
+   character(len=256):: local_errmsg
+   !
+   character(len=len(src)) :: src_nospace
+   integer                 :: ic, ip, jp
+   !
+   rule_id = 0
+   ierr    = 0
+   if (present(errmsg)) errmsg = ''
+   !
+   ! Empty / whitespace-only source: never fires, no registry entry.
+   !
+   if (len_trim(src) == 0) return
+   !
+   ! Strip all whitespace (space, tab, LF, CR) so callers can write
+   ! 'z1 < 0.5' or 'z2 - z1 > 0.05' as freely as 'z1<0.5' / 'z2-z1>0.05'.
+   !
+   jp = 0
+   do ip = 1, len(src)
+      !
+      ic = iachar(src(ip:ip))
+      !
+      if (ic /= iachar(' ') .and. ic /= 9 .and. ic /= 10 .and. ic /= 13) then
+         !
+         jp = jp + 1
+         src_nospace(jp:jp) = src(ip:ip)
+         !
+      endif
+      !
+   enddo
+   !
+   if (jp == 0) return
+   !
+   call parse_rule_expression(src_nospace(1:jp), ops_buf, atoms_buf, cmps_buf, thr_buf, &
+        nops, ierr, local_errmsg)
+   !
+   if (ierr /= 0) then
+      !
+      if (present(errmsg)) errmsg = local_errmsg
+      return
+      !
+   endif
+   !
+   if (nops <= 0) then
+      !
+      ierr = 1
+      if (present(errmsg)) errmsg = 'rule parse produced no ops'
+      return
+      !
+   endif
+   !
+   ! Ensure the op stream has room for the new ops.
+   !
+   call grow_rule_storage(rule_n_ops + nops)
+   !
+   new_start = rule_n_ops + 1
+   !
+   rule_opcode   (new_start : new_start + nops - 1) = ops_buf  (1:nops)
+   rule_atom     (new_start : new_start + nops - 1) = atoms_buf(1:nops)
+   rule_cmp      (new_start : new_start + nops - 1) = cmps_buf (1:nops)
+   rule_threshold(new_start : new_start + nops - 1) = thr_buf  (1:nops)
+   !
+   rule_n_ops = rule_n_ops + nops
+   !
+   ! Register the new rule and return its id.
+   !
+   call grow_rule_registry(n_rules + 1)
+   !
+   n_rules             = n_rules + 1
+   rule_start(n_rules) = new_start
+   rule_length(n_rules)= nops
+   rule_id             = n_rules
+   !
+   end subroutine
+   !
+   !
+   subroutine finalize_rule_storage()
+   !
+   ! Shrink the rule_* op streams to exactly rule_n_ops and the registry
+   ! to exactly n_rules. If nothing was ever allocated (no rules parsed)
+   ! everything is allocated to size 0 so downstream openacc directives
+   ! can reference the arrays safely.
+   !
+   implicit none
+   !
+   integer, allocatable :: tmp_i(:)
+   real,    allocatable :: tmp_r(:)
+   !
+   ! Op streams.
+   !
+   if (.not. allocated(rule_opcode)) then
+      !
+      allocate(rule_opcode(0))
+      allocate(rule_atom(0))
+      allocate(rule_cmp(0))
+      allocate(rule_threshold(0))
+      rule_capacity = 0
+      rule_n_ops    = 0
+      !
+   else if (rule_capacity /= rule_n_ops) then
+      !
+      allocate(tmp_i(rule_n_ops))
+      if (rule_n_ops > 0) tmp_i = rule_opcode(1:rule_n_ops)
+      call move_alloc(tmp_i, rule_opcode)
+      !
+      allocate(tmp_i(rule_n_ops))
+      if (rule_n_ops > 0) tmp_i = rule_atom(1:rule_n_ops)
+      call move_alloc(tmp_i, rule_atom)
+      !
+      allocate(tmp_i(rule_n_ops))
+      if (rule_n_ops > 0) tmp_i = rule_cmp(1:rule_n_ops)
+      call move_alloc(tmp_i, rule_cmp)
+      !
+      allocate(tmp_r(rule_n_ops))
+      if (rule_n_ops > 0) tmp_r = rule_threshold(1:rule_n_ops)
+      call move_alloc(tmp_r, rule_threshold)
+      !
+      rule_capacity = rule_n_ops
+      !
+   endif
+   !
+   ! Registry.
+   !
+   if (.not. allocated(rule_start)) then
+      !
+      allocate(rule_start(0))
+      allocate(rule_length(0))
+      rule_registry_capacity = 0
+      n_rules                = 0
+      !
+   else if (rule_registry_capacity /= n_rules) then
+      !
+      allocate(tmp_i(n_rules))
+      if (n_rules > 0) tmp_i = rule_start(1:n_rules)
+      call move_alloc(tmp_i, rule_start)
+      !
+      allocate(tmp_i(n_rules))
+      if (n_rules > 0) tmp_i = rule_length(1:n_rules)
+      call move_alloc(tmp_i, rule_length)
+      !
+      rule_registry_capacity = n_rules
+      !
+   endif
+   !
+   end subroutine
+   !
+   !
+   pure function evaluate_rule(rule_id, z1, z2) result(fired)
+   !
+   ! Fixed-depth stack machine that evaluates a compiled rule against
+   ! the two water levels z1 (intake) and z2 (outfall). A rule_id of 0
+   ! short-circuits to .false. ("never fires").
+   !
+   !$acc routine seq
+   !
+   implicit none
+   !
+   integer, intent(in) :: rule_id
+   real,    intent(in) :: z1, z2
+   logical             :: fired
+   !
+   logical :: stack(expr_stack_max)
+   integer :: sp, k, idx, rs, rl
+   real    :: zval
+   logical :: a, b
+   !
+   fired = .false.
+   !
+   if (rule_id <= 0) return
+   !
+   rs = rule_start(rule_id)
+   rl = rule_length(rule_id)
+   !
+   if (rl <= 0) return
+   !
+   sp = 0
+   !
+   do k = 1, rl
+      !
+      idx = rs + k - 1
+      !
+      select case (rule_opcode(idx))
+         !
+         case (op_cmp)
+            !
+            select case (rule_atom(idx))
+               !
+               case (atom_z1)
+                  !
+                  zval = z1
+                  !
+               case (atom_z2)
+                  !
+                  zval = z2
+                  !
+               case (atom_z2_minus_z1)
+                  !
+                  zval = z2 - z1
+                  !
+               case (atom_z1_minus_z2)
+                  !
+                  zval = z1 - z2
+                  !
+               case default
+                  !
+                  zval = 0.0
+                  !
+            end select
+            !
+            if (sp >= expr_stack_max) return
+            sp = sp + 1
+            !
+            select case (rule_cmp(idx))
+               !
+               case (cmp_lt)
+                  !
+                  stack(sp) = zval < rule_threshold(idx)
+                  !
+               case (cmp_gt)
+                  !
+                  stack(sp) = zval > rule_threshold(idx)
+                  !
+               case (cmp_le)
+                  !
+                  stack(sp) = zval <= rule_threshold(idx)
+                  !
+               case (cmp_ge)
+                  !
+                  stack(sp) = zval >= rule_threshold(idx)
+                  !
+               case (cmp_eq)
+                  !
+                  stack(sp) = zval == rule_threshold(idx)
+                  !
+               case default
+                  !
+                  stack(sp) = .false.
+                  !
+            end select
+            !
+         case (op_and)
+            !
+            b = stack(sp)
+            a = stack(sp - 1)
+            sp = sp - 1
+            stack(sp) = a .and. b
+            !
+         case (op_or)
+            !
+            b = stack(sp)
+            a = stack(sp - 1)
+            sp = sp - 1
+            stack(sp) = a .or. b
+            !
+      end select
+      !
+   enddo
+   !
+   if (sp >= 1) fired = stack(1)
+   !
+   end function
+   !
+   !
+   subroutine grow_rule_storage(min_capacity)
+   !
+   ! Ensure rule_capacity >= min_capacity. On first growth, allocates to
+   ! max(initial_capacity, min_capacity). On subsequent growth, doubles
+   ! until the requested capacity fits. Existing contents are preserved.
+   !
+   implicit none
+   !
+   integer, intent(in) :: min_capacity
+   !
+   integer :: new_capacity
+   integer, allocatable :: tmp_i(:)
+   real,    allocatable :: tmp_r(:)
+   !
+   if (.not. allocated(rule_opcode)) then
+      !
+      new_capacity = max(initial_capacity, min_capacity)
+      allocate(rule_opcode   (new_capacity))
+      allocate(rule_atom     (new_capacity))
+      allocate(rule_cmp      (new_capacity))
+      allocate(rule_threshold(new_capacity))
+      rule_capacity = new_capacity
+      return
+      !
+   endif
+   !
+   if (min_capacity <= rule_capacity) return
+   !
+   new_capacity = max(2 * rule_capacity, min_capacity)
+   !
+   allocate(tmp_i(new_capacity))
+   if (rule_n_ops > 0) tmp_i(1:rule_n_ops) = rule_opcode(1:rule_n_ops)
+   call move_alloc(tmp_i, rule_opcode)
+   !
+   allocate(tmp_i(new_capacity))
+   if (rule_n_ops > 0) tmp_i(1:rule_n_ops) = rule_atom(1:rule_n_ops)
+   call move_alloc(tmp_i, rule_atom)
+   !
+   allocate(tmp_i(new_capacity))
+   if (rule_n_ops > 0) tmp_i(1:rule_n_ops) = rule_cmp(1:rule_n_ops)
+   call move_alloc(tmp_i, rule_cmp)
+   !
+   allocate(tmp_r(new_capacity))
+   if (rule_n_ops > 0) tmp_r(1:rule_n_ops) = rule_threshold(1:rule_n_ops)
+   call move_alloc(tmp_r, rule_threshold)
+   !
+   rule_capacity = new_capacity
+   !
+   end subroutine
+   !
+   !
+   subroutine grow_rule_registry(min_capacity)
+   !
+   ! Ensure rule_registry_capacity >= min_capacity. On first growth,
+   ! allocates to max(initial_registry_capacity, min_capacity). On
+   ! subsequent growth, doubles until the requested capacity fits.
+   ! Existing contents are preserved.
+   !
+   implicit none
+   !
+   integer, intent(in) :: min_capacity
+   !
+   integer :: new_capacity
+   integer, allocatable :: tmp_i(:)
+   !
+   if (.not. allocated(rule_start)) then
+      !
+      new_capacity = max(initial_registry_capacity, min_capacity)
+      allocate(rule_start (new_capacity))
+      allocate(rule_length(new_capacity))
+      rule_registry_capacity = new_capacity
+      return
+      !
+   endif
+   !
+   if (min_capacity <= rule_registry_capacity) return
+   !
+   new_capacity = max(2 * rule_registry_capacity, min_capacity)
+   !
+   allocate(tmp_i(new_capacity))
+   if (n_rules > 0) tmp_i(1:n_rules) = rule_start(1:n_rules)
+   call move_alloc(tmp_i, rule_start)
+   !
+   allocate(tmp_i(new_capacity))
+   if (n_rules > 0) tmp_i(1:n_rules) = rule_length(1:n_rules)
+   call move_alloc(tmp_i, rule_length)
+   !
+   rule_registry_capacity = new_capacity
+   !
+   end subroutine
+   !
+   !
+   subroutine parse_rule_expression(src, ops, atoms, cmps, thresholds, nops, ierr, errmsg)
+   !
+   ! Recursive-descent parser that compiles a rule string to reverse-
+   ! polish bytecode in four parallel arrays. op_cmp entries use all
+   ! three of atoms / cmps / thresholds; op_and / op_or use only opcode.
+   !
+   implicit none
+   !
+   character(len=*), intent(in)  :: src
+   integer,          intent(out) :: ops(:)
+   integer,          intent(out) :: atoms(:)
+   integer,          intent(out) :: cmps(:)
+   real,             intent(out) :: thresholds(:)
+   integer,          intent(out) :: nops
+   integer,          intent(out) :: ierr
+   character(len=*), intent(out) :: errmsg
+   !
+   ! Token kinds:
+   !   1 = ident (z1/z2/z2-z1/z1-z2)  payload: atom code in tok_atom
+   !   2 = number                 payload: real in tok_num
+   !   3 = lparen
+   !   4 = rparen
+   !   5 = and
+   !   6 = or
+   !   7 = lt
+   !   8 = gt
+   !   9 = le
+   !  10 = ge
+   !  11 = eq
+   !
+   integer :: tok_kind(expr_tokens_max)
+   integer :: tok_atom(expr_tokens_max)
+   real    :: tok_num (expr_tokens_max)
+   integer :: tok_pos (expr_tokens_max)
+   integer :: n_tokens, ip
+   !
+   nops   = 0
+   ierr   = 0
+   errmsg = ''
+   !
+   call tokenize_rule(src, tok_kind, tok_atom, tok_num, tok_pos, n_tokens, ierr, errmsg)
+   !
+   if (ierr /= 0) return
+   !
+   if (n_tokens == 0) then
+      !
+      ierr   = 1
+      errmsg = 'empty rule expression'
+      return
+      !
+   endif
+   !
+   ip = 1
+   !
+   call parse_or_expr(tok_kind, tok_atom, tok_num, tok_pos, n_tokens, ip, &
+        ops, atoms, cmps, thresholds, nops, ierr, errmsg)
+   !
+   if (ierr /= 0) return
+   !
+   if (ip <= n_tokens) then
+      !
+      ierr = 1
+      write(errmsg,'(a,i0)') 'unexpected trailing token at position ', tok_pos(ip)
+      return
+      !
+   endif
+   !
+   end subroutine
+   !
+   !
+   subroutine tokenize_rule(src, tok_kind, tok_atom, tok_num, tok_pos, n_tokens, ierr, errmsg)
+   !
+   ! One-pass tokenizer. Emits fixed-size parallel arrays: kind, atom
+   ! code, number value, source position. Token kinds match the
+   ! parameters above in parse_rule_expression.
+   !
+   implicit none
+   !
+   character(len=*), intent(in)    :: src
+   integer,          intent(out)   :: tok_kind(:)
+   integer,          intent(out)   :: tok_atom(:)
+   real,             intent(out)   :: tok_num(:)
+   integer,          intent(out)   :: tok_pos(:)
+   integer,          intent(out)   :: n_tokens
+   integer,          intent(inout) :: ierr
+   character(len=*), intent(inout) :: errmsg
+   !
+   integer, parameter :: tok_ident  = 1
+   integer, parameter :: tok_number = 2
+   integer, parameter :: tok_lparen = 3
+   integer, parameter :: tok_rparen = 4
+   integer, parameter :: tok_and    = 5
+   integer, parameter :: tok_or     = 6
+   integer, parameter :: tok_lt     = 7
+   integer, parameter :: tok_gt     = 8
+   integer, parameter :: tok_le     = 9
+   integer, parameter :: tok_ge     = 10
+   integer, parameter :: tok_eq     = 11
+   !
+   integer :: pos, slen, start, kstart, ic, atom_code, iostat_read
+   character(len=:), allocatable :: lower
+   character(len=32) :: num_buf
+   logical :: matched
+   !
+   lower    = to_lower_local(src)
+   slen     = len(lower)
+   pos      = 1
+   n_tokens = 0
+   !
+   do while (pos <= slen)
+      !
+      ! Skip whitespace.
+      !
+      ic = iachar(lower(pos:pos))
+      !
+      if (ic == iachar(' ') .or. ic == 9 .or. ic == 10 .or. ic == 13) then
+         !
+         pos = pos + 1
+         cycle
+         !
+      endif
+      !
+      if (n_tokens >= expr_tokens_max) then
+         !
+         ierr = 1
+         write(errmsg,'(a,i0,a)') 'too many tokens (>', expr_tokens_max, ') in rule expression'
+         return
+         !
+      endif
+      !
+      start = pos
+      !
+      ! Single-character tokens.
+      !
+      matched = .true.
+      !
+      select case (lower(pos:pos))
+         !
+         case ('(')
+            !
+            n_tokens = n_tokens + 1
+            tok_kind(n_tokens) = tok_lparen
+            tok_pos (n_tokens) = start
+            pos = pos + 1
+            !
+         case (')')
+            !
+            n_tokens = n_tokens + 1
+            tok_kind(n_tokens) = tok_rparen
+            tok_pos (n_tokens) = start
+            pos = pos + 1
+            !
+         case ('&')
+            !
+            n_tokens = n_tokens + 1
+            tok_kind(n_tokens) = tok_and
+            tok_pos (n_tokens) = start
+            pos = pos + 1
+            !
+         case ('|')
+            !
+            n_tokens = n_tokens + 1
+            tok_kind(n_tokens) = tok_or
+            tok_pos (n_tokens) = start
+            pos = pos + 1
+            !
+         case ('<')
+            !
+            n_tokens = n_tokens + 1
+            tok_pos (n_tokens) = start
+            if (pos + 1 <= slen .and. lower(min(pos+1,slen):min(pos+1,slen)) == '=') then
+               !
+               tok_kind(n_tokens) = tok_le
+               pos = pos + 2
+               !
+            else
+               !
+               tok_kind(n_tokens) = tok_lt
+               pos = pos + 1
+               !
+            endif
+            !
+         case ('>')
+            !
+            n_tokens = n_tokens + 1
+            tok_pos (n_tokens) = start
+            if (pos + 1 <= slen .and. lower(min(pos+1,slen):min(pos+1,slen)) == '=') then
+               !
+               tok_kind(n_tokens) = tok_ge
+               pos = pos + 2
+               !
+            else
+               !
+               tok_kind(n_tokens) = tok_gt
+               pos = pos + 1
+               !
+            endif
+            !
+         case ('=')
+            !
+            n_tokens = n_tokens + 1
+            tok_kind(n_tokens) = tok_eq
+            tok_pos (n_tokens) = start
+            if (pos + 1 <= slen .and. lower(min(pos+1,slen):min(pos+1,slen)) == '=') then
+               !
+               pos = pos + 2
+               !
+            else
+               !
+               pos = pos + 1
+               !
+            endif
+            !
+         case default
+            !
+            matched = .false.
+            !
+      end select
+      !
+      if (matched) cycle
+      !
+      ! Number: optional sign is not part of the grammar (z2-z1 is a
+      ! fixed atom, not arithmetic). A leading '-' or '+' is only
+      ! treated as a number's sign when the next char is digit or dot.
+      !
+      ic = iachar(lower(pos:pos))
+      !
+      if (ic == iachar('-') .or. ic == iachar('+') .or. &
+          ic == iachar('.') .or. (ic >= iachar('0') .and. ic <= iachar('9'))) then
+         !
+         if (lower(pos:pos) == '-' .or. lower(pos:pos) == '+') then
+            !
+            if (pos + 1 > slen) then
+               !
+               ierr = 1
+               write(errmsg,'(a,i0)') 'trailing sign without digits at position ', pos
+               return
+               !
+            endif
+            !
+            ic = iachar(lower(pos+1:pos+1))
+            !
+            if (.not. (ic == iachar('.') .or. (ic >= iachar('0') .and. ic <= iachar('9')))) then
+               !
+               ierr = 1
+               write(errmsg,'(a,a,a,i0)') 'unexpected character "', lower(pos:pos), &
+                    '" at position ', pos
+               return
+               !
+            endif
+            !
+         endif
+         !
+         kstart = pos
+         !
+         ! Leading sign.
+         !
+         if (lower(pos:pos) == '-' .or. lower(pos:pos) == '+') pos = pos + 1
+         !
+         ! Integer part.
+         !
+         do while (pos <= slen)
+            !
+            ic = iachar(lower(pos:pos))
+            if (.not. (ic >= iachar('0') .and. ic <= iachar('9'))) exit
+            pos = pos + 1
+            !
+         enddo
+         !
+         ! Fractional part.
+         !
+         if (pos <= slen) then
+            !
+            if (lower(pos:pos) == '.') then
+               !
+               pos = pos + 1
+               !
+               do while (pos <= slen)
+                  !
+                  ic = iachar(lower(pos:pos))
+                  if (.not. (ic >= iachar('0') .and. ic <= iachar('9'))) exit
+                  pos = pos + 1
+                  !
+               enddo
+               !
+            endif
+            !
+         endif
+         !
+         ! Exponent.
+         !
+         if (pos <= slen) then
+            !
+            if (lower(pos:pos) == 'e') then
+               !
+               pos = pos + 1
+               !
+               if (pos <= slen) then
+                  !
+                  if (lower(pos:pos) == '+' .or. lower(pos:pos) == '-') pos = pos + 1
+                  !
+               endif
+               !
+               do while (pos <= slen)
+                  !
+                  ic = iachar(lower(pos:pos))
+                  if (.not. (ic >= iachar('0') .and. ic <= iachar('9'))) exit
+                  pos = pos + 1
+                  !
+               enddo
+               !
+            endif
+            !
+         endif
+         !
+         num_buf = lower(kstart:pos-1)
+         !
+         read(num_buf, *, iostat=iostat_read) tok_num(n_tokens + 1)
+         !
+         if (iostat_read /= 0) then
+            !
+            ierr = 1
+            write(errmsg,'(a,a,a,i0)') 'invalid number "', trim(num_buf), &
+                 '" at position ', kstart
+            return
+            !
+         endif
+         !
+         n_tokens = n_tokens + 1
+         tok_kind(n_tokens) = tok_number
+         tok_pos (n_tokens) = kstart
+         !
+         cycle
+         !
+      endif
+      !
+      ! Identifiers: z1, z2, z2-z1, z1-z2. The 'z2-z1' / 'z1-z2' atoms
+      ! contain a '-', which would otherwise be eaten by the number path;
+      ! we match them as longest-match-first prefixes here.
+      !
+      kstart = pos
+      !
+      select case (lower(pos:pos))
+         !
+         case ('z')
+            !
+            if (pos + 4 <= slen) then
+               !
+               if (lower(pos:pos+4) == 'z2-z1') then
+                  !
+                  atom_code = atom_z2_minus_z1
+                  n_tokens = n_tokens + 1
+                  tok_kind(n_tokens) = tok_ident
+                  tok_atom(n_tokens) = atom_code
+                  tok_pos (n_tokens) = kstart
+                  pos = pos + 5
+                  cycle
+                  !
+               elseif (lower(pos:pos+4) == 'z1-z2') then
+                  !
+                  atom_code = atom_z1_minus_z2
+                  n_tokens = n_tokens + 1
+                  tok_kind(n_tokens) = tok_ident
+                  tok_atom(n_tokens) = atom_code
+                  tok_pos (n_tokens) = kstart
+                  pos = pos + 5
+                  cycle
+                  !
+               endif
+               !
+            endif
+            !
+            if (pos + 1 <= slen) then
+               !
+               if (lower(pos:pos+1) == 'z1') then
+                  !
+                  atom_code = atom_z1
+                  n_tokens = n_tokens + 1
+                  tok_kind(n_tokens) = tok_ident
+                  tok_atom(n_tokens) = atom_code
+                  tok_pos (n_tokens) = kstart
+                  pos = pos + 2
+                  cycle
+                  !
+               elseif (lower(pos:pos+1) == 'z2') then
+                  !
+                  atom_code = atom_z2
+                  n_tokens = n_tokens + 1
+                  tok_kind(n_tokens) = tok_ident
+                  tok_atom(n_tokens) = atom_code
+                  tok_pos (n_tokens) = kstart
+                  pos = pos + 2
+                  cycle
+                  !
+               endif
+               !
+            endif
+            !
+            ierr = 1
+            write(errmsg,'(a,i0)') 'unknown z-identifier at position ', pos
+            return
+            !
+         case default
+            !
+            ierr = 1
+            write(errmsg,'(a,a,a,i0)') 'unexpected character "', lower(pos:pos), &
+                 '" at position ', pos
+            return
+            !
+      end select
+      !
+   enddo
+   !
+   end subroutine
+   !
+   !
+   recursive subroutine parse_or_expr(tok_kind, tok_atom, tok_num, tok_pos, n_tokens, ip, &
+                                      ops, atoms, cmps, thresholds, nops, ierr, errmsg)
+   !
+   ! Parse an or-expression. Emits a parse_and_expr, then while the
+   ! next token is 'or', consumes it, parses another and-expression,
+   ! and emits op_or.
+   !
+   implicit none
+   !
+   integer,          intent(in)    :: tok_kind(:), tok_atom(:), tok_pos(:)
+   real,             intent(in)    :: tok_num(:)
+   integer,          intent(in)    :: n_tokens
+   integer,          intent(inout) :: ip
+   integer,          intent(inout) :: ops(:), atoms(:), cmps(:)
+   real,             intent(inout) :: thresholds(:)
+   integer,          intent(inout) :: nops
+   integer,          intent(inout) :: ierr
+   character(len=*), intent(inout) :: errmsg
+   !
+   integer, parameter :: tok_or = 6
+   !
+   call parse_and_expr(tok_kind, tok_atom, tok_num, tok_pos, n_tokens, ip, &
+        ops, atoms, cmps, thresholds, nops, ierr, errmsg)
+   if (ierr /= 0) return
+   !
+   do while (ip <= n_tokens)
+      !
+      if (tok_kind(ip) /= tok_or) exit
+      !
+      ip = ip + 1
+      !
+      call parse_and_expr(tok_kind, tok_atom, tok_num, tok_pos, n_tokens, ip, &
+           ops, atoms, cmps, thresholds, nops, ierr, errmsg)
+      if (ierr /= 0) return
+      !
+      if (nops >= expr_ops_max_per_rule) then
+         !
+         ierr = 1
+         errmsg = 'rule expression too long (op buffer full)'
+         return
+         !
+      endif
+      !
+      nops = nops + 1
+      ops(nops)        = op_or
+      atoms(nops)      = 0
+      cmps(nops)       = 0
+      thresholds(nops) = 0.0
+      !
+   enddo
+   !
+   end subroutine
+   !
+   !
+   recursive subroutine parse_and_expr(tok_kind, tok_atom, tok_num, tok_pos, n_tokens, ip, &
+                                       ops, atoms, cmps, thresholds, nops, ierr, errmsg)
+   !
+   ! Parse an and-expression. Emits a parse_comp, then while the next
+   ! token is 'and', consumes it, parses another comp, and emits op_and.
+   !
+   implicit none
+   !
+   integer,          intent(in)    :: tok_kind(:), tok_atom(:), tok_pos(:)
+   real,             intent(in)    :: tok_num(:)
+   integer,          intent(in)    :: n_tokens
+   integer,          intent(inout) :: ip
+   integer,          intent(inout) :: ops(:), atoms(:), cmps(:)
+   real,             intent(inout) :: thresholds(:)
+   integer,          intent(inout) :: nops
+   integer,          intent(inout) :: ierr
+   character(len=*), intent(inout) :: errmsg
+   !
+   integer, parameter :: tok_and = 5
+   !
+   call parse_comp(tok_kind, tok_atom, tok_num, tok_pos, n_tokens, ip, &
+        ops, atoms, cmps, thresholds, nops, ierr, errmsg)
+   if (ierr /= 0) return
+   !
+   do while (ip <= n_tokens)
+      !
+      if (tok_kind(ip) /= tok_and) exit
+      !
+      ip = ip + 1
+      !
+      call parse_comp(tok_kind, tok_atom, tok_num, tok_pos, n_tokens, ip, &
+           ops, atoms, cmps, thresholds, nops, ierr, errmsg)
+      if (ierr /= 0) return
+      !
+      if (nops >= expr_ops_max_per_rule) then
+         !
+         ierr = 1
+         errmsg = 'rule expression too long (op buffer full)'
+         return
+         !
+      endif
+      !
+      nops = nops + 1
+      ops(nops)        = op_and
+      atoms(nops)      = 0
+      cmps(nops)       = 0
+      thresholds(nops) = 0.0
+      !
+   enddo
+   !
+   end subroutine
+   !
+   !
+   recursive subroutine parse_comp(tok_kind, tok_atom, tok_num, tok_pos, n_tokens, ip, &
+                                   ops, atoms, cmps, thresholds, nops, ierr, errmsg)
+   !
+   ! Parse either a parenthesised expression or a leaf comparison
+   ! "atom <|> number". Emits op_cmp for the leaf case.
+   !
+   implicit none
+   !
+   integer,          intent(in)    :: tok_kind(:), tok_atom(:), tok_pos(:)
+   real,             intent(in)    :: tok_num(:)
+   integer,          intent(in)    :: n_tokens
+   integer,          intent(inout) :: ip
+   integer,          intent(inout) :: ops(:), atoms(:), cmps(:)
+   real,             intent(inout) :: thresholds(:)
+   integer,          intent(inout) :: nops
+   integer,          intent(inout) :: ierr
+   character(len=*), intent(inout) :: errmsg
+   !
+   integer, parameter :: tok_ident  = 1
+   integer, parameter :: tok_number = 2
+   integer, parameter :: tok_lparen = 3
+   integer, parameter :: tok_rparen = 4
+   integer, parameter :: tok_lt     = 7
+   integer, parameter :: tok_gt     = 8
+   integer, parameter :: tok_le     = 9
+   integer, parameter :: tok_ge     = 10
+   integer, parameter :: tok_eq     = 11
+   !
+   integer :: atom_code, cmp_code
+   !
+   if (ip > n_tokens) then
+      !
+      ierr   = 1
+      errmsg = 'unexpected end of expression'
+      return
+      !
+   endif
+   !
+   if (tok_kind(ip) == tok_lparen) then
+      !
+      ip = ip + 1
+      !
+      call parse_or_expr(tok_kind, tok_atom, tok_num, tok_pos, n_tokens, ip, &
+           ops, atoms, cmps, thresholds, nops, ierr, errmsg)
+      if (ierr /= 0) return
+      !
+      if (ip > n_tokens) then
+         !
+         ierr   = 1
+         errmsg = 'missing closing ")"'
+         return
+         !
+      endif
+      !
+      if (tok_kind(ip) /= tok_rparen) then
+         !
+         ierr = 1
+         write(errmsg,'(a,i0)') 'expected ")" at position ', tok_pos(ip)
+         return
+         !
+      endif
+      !
+      ip = ip + 1
+      return
+      !
+   endif
+   !
+   ! Leaf: atom cmp_op number.
+   !
+   if (tok_kind(ip) /= tok_ident) then
+      !
+      ierr = 1
+      write(errmsg,'(a,i0)') 'expected atom (z1/z2/z2-z1/z1-z2) at position ', tok_pos(ip)
+      return
+      !
+   endif
+   !
+   atom_code = tok_atom(ip)
+   ip = ip + 1
+   !
+   if (ip > n_tokens) then
+      !
+      ierr   = 1
+      errmsg = 'expected comparator after atom'
+      return
+      !
+   endif
+   !
+   select case (tok_kind(ip))
+      !
+      case (tok_lt)
+         !
+         cmp_code = cmp_lt
+         !
+      case (tok_gt)
+         !
+         cmp_code = cmp_gt
+         !
+      case (tok_le)
+         !
+         cmp_code = cmp_le
+         !
+      case (tok_ge)
+         !
+         cmp_code = cmp_ge
+         !
+      case (tok_eq)
+         !
+         cmp_code = cmp_eq
+         !
+      case default
+         !
+         ierr = 1
+         write(errmsg,'(a,i0)') 'expected comparator ("<", ">", "<=", ">=", "=") at position ', tok_pos(ip)
+         return
+         !
+   end select
+   !
+   ip = ip + 1
+   !
+   if (ip > n_tokens) then
+      !
+      ierr   = 1
+      errmsg = 'expected number after comparator'
+      return
+      !
+   endif
+   !
+   if (tok_kind(ip) /= tok_number) then
+      !
+      ierr = 1
+      write(errmsg,'(a,i0)') 'expected numeric threshold at position ', tok_pos(ip)
+      return
+      !
+   endif
+   !
+   if (nops >= expr_ops_max_per_rule) then
+      !
+      ierr = 1
+      errmsg = 'rule expression too long (op buffer full)'
+      return
+      !
+   endif
+   !
+   nops = nops + 1
+   ops(nops)        = op_cmp
+   atoms(nops)      = atom_code
+   cmps(nops)       = cmp_code
+   thresholds(nops) = tok_num(ip)
+   !
+   ip = ip + 1
+   !
+   end subroutine
+   !
+   !
+   function to_lower_local(str) result(lower)
+   !
+   ! Return a lowercase copy of str (ASCII only). Local to this module
+   ! so rule-parsing doesn't depend on sfincs_src_structures for a case
+   ! fold; the trivial duplication is worth the decoupling.
+   !
+   implicit none
+   !
+   character(len=*), intent(in)  :: str
+   character(len=:), allocatable :: lower
+   !
+   integer :: k, ic
+   !
+   lower = str
+   !
+   do k = 1, len(lower)
+      !
+      ic = iachar(lower(k:k))
+      !
+      if (ic >= iachar('A') .and. ic <= iachar('Z')) then
+         !
+         lower(k:k) = achar(ic + 32)
+         !
+      endif
+      !
+   enddo
+   !
+   end function
+   !
+end module

--- a/source/src/sfincs_snapwave.f90
+++ b/source/src/sfincs_snapwave.f90
@@ -17,7 +17,6 @@ module sfincs_snapwave
    real*4,    dimension(:),   allocatable    :: snapwave_Tp
    real*4,    dimension(:),   allocatable    :: snapwave_Tp_ig   
    real*4,    dimension(:),   allocatable    :: snapwave_mean_direction
-   real*4,    dimension(:),   allocatable    :: snapwave_directional_spreading
    real*4,    dimension(:),   allocatable    :: snapwave_u10
    real*4,    dimension(:),   allocatable    :: snapwave_u10dir   
    real*4,    dimension(:),   allocatable    :: snapwave_Fx
@@ -302,15 +301,6 @@ contains
    !   
    real*4,    dimension(:), allocatable       :: fwx0
    real*4,    dimension(:), allocatable       :: fwy0
-   real*4,    dimension(:), allocatable       :: dw0
-   real*4,    dimension(:), allocatable       :: df0   
-   real*4,    dimension(:), allocatable       :: dwig0
-   real*4,    dimension(:), allocatable       :: dfig0   
-   real*4,    dimension(:), allocatable       :: cg0   
-   !real*4,    dimension(:), allocatable       :: qb0   
-   real*4,    dimension(:), allocatable       :: beta0 
-   real*4,    dimension(:), allocatable       :: srcig0      
-   real*4,    dimension(:), allocatable       :: alphaig0   
    integer   :: ip, nm, nmu, idir
    real*8    :: t
    !
@@ -318,27 +308,9 @@ contains
    !
    allocate(fwx0(np))
    allocate(fwy0(np))
-   allocate(dw0(np))
-   allocate(df0(np))   
-   allocate(dwig0(np))
-   allocate(dfig0(np))  
-   allocate(cg0(np))  
-   !allocate(qb0(np))   
-   allocate(beta0(np))   
-   allocate(srcig0(np))      
-   allocate(alphaig0(np))      
    !
    fwx0 = 0.0
    fwy0 = 0.0
-   dw0 = 0.0
-   df0 = 0.0   
-   dwig0 = 0.0
-   dfig0 = 0.0
-   cg0 = 0.0
-   !qb0 = 0.0
-   beta0 = 0.0
-   srcig0 = 0.0
-   alphaig0 = 0.0   
    !
    ! Determine SnapWave water depth
    !
@@ -420,25 +392,10 @@ contains
       !
       if (ip>0) then
          !
-         hm0(nm)    = snapwave_H(ip)   
-         hm0_ig(nm) = snapwave_H_ig(ip) 
-         sw_tp(nm)    = snapwave_Tp(ip)         
-         sw_tp_ig(nm) = snapwave_Tp_ig(ip)         
-         fwx0(nm)   = snapwave_Fx(ip)   
-         fwy0(nm)   = snapwave_Fy(ip) 
-         dw0(nm)    = snapwave_Dw(ip)   
-         df0(nm)    = snapwave_Df(ip)     
-         dwig0(nm)  = snapwave_Dwig(ip)   
-         dfig0(nm)  = snapwave_Dfig(ip)
-         cg0(nm)    = snapwave_cg(ip)
-         !qb0(nm)    = snapwave_Qb(ip)
-         beta0(nm)  = snapwave_beta(ip)
-         srcig0(nm) = snapwave_srcig(ip)
-         alphaig0(nm) = snapwave_alphaig(ip)
-         if (store_wave_direction) then
-            mean_wave_direction(nm) = snapwave_mean_direction(ip)             
-            wave_directional_spreading(nm) = snapwave_directional_spreading(ip)*180/pi   
-         endif
+         hm0(nm)    = snapwave_H(ip)
+         hm0_ig(nm) = snapwave_H_ig(ip)
+         fwx0(nm)   = snapwave_Fx(ip)
+         fwy0(nm)   = snapwave_Fy(ip)
          !
       else
          !
@@ -446,44 +403,13 @@ contains
          !
          hm0(nm)    = 0.0
          hm0_ig(nm) = 0.0
-         sw_tp(nm)  = 0.0
-         sw_tp_ig(nm) = 0.0         
          fwx0(nm)   = 0.0
-         fwy0(nm)   = 0.0   
-         dw0(nm)    = 0.0
-         df0(nm)    = 0.0         
-         dwig0(nm)  = 0.0
-         dfig0(nm)  = 0.0
-         cg0(nm)    = 0.0
-         !qb0(nm)    = 0.0
-         beta0(nm)  = 0.0
-         srcig0(nm) = 0.0
-         alphaig0(nm) = 0.0         
-         if (store_wave_direction) then
-            mean_wave_direction(nm)        = 0.0
-            wave_directional_spreading(nm) = 0.0  
-         endif
+         fwy0(nm)   = 0.0
          !
-      endif   
+      endif
       !
-      if (store_wave_forces) then
-         !
-         fwx(nm)        = fwx0(nm)
-         fwy(nm)        = fwy0(nm)
-         dw(nm)         = dw0(nm)
-         df(nm)         = df0(nm)         
-         dwig(nm)       = dwig0(nm)
-         dfig(nm)       = dfig0(nm)
-         cg(nm)         = cg0(nm)   
-         !qb(nm)         = qb0(nm)         
-         betamean(nm)   = beta0(nm)         
-         srcig(nm)      = srcig0(nm)         
-         alphaig(nm)    = alphaig0(nm)                  
-         !
-      endif   
-      !
-   enddo   
-   !   
+   enddo
+   !
    hm0 = hm0 * sqrt(2.0)
    hm0_ig = hm0_ig * sqrt(2.0)
    !
@@ -549,7 +475,6 @@ contains
    snapwave_Tp                    = Tp
    snapwave_Tp_ig                 = Tp_ig   
    snapwave_mean_direction        = modulo(270.0 - thetam * 180 / pi + 360.0, 360.0)
-   snapwave_directional_spreading = thetam  ! TL: CORRECT? > is not spreading but mean direction?
    snapwave_Dw                    = Dw
    snapwave_Df                    = Df
    snapwave_Dwig                  = Dw_ig
@@ -574,7 +499,6 @@ contains
        if (snapwave_H(k) <= 0.0) then
            snapwave_Tp(k) = 0.0
            snapwave_mean_direction(k) = 0.0
-           snapwave_directional_spreading(k) = 0.0
            snapwave_cg(k) = 0.0
        endif
        !

--- a/source/src/sfincs_src_structures.f90
+++ b/source/src/sfincs_src_structures.f90
@@ -1,0 +1,2584 @@
+module sfincs_src_structures
+   !
+   ! Point structures that move water between two grid cells by user-specified
+   ! rules rather than by momentum conservation:
+   !    type 1 - pump           (fixed discharge)
+   !    type 2 - culvert_simple (bidirectional, optional direction filter)
+   !    type 3 - culvert        (physics-based pipe flow with entrance /
+   !                             friction / exit losses, bidirectional,
+   !                             optional direction filter)
+   !    type 4 - gate           (rule-driven state machine, bidirectional)
+   !
+   ! Legacy TOML alias accepted by the parser:
+   !    "check_valve" -> culvert_simple + direction = "positive"
+   !
+   ! Orifice behaviour is not a first-class type; use type = "culvert"
+   ! with submergence_ratio = 0.0 to reproduce it.
+   !
+   ! These used to live in sfincs_discharges.f90 alongside the river point
+   ! discharges read from src/dis/netsrcdis. They have been split out so that
+   ! each module has a single responsibility.
+   !
+   ! Runtime handoff to the continuity module is via the cell-wise qsrc(np)
+   ! array (in sfincs_data): this module accumulates qq on endpoint-1
+   ! (src_struc_nm_s1) and endpoint-2 (src_struc_nm_s2) cells. Per-structure
+   ! signed discharge is also stored in src_struc_q_now(nr_src_structures)
+   ! for his output.
+   !
+   ! Sign convention: a positive qq means flow from nm_s1 to nm_s2.
+   ! No direction is baked into the endpoint names themselves; for pumps,
+   ! endpoint 1 (nm_s1) is the intake and endpoint 2 (nm_s2) is the discharge,
+   ! and the pump logic enforces qq >= 0. All other structure types are
+   ! bidirectional and the sign of qq carries the flow direction.
+   !
+   ! Concurrency: qsrc updates use atomic because two structures (or a river
+   ! source and a structure) can land in the same cell.
+   !
+   ! Subroutines:
+   !
+   !   initialize_src_structures()
+   !     Main entry point. Detects legacy vs TOML, dispatches through the
+   !     TOML reader, flattens into src_struc_* arrays, resolves grid-cell
+   !     indices, and seeds rule-driven gate positions from the initial zs.
+   !     Called from sfincs_lib at init time.
+   !
+   !   update_src_structures(t, dt)
+   !     Evaluates each rule-driven structure's ordered rule list to set a
+   !     target gate position and ramps fraction_open toward it, evaluates the
+   !     per-type flux formula, and accumulates signed discharges into qsrc and
+   !     src_struc_q_now. Called from update_continuity (sfincs_continuity)
+   !     once per time step, after update_discharges.
+   !
+   !   read_toml_src_structures(filename, structures, ierr)
+   !     Parse a TOML drn file into an allocatable t_src_structure(:) array.
+   !     Validates required per-type keys; returns ierr /= 0 on failure.
+   !     Called from initialize_src_structures (this module).
+   !
+   !   check_required(table, keys, seq_index, ierr)
+   !     Helper for read_toml_src_structures: verifies that every key in a
+   !     required-key list is present in a given TOML table. Called from
+   !     read_toml_src_structures (this module).
+   !
+   !   parse_structure_type(str, code, ierr)
+   !     Translate a TOML "type" string to one of the structure_* codes.
+   !     Called from read_toml_src_structures (this module).
+   !
+   !   parse_direction(str, code, ierr)
+   !     Translate a TOML "direction" string to one of the direction_* codes.
+   !     Called from read_toml_src_structures (this module).
+   !
+   !   to_lower(str) result(lower)
+   !     Return a lowercase copy of a string (ASCII). Called from
+   !     parse_structure_type, parse_direction, and convert_legacy_to_toml
+   !     (all in this module).
+   !
+   !   write_src_structures_log_summary()
+   !     Emit a one-block-per-structure human-readable description to the
+   !     log file; called from initialize_src_structures (this module) once
+   !     at init time after marshalling.
+   !
+   !   convert_legacy_to_toml(legacy_path, toml_path, ierr)
+   !     Transcribe a legacy fixed-column .drn file into a TOML sibling so
+   !     the downstream code only has to consume the TOML schema. Called
+   !     from initialize_src_structures (this module) when the drn file
+   !     fails TOML probing.
+   !
+   use sfincs_log
+   use sfincs_error
+   use sfincs_rule_expression, only: add_rule, evaluate_rule, finalize_rule_storage
+   !
+   private :: parse_structure_type, parse_direction, parse_operation, to_lower, check_required
+   private :: convert_legacy_to_toml
+   private :: write_src_structures_log_summary
+   !
+   ! Structure type codes
+   !
+   integer, parameter :: structure_pump           = 1
+   integer, parameter :: structure_culvert_simple = 2
+   integer, parameter :: structure_culvert        = 3
+   integer, parameter :: structure_gate           = 4
+   integer, parameter :: structure_dike_breach    = 5
+   !
+   ! Direction filter codes (culvert_simple / culvert). Controls which sign
+   ! of discharge is allowed through the structure. Default is "both".
+   !
+   integer, parameter :: direction_both     = 1
+   integer, parameter :: direction_positive = 2
+   integer, parameter :: direction_negative = 3
+   !
+   ! Pump reduction curve depth (m). Pump discharge is scaled by
+   ! min(1, h_up/pump_reduction_depth) so the pump cannot pump the intake
+   ! cell dry. Fixed constant, not user-tunable.
+   !
+   real*4, parameter :: pump_reduction_depth = 0.1
+   !
+   ! Gate operation codes for rule-driven structures. Each rule sets a
+   ! target gate position: open -> fraction 1.0, close -> 0.0, hold ->
+   ! freeze at the current fraction. These are the only operations.
+   !
+   integer, parameter :: gate_op_close = 0
+   integer, parameter :: gate_op_open  = 1
+   integer, parameter :: gate_op_hold  = 2
+   !
+   ! A single gate control rule: an operation plus the boolean expression
+   ! (in the sfincs_rule_expression mini-language, e.g. "z1>-0.15 & z1-z2>0.09")
+   ! that, when true, selects that operation. Rules are evaluated in order
+   ! and the first whose expression fires wins; if none fires the gate holds.
+   !
+   type :: t_gate_rule
+      integer                       :: op       ! gate_op_*
+      character(len=:), allocatable :: when     ! trigger expression (raw string)
+   end type t_gate_rule
+   !
+   ! Derived type for the TOML-based src structure input.
+   !
+   ! Gate control is an ordered list of (operation, when) rules; the parser
+   ! runs during marshalling and emits each "when" expression as bytecode
+   ! into the shared rule_* streams owned by the sfincs_rule_expression module.
+   !
+   type :: t_src_structure
+      !
+      ! Identification (populated by the TOML reader). name is the sole
+      ! identifier and is required for every structure type.
+      !
+      character(len=:), allocatable :: name
+      !
+      ! Structure kind (one of the structure_* codes)
+      !
+      integer :: structure_type
+      !
+      ! Direction filter (one of direction_both / _positive / _negative).
+      ! Honoured only for culvert_simple and culvert; other types ignore it.
+      !
+      integer :: direction
+      !
+      ! Geometry - x_s1/y_s1 and x_s2/y_s2 define the two endpoint cell
+      ! coordinates; x_o1/y_o1 and x_o2/y_o2 are optional observation-point
+      ! coordinates and default to the endpoint coordinates in the marshal
+      ! when the TOML reader did not see the keys (tracked via has_o1 / has_o2).
+      !
+      real :: x_s1, y_s1
+      real :: x_s2, y_s2
+      real :: x_o1, y_o1
+      real :: x_o2, y_o2
+      logical :: has_o1
+      logical :: has_o2
+      !
+      ! Parameters
+      !
+      ! q                 - pump discharge
+      ! width             - gate / culvert width
+      ! sill_elevation    - gate sill elevation
+      ! mannings_n        - gate Manning's n
+      ! opening_duration  - time (s) to go from closed to fully open
+      ! closing_duration  - time (s) to go from open to fully closed
+      ! flow_coef         - culvert_simple / check_valve / culvert flow coefficient
+      ! height            - culvert pipe height (m, rectangular cross-section)
+      ! invert_1          - culvert bed elevation at endpoint 1 (m)
+      ! invert_2          - culvert bed elevation at endpoint 2 (m)
+      ! submergence_ratio - culvert submergence threshold h_dn/h_up (-)
+      !
+      real :: q
+      real :: width
+      real :: sill_elevation
+      real :: mannings_n
+      real :: opening_duration
+      real :: closing_duration
+      real :: flow_coef
+      !
+      ! Detailed-culvert geometry + submergence threshold
+      !
+      real :: height
+      real :: invert_1
+      real :: invert_2
+      real :: submergence_ratio
+      !
+      ! Dike breach parameters (structure_dike_breach only)
+      !
+      real    :: z_crest      ! initial crest elevation (m)
+      real    :: t_breach     ! breach start time (s since t=0)
+      real    :: z_min        ! minimum breach level (m)
+      real    :: B0           ! initial breach width at start of phase 2 (m)
+      real    :: t0           ! duration of phase 1: crest lowering (s)
+      integer :: dike_core    ! core material: 1=sand, 2=clay
+      !
+      ! Ordered list of gate control rules (parsed by marshal). Unallocated
+      ! or zero-length means "no rules": the structure stays fully open and
+      ! the runtime skips the rule machinery entirely.
+      !
+      type(t_gate_rule), allocatable :: rules(:)
+      !
+   end type t_src_structure
+   !
+   ! Module-level storage for structures parsed from a TOML input file.
+   ! Populated by the dispatcher and flattened into the flat arrays below
+   ! by the marshal.
+   !
+   type(t_src_structure), allocatable :: src_structures(:)   ! intermediate derived-type array; flattened + deallocated by marshal_src_structures_to_flat_arrays on the toml path (gpu deep-copy avoidance).
+   !
+   ! Module-level runtime state for src structures (moved from sfincs_data).
+   ! Populated by the legacy reader or by marshal_src_structures_to_flat_arrays
+   ! from the TOML path; consumed by update_src_structures and the his output.
+   ! Public so downstream modules (sfincs_openacc, sfincs_output, sfincs_ncoutput,
+   ! sfincs_lib) can reference them.
+   !
+   ! Meta / name
+   !
+   integer, parameter :: src_struc_name_len = 128          ! max length of struct name strings
+   character(len=src_struc_name_len), dimension(:), allocatable, public :: src_struc_name
+   !
+   ! Kind / state
+   !
+   integer*1, dimension(:), allocatable, public :: src_struc_type
+   integer,   dimension(:), allocatable, public :: src_struc_direction   ! direction_* code; honoured by culvert_simple and culvert
+   real*4,    dimension(:), allocatable, public :: src_struc_distance
+   real*4,    dimension(:), allocatable, public :: src_struc_fraction_open
+   !
+   ! Input file path (sfincs.inp keyword 'drnfile'); 'none' when no drainage
+   ! structures file is supplied.
+   !
+   character(len=256), public :: drnfile
+   !
+   ! Input file path (sfincs.inp keyword 'dkbfile'); 'none' when no dike
+   ! breach file is supplied.  Entries are appended to the same flat arrays
+   ! as drnfile structures so the runtime sees one unified pool.
+   !
+   character(len=256), public :: dkbfile
+   !
+   ! Cell mapping
+   !
+   integer, public :: nr_src_structures
+   integer*4, dimension(:), allocatable, public :: src_struc_nm_s1     ! (nr_src_structures) endpoint-1 cell indices
+   integer*4, dimension(:), allocatable, public :: src_struc_nm_s2     ! (nr_src_structures) endpoint-2 cell indices
+   integer*4, dimension(:), allocatable, public :: src_struc_nm_o1     ! (nr_src_structures) obs-1 cell indices (gate rule inputs; defaults to endpoint-1 cell)
+   integer*4, dimension(:), allocatable, public :: src_struc_nm_o2     ! (nr_src_structures) obs-2 cell indices (gate rule inputs; defaults to endpoint-2 cell)
+   !
+   ! Coordinates
+   !
+   real*4, dimension(:), allocatable, public :: src_struc_x_s1, src_struc_y_s1
+   real*4, dimension(:), allocatable, public :: src_struc_x_s2, src_struc_y_s2
+   real*4, dimension(:), allocatable, public :: src_struc_x_o1, src_struc_y_o1
+   real*4, dimension(:), allocatable, public :: src_struc_x_o2, src_struc_y_o2
+   !
+   ! Named parameters
+   !
+   real*4, dimension(:), allocatable, public :: src_struc_q                  ! pump discharge
+   real*4, dimension(:), allocatable, public :: src_struc_flow_coef          ! culvert_simple / check_valve / culvert flow coefficient
+   real*4, dimension(:), allocatable, public :: src_struc_width              ! gate / culvert width
+   real*4, dimension(:), allocatable, public :: src_struc_sill_elevation     ! gate sill elevation
+   real*4, dimension(:), allocatable, public :: src_struc_mannings_n         ! gate / culvert Manning's n
+   real*4, dimension(:), allocatable, public :: src_struc_opening_duration   ! gate opening duration (s)
+   real*4, dimension(:), allocatable, public :: src_struc_closing_duration   ! gate closing duration (s)
+   !
+   ! Detailed-culvert geometry
+   !
+   real*4, dimension(:), allocatable, public :: src_struc_height             ! culvert pipe height (m)
+   real*4, dimension(:), allocatable, public :: src_struc_invert_1           ! culvert bed elevation at endpoint 1 (m)
+   real*4, dimension(:), allocatable, public :: src_struc_invert_2           ! culvert bed elevation at endpoint 2 (m)
+   !
+   ! Detailed-culvert submergence threshold
+   !
+   real*4, dimension(:), allocatable, public :: src_struc_submergence_ratio  ! culvert submergence threshold h_dn/h_up (-)
+   !
+   ! Dike breach parameters
+   !
+   real*4,  dimension(:), allocatable, public :: src_struc_z_crest      ! initial crest elevation (m)
+   real*4,  dimension(:), allocatable, public :: src_struc_t_breach     ! breach start time (s)
+   real*4,  dimension(:), allocatable, public :: src_struc_z_min        ! minimum breach level (m)
+   real*4,  dimension(:), allocatable, public :: src_struc_B0           ! initial breach width (m)
+   real*4,  dimension(:), allocatable, public :: src_struc_t0           ! phase-1 duration (s)
+   integer, dimension(:), allocatable, public :: src_struc_dike_core    ! 1=sand, 2=clay
+   !
+   ! Dike breach runtime state
+   !
+   real*4, dimension(:), allocatable, public :: src_struc_breach_width  ! current breach width (m)
+   real*4, dimension(:), allocatable, public :: src_struc_breach_level  ! current breach crest level (m)
+   !
+   ! Runtime state
+   !
+   real*4, dimension(:), allocatable, public :: src_struc_q_now               ! (nr_src_structures) signed discharge this step per structure, mirrors the qsrc pattern
+   !
+   ! Ordered gate-rule lists, flattened across all structures into shared
+   ! concatenated arrays (mirrors the rule_* bytecode registry pattern so
+   ! the data is GPU-friendly - no ragged arrays, no allocatable components).
+   !
+   ! src_struc_rule_start(i) is the 1-based offset into rule_list_* of the
+   ! first rule for structure i (0 = structure has no rules); src_struc_rule_count(i)
+   ! is how many rules it has. rule_list_op(j) is the operation (gate_op_*) and
+   ! rule_list_id(j) the rule_id into the sfincs_rule_expression registry.
+   ! rule_list_src(j) holds the raw "when" string for log emission only and
+   ! does not travel to GPU.
+   !
+   integer, dimension(:), allocatable, public :: src_struc_rule_start      ! (nr_src_structures) 1-based start in rule_list_*, 0 = no rules
+   integer, dimension(:), allocatable, public :: src_struc_rule_count      ! (nr_src_structures) number of rules
+   !
+   integer, public                            :: nr_rule_list = 0          ! total length of the concatenated rule lists
+   integer, dimension(:), allocatable, public :: rule_list_op              ! (nr_rule_list) gate_op_* per rule
+   integer, dimension(:), allocatable, public :: rule_list_id              ! (nr_rule_list) rule_id into sfincs_rule_expression registry
+   !
+   integer, parameter :: src_struc_rule_src_len = 256
+   character(len=src_struc_rule_src_len), dimension(:), allocatable, public :: rule_list_src   ! (nr_rule_list) raw "when" string, log only
+   !
+contains
+   !
+   !-----------------------------------------------------------------------------------------------------!
+   !
+   subroutine initialize_src_structures()
+      !
+      ! Dispatcher for the src_structures / drainage input file.
+      !
+      ! Probes the file with toml-f. If it parses as TOML, the TOML reader
+      ! populates the module-level src_structures(:) array. If toml-f rejects
+      ! it, the file is assumed to be in the legacy fixed-column format and
+      ! is transcribed on-the-fly into a TOML sibling file, which is then
+      ! read via the same TOML path. This keeps only one parser alive in the
+      ! source tree.
+      !
+      ! If a file parses as TOML but fails semantic validation (e.g. a
+      ! missing required field), that is treated as a hard error.
+      !
+      ! After parsing, the derived-type src_structures(:) array is flattened
+      ! into the src_struc_* 1D arrays (the runtime's sole state representation),
+      ! grid-cell indices and distances are resolved, a descriptive block is
+      ! written to the log, and gate statuses are seeded from the initial
+      ! water-level field.
+      !
+      ! Called from: sfincs_lib (once, at init time).
+      !
+      use sfincs_data
+      use quadtree
+      use tomlf, only : toml_table, toml_error, toml_load
+      !
+      implicit none
+      !
+      ! Dispatcher locals
+      !
+      type(toml_table), allocatable :: probe_top
+      type(toml_error), allocatable :: probe_err
+      integer                       :: ierr_toml, ierr_conv
+      logical                       :: ok, is_toml
+      character(len=512)            :: toml_path
+      !
+      ! dkbfile locals
+      !
+      type(t_src_structure), allocatable :: src_structures_dkb(:)
+      type(t_src_structure), allocatable :: src_structures_all(:)
+      integer                            :: n_drn, n_dkb
+      !
+      ! Marshal locals
+      !
+      integer                       :: i, j, ierr_parse, irule, nr_rules_i
+      character(len=256)            :: errmsg
+      !
+      ! Cell-index / distance locals
+      !
+      integer                       :: istruc, nmq
+      real*4                        :: x_s1_tmp, y_s1_tmp, x_s2_tmp, y_s2_tmp
+      !
+      ! Gate-position seeding locals
+      !
+      integer                       :: nm_o1, nm_o2, k, iop
+      real                          :: zs_o1, zs_o2
+      character(len=16)             :: status_str
+      !
+      drainage_structures = .false.
+      !
+      if (drnfile(1:4) == 'none' .and. dkbfile(1:4) == 'none') return
+      !
+      ! Read drnfile (drainage structures: pumps / culverts / gates).
+      ! Skipped when drnfile = 'none'; dkbfile-only runs are valid.
+      !
+      if (drnfile(1:4) /= 'none') then
+         !
+         ok = check_file_exists(drnfile, 'Drainage points drn file', .true.)
+         !
+         ! Probe TOML / convert legacy / re-read TOML
+         !
+         call toml_load(probe_top, drnfile, error=probe_err)
+         !
+         is_toml = .not. allocated(probe_err)
+         !
+         if (allocated(probe_err)) deallocate(probe_err)
+         if (allocated(probe_top)) deallocate(probe_top)
+         !
+         if (is_toml) then
+            toml_path = drnfile
+         else
+            call convert_legacy_to_toml(drnfile, toml_path, ierr_conv)
+            if (ierr_conv /= 0) then
+               write(logstr,'(a,a,a)')' Error ! Failed to convert legacy drn file "', trim(drnfile), &
+                    '" to TOML; see preceding log entries for the reason'
+               call stop_sfincs(trim(logstr), -1)
+            endif
+         endif
+         !
+         call read_toml_src_structures(trim(toml_path), src_structures, ierr_toml)
+         !
+         if (ierr_toml /= 0) then
+            write(logstr,'(a,a,a)')' Error ! Failed to load TOML src_structures file ', trim(toml_path), ' !'
+            call stop_sfincs(trim(logstr), -1)
+         endif
+         !
+      endif
+      !
+      ! If a dike breach file is also provided, read it and append its
+      ! entries to src_structures so the marshal sees one unified array.
+      !
+      if (dkbfile(1:4) /= 'none') then
+         !
+         ok = check_file_exists(dkbfile, 'Dike breach dkb file', .true.)
+         !
+         call read_toml_src_structures(trim(dkbfile), src_structures_dkb, ierr_toml)
+         !
+         if (ierr_toml /= 0) then
+            write(logstr,'(a,a,a)')' Error ! Failed to load TOML dkb file ', trim(dkbfile), ' !'
+            call stop_sfincs(trim(logstr), -1)
+         endif
+         !
+         if (allocated(src_structures_dkb)) then
+            !
+            n_drn = 0
+            if (allocated(src_structures)) n_drn = size(src_structures)
+            n_dkb = size(src_structures_dkb)
+            !
+            allocate(src_structures_all(n_drn + n_dkb))
+            !
+            if (n_drn > 0) src_structures_all(1:n_drn)             = src_structures(1:n_drn)
+            src_structures_all(n_drn+1 : n_drn+n_dkb) = src_structures_dkb(1:n_dkb)
+            !
+            if (allocated(src_structures))     deallocate(src_structures)
+            if (allocated(src_structures_dkb)) deallocate(src_structures_dkb)
+            !
+            call move_alloc(src_structures_all, src_structures)
+            !
+         endif
+         !
+      endif
+      !
+      ! Marshal src_structures(:) -> src_struc_* flat arrays.
+      !
+      ! The runtime reads all src-structure state from flat per-struct
+      ! arrays (the src_struc_* family: src_struc_type, src_struc_q, src_struc_flow_coef, ...).
+      ! The TOML reader, however, naturally produces a derived-type array
+      ! src_structures(:) of t_src_structure, which carries allocatable
+      ! components: character(len=:), allocatable :: name, plus the rule
+      ! expression strings.
+      !
+      ! nvfortran's openacc implicit deep-copy of derived types that
+      ! contain allocatable components has been unreliable in practice:
+      ! pushing a type(...), allocatable :: arr(:) with nested allocatables
+      ! to the device tends to produce runtime issues. Flat arrays of
+      ! primitive types (real, integer, fixed-length character) copy
+      ! cleanly across !$acc enter data copyin(...), so we keep the live
+      ! runtime state in those.
+      !
+      ! The marshal is the one-shot bridge: toml -> src_structures(:)
+      ! -> src_struc_* flat arrays -> deallocate(src_structures). After it
+      ! runs, nothing of the derived-type array survives, so no gpu
+      ! region ever sees a problematic allocatable-in-derived-type.
+      !
+      if (.not. allocated(src_structures)) then
+         !
+         nr_src_structures = 0
+         !
+         call write_src_structures_log_summary()
+         !
+         return
+         !
+      endif
+      !
+      nr_src_structures = size(src_structures)
+      !
+      if (nr_src_structures <= 0) then
+         !
+         deallocate(src_structures)
+         !
+         call write_src_structures_log_summary()
+         !
+         return
+         !
+      endif
+      !
+      ! drainage_structures is set after marshalling once src_struc_type is
+      ! populated; dike_breaching is set the same way (line ~755).
+      ! Both are resolved below via any() on the flat type array.
+      !
+      ! Allocate flat arrays to size nr_src_structures and seed defaults.
+      !
+      allocate(src_struc_nm_s1(nr_src_structures))
+      allocate(src_struc_nm_s2(nr_src_structures))
+      allocate(src_struc_nm_o1(nr_src_structures))
+      allocate(src_struc_nm_o2(nr_src_structures))
+      allocate(src_struc_q_now(nr_src_structures))
+      allocate(src_struc_type(nr_src_structures))
+      allocate(src_struc_direction(nr_src_structures))
+      allocate(src_struc_distance(nr_src_structures))
+      allocate(src_struc_fraction_open(nr_src_structures))
+      allocate(src_struc_rule_start(nr_src_structures))
+      allocate(src_struc_rule_count(nr_src_structures))
+      allocate(src_struc_name(nr_src_structures))
+      allocate(src_struc_x_s1(nr_src_structures))
+      allocate(src_struc_y_s1(nr_src_structures))
+      allocate(src_struc_x_s2(nr_src_structures))
+      allocate(src_struc_y_s2(nr_src_structures))
+      allocate(src_struc_x_o1(nr_src_structures))
+      allocate(src_struc_y_o1(nr_src_structures))
+      allocate(src_struc_x_o2(nr_src_structures))
+      allocate(src_struc_y_o2(nr_src_structures))
+      allocate(src_struc_q(nr_src_structures))
+      allocate(src_struc_flow_coef(nr_src_structures))
+      allocate(src_struc_width(nr_src_structures))
+      allocate(src_struc_sill_elevation(nr_src_structures))
+      allocate(src_struc_mannings_n(nr_src_structures))
+      allocate(src_struc_opening_duration(nr_src_structures))
+      allocate(src_struc_closing_duration(nr_src_structures))
+      allocate(src_struc_height(nr_src_structures))
+      allocate(src_struc_invert_1(nr_src_structures))
+      allocate(src_struc_invert_2(nr_src_structures))
+      allocate(src_struc_submergence_ratio(nr_src_structures))
+      allocate(src_struc_z_crest(nr_src_structures))
+      allocate(src_struc_t_breach(nr_src_structures))
+      allocate(src_struc_z_min(nr_src_structures))
+      allocate(src_struc_B0(nr_src_structures))
+      allocate(src_struc_t0(nr_src_structures))
+      allocate(src_struc_dike_core(nr_src_structures))
+      allocate(src_struc_breach_width(nr_src_structures))
+      allocate(src_struc_breach_level(nr_src_structures))
+      !
+      src_struc_rule_start     = 0
+      src_struc_rule_count     = 0
+      !
+      src_struc_nm_s1          = 0
+      src_struc_nm_s2          = 0
+      src_struc_nm_o1          = 0
+      src_struc_nm_o2          = 0
+      src_struc_q_now          = 0.0
+      src_struc_type           = 0
+      src_struc_direction      = direction_both
+      src_struc_distance       = 0.0
+      src_struc_fraction_open  = 1.0   ! default "fully open": structures without rules use this as a no-op multiplier in the common-tail scaling. Rule-driven structures are re-seeded at init below.
+      src_struc_name           = ' '
+      src_struc_x_s1           = 0.0
+      src_struc_y_s1           = 0.0
+      src_struc_x_s2           = 0.0
+      src_struc_y_s2           = 0.0
+      src_struc_x_o1           = 0.0
+      src_struc_y_o1           = 0.0
+      src_struc_x_o2           = 0.0
+      src_struc_y_o2           = 0.0
+      src_struc_q              = 0.0
+      src_struc_flow_coef      = 1.0
+      src_struc_width          = 0.0
+      src_struc_sill_elevation = 0.0
+      src_struc_mannings_n     = 0.024
+      src_struc_opening_duration = 600.0
+      src_struc_closing_duration = 600.0
+      src_struc_height           = 0.0
+      src_struc_invert_1         = 0.0
+      src_struc_invert_2         = 0.0
+      src_struc_submergence_ratio = 0.667
+      src_struc_z_crest          = 0.0
+      src_struc_t_breach         = 0.0
+      src_struc_z_min            = 0.0
+      src_struc_B0               = 0.0
+      src_struc_t0               = 0.0
+      src_struc_dike_core        = 1
+      src_struc_breach_width     = 0.0
+      src_struc_breach_level     = 0.0
+      !
+      ! Count the total number of gate rules across all structures and allocate
+      ! the concatenated rule_list_* arrays (size 0 when no structure has rules,
+      ! so the downstream openacc directives can still reference them safely).
+      !
+      nr_rule_list = 0
+      do i = 1, nr_src_structures
+         if (allocated(src_structures(i)%rules)) nr_rule_list = nr_rule_list + size(src_structures(i)%rules)
+      enddo
+      !
+      allocate(rule_list_op(nr_rule_list))
+      allocate(rule_list_id(nr_rule_list))
+      allocate(rule_list_src(nr_rule_list))
+      !
+      ! Copy scalar / coord / string / parameter fields from src_structures(:)
+      ! into the flat arrays, and concatenate each structure's gate-rule list
+      ! into rule_list_* (parsing each "when" expression via add_rule).
+      !
+      irule = 0
+      !
+      do i = 1, nr_src_structures
+         !
+         ! String fields: truncation warning if longer than src_struc_name_len.
+         !
+         if (allocated(src_structures(i)%name)) then
+            !
+            if (len(src_structures(i)%name) > src_struc_name_len) then
+               !
+               write(logstr,'(a,i0,a,i0,a)')' Warning ! src_structure name length > ', src_struc_name_len, &
+                    ' at entry ', i, '; truncating'
+               call write_log(logstr, 0)
+               !
+            endif
+            !
+            src_struc_name(i) = src_structures(i)%name
+            !
+         endif
+         !
+         src_struc_type(i)      = int(src_structures(i)%structure_type, 1)
+         src_struc_direction(i) = src_structures(i)%direction
+         !
+         src_struc_x_s1(i) = src_structures(i)%x_s1
+         src_struc_y_s1(i) = src_structures(i)%y_s1
+         src_struc_x_s2(i) = src_structures(i)%x_s2
+         src_struc_y_s2(i) = src_structures(i)%y_s2
+         !
+         ! obs 1 / obs 2 default to the corresponding endpoint when the TOML
+         ! reader did not see the key (tracked via has_o1 / has_o2).
+         ! This lets 0.0 remain a legal coordinate value.
+         !
+         if (src_structures(i)%has_o1) then
+            !
+            src_struc_x_o1(i) = src_structures(i)%x_o1
+            src_struc_y_o1(i) = src_structures(i)%y_o1
+            !
+         else
+            !
+            src_struc_x_o1(i) = src_structures(i)%x_s1
+            src_struc_y_o1(i) = src_structures(i)%y_s1
+            !
+         endif
+         !
+         if (src_structures(i)%has_o2) then
+            !
+            src_struc_x_o2(i) = src_structures(i)%x_o2
+            src_struc_y_o2(i) = src_structures(i)%y_o2
+            !
+         else
+            !
+            src_struc_x_o2(i) = src_structures(i)%x_s2
+            src_struc_y_o2(i) = src_structures(i)%y_s2
+            !
+         endif
+         !
+         src_struc_q(i)                 = src_structures(i)%q
+         src_struc_flow_coef(i)         = src_structures(i)%flow_coef
+         src_struc_width(i)             = src_structures(i)%width
+         src_struc_sill_elevation(i)    = src_structures(i)%sill_elevation
+         src_struc_mannings_n(i)        = src_structures(i)%mannings_n
+         src_struc_opening_duration(i)  = src_structures(i)%opening_duration
+         src_struc_closing_duration(i)  = src_structures(i)%closing_duration
+         src_struc_height(i)            = src_structures(i)%height
+         src_struc_invert_1(i)          = src_structures(i)%invert_1
+         src_struc_invert_2(i)          = src_structures(i)%invert_2
+         src_struc_submergence_ratio(i) = src_structures(i)%submergence_ratio
+         !
+         if (src_structures(i)%structure_type == structure_dike_breach) then
+            src_struc_z_crest(i)      = src_structures(i)%z_crest
+            src_struc_t_breach(i)     = src_structures(i)%t_breach
+            src_struc_z_min(i)        = src_structures(i)%z_min
+            src_struc_B0(i)           = src_structures(i)%B0
+            src_struc_t0(i)           = src_structures(i)%t0
+            src_struc_dike_core(i)    = src_structures(i)%dike_core
+            src_struc_breach_level(i) = src_structures(i)%z_crest  ! starts at crest
+            src_struc_breach_width(i) = 0.0
+         endif
+         !
+         ! Gate control rules: concatenate this structure's ordered list into
+         ! the shared rule_list_* arrays. Each "when" expression is compiled to
+         ! bytecode via add_rule; the operation code and raw string travel
+         ! alongside the resulting rule_id.
+         !
+         if (allocated(src_structures(i)%rules)) then
+            !
+            nr_rules_i = size(src_structures(i)%rules)
+            !
+            if (nr_rules_i > 0) then
+               !
+               src_struc_rule_start(i) = irule + 1
+               src_struc_rule_count(i) = nr_rules_i
+               !
+               do j = 1, nr_rules_i
+                  !
+                  irule = irule + 1
+                  !
+                  call add_rule(src_structures(i)%rules(j)%when, &
+                       rule_list_id(irule), ierr_parse, errmsg)
+                  !
+                  if (ierr_parse /= 0) then
+                     !
+                     write(logstr,'(a,a,a,i0,a,a)')' Error ! src_structure "', trim(src_struc_name(i)), &
+                          '" rule ', j, ' parse failed: ', trim(errmsg)
+                     call write_log(logstr, 1)
+                     call stop_sfincs(trim(logstr), -1)
+                     !
+                  endif
+                  !
+                  rule_list_op(irule)  = src_structures(i)%rules(j)%op
+                  rule_list_src(irule) = src_structures(i)%rules(j)%when
+                  !
+               enddo
+               !
+            endif
+            !
+         endif
+         !
+      enddo
+      !
+      ! Shrink the shared rule bytecode stream to exactly the concatenated
+      ! length (also allocates zero-length arrays when no rules were seen).
+      !
+      call finalize_rule_storage()
+      !
+      ! Drop the derived-type array; flat arrays carry all runtime state now.
+      !
+      deallocate(src_structures)
+      !
+      ! Resolve cell-index lookups (src_struc_nm_s1 / _s2 / _o1 / _o2)
+      ! and centre-to-centre distance from coordinate pairs.
+      !
+      do istruc = 1, nr_src_structures
+         !
+         nmq = find_quadtree_cell(src_struc_x_s1(istruc), src_struc_y_s1(istruc))
+         if (nmq > 0) src_struc_nm_s1(istruc) = index_sfincs_in_quadtree(nmq)
+         !
+         nmq = find_quadtree_cell(src_struc_x_s2(istruc), src_struc_y_s2(istruc))
+         if (nmq > 0) src_struc_nm_s2(istruc) = index_sfincs_in_quadtree(nmq)
+         !
+         ! obs cell indices feed the gate rule evaluator. The marshal has
+         ! already defaulted x_o1/y_o1 and x_o2/y_o2 to the endpoint
+         ! coordinates when the TOML reader did not see the keys, so this
+         ! lookup gives us obs-1 == endpoint-1 and obs-2 == endpoint-2 for
+         ! those cases without extra branching.
+         !
+         nmq = find_quadtree_cell(src_struc_x_o1(istruc), src_struc_y_o1(istruc))
+         if (nmq > 0) src_struc_nm_o1(istruc) = index_sfincs_in_quadtree(nmq)
+         !
+         nmq = find_quadtree_cell(src_struc_x_o2(istruc), src_struc_y_o2(istruc))
+         if (nmq > 0) src_struc_nm_o2(istruc) = index_sfincs_in_quadtree(nmq)
+         !
+         if (src_struc_nm_s1(istruc) > 0 .and. src_struc_nm_s2(istruc) > 0) then
+            !
+            x_s1_tmp = z_xz(src_struc_nm_s1(istruc))
+            y_s1_tmp = z_yz(src_struc_nm_s1(istruc))
+            x_s2_tmp = z_xz(src_struc_nm_s2(istruc))
+            y_s2_tmp = z_yz(src_struc_nm_s2(istruc))
+            src_struc_distance(istruc) = sqrt( (x_s2_tmp - x_s1_tmp)**2 + (y_s2_tmp - y_s1_tmp)**2 )
+            !
+         endif
+         !
+      enddo
+      !
+      if (any(src_struc_nm_s1 == 0) .or. any(src_struc_nm_s2 == 0)) then
+         !
+         write(logstr,'(a)') 'Warning ! For some source-structure endpoints no matching active grid cell was found!'
+         call write_log(logstr, 0)
+         write(logstr,'(a)') 'Warning ! These points will be skipped, please check your input!'
+         call write_log(logstr, 0)
+         !
+      endif
+      !
+      dike_breaching      = any(src_struc_type == structure_dike_breach)
+      drainage_structures = any(src_struc_type /= structure_dike_breach)
+      !
+      ! Write the per-structure descriptive block to the log file.
+      ! Emitted before the gate-position seeding so the per-gate init lines
+      ! trail the structure block they annotate.
+      !
+      call write_src_structures_log_summary()
+      !
+      ! Initial-position seeding for rule-driven structures.
+      !
+      ! zs(:) has already been populated by initialize_domain -> initialize_hydro
+      ! -> set_initial_conditions by the time we get here, so obs-point lookups
+      ! against zs are valid. Structures without rules keep the default
+      ! fraction_open = 1.0 ("always open"), a no-op in the common-tail scaling.
+      !
+      ! For rule-driven structures the rule list is evaluated once (first match
+      ! wins) and the gate is snapped to the resulting target: open -> 1.0,
+      ! close -> 0.0. If the first match is "hold", or no rule fires, there is
+      ! no prior position to hold, so the gate starts closed (0.0).
+      !
+      do istruc = 1, nr_src_structures
+         !
+         ! Skip structures without rules - keep the "always open" default.
+         !
+         if (src_struc_rule_count(istruc) <= 0) cycle
+         !
+         nm_o1 = src_struc_nm_o1(istruc)
+         nm_o2 = src_struc_nm_o2(istruc)
+         !
+         if (nm_o1 > 0) then
+            zs_o1 = real(zs(nm_o1), 4)
+         else
+            zs_o1 = 0.0
+         endif
+         !
+         if (nm_o2 > 0) then
+            zs_o2 = real(zs(nm_o2), 4)
+         else
+            zs_o2 = 0.0
+         endif
+         !
+         ! First matching rule wins; default to hold (-> closed at init).
+         !
+         iop = gate_op_hold
+         !
+         do k = 1, src_struc_rule_count(istruc)
+            !
+            if (evaluate_rule(rule_list_id(src_struc_rule_start(istruc) + k - 1), zs_o1, zs_o2)) then
+               !
+               iop = rule_list_op(src_struc_rule_start(istruc) + k - 1)
+               exit
+               !
+            endif
+            !
+         enddo
+         !
+         if (iop == gate_op_open) then
+            !
+            src_struc_fraction_open(istruc) = 1.0
+            status_str                      = 'open'
+            !
+         else
+            !
+            ! close, or hold/none at init (no prior position to hold)
+            !
+            src_struc_fraction_open(istruc) = 0.0
+            status_str                      = 'closed'
+            !
+         endif
+         !
+         write(logstr,'(a,a,a,a)')'structure ', trim(src_struc_name(istruc)), &
+              ' initialised ', trim(status_str)
+         call write_log(logstr, 0)
+         !
+      enddo
+      !
+   end subroutine
+   !
+   !-----------------------------------------------------------------------------------------------------!
+   !
+   subroutine update_src_structures(t, dt)
+      !
+      ! Compute discharges through each drainage structure, accumulate them
+      ! into qsrc(np) (endpoint 1: -qq, endpoint 2: +qq), and store
+      ! per-structure signed discharge in src_struc_q_now(nr_src_structures)
+      ! for his output. Sign convention: qq > 0 means flow from endpoint 1
+      ! to endpoint 2.
+      !
+      ! Called AFTER update_discharges, which zeros qsrc first.
+      !
+      ! Atomic updates on qsrc(nm) guard against two structures (or a river
+      ! and a structure) writing to the same cell under parallel execution.
+      !
+      ! Called from: update_continuity (sfincs_continuity), once per time step.
+      !
+      use sfincs_data
+      !
+      implicit none
+      !
+      real*8  :: t
+      real*4  :: dt
+      !
+      integer :: istruc, nm_s1, nm_s2, nm_o1, nm_o2, k, iop
+      real*4  :: qq, zs_o1, zs_o2, target_frac
+      real*4  :: frac, wdt, mng, zsill, dist, dzds, hgate, qq0, alpha
+      real*4  :: dh, a_eff
+      real*4  :: h_up, h_dn, qq_sign
+      !
+      real*4  :: crest_breach, width_breach, z_crest_breach, z_min_breach
+      real*4  :: tstart_breach, tstart_widening, t_phase1_deepening
+      real*4  :: vk_f1, vk_f2, uc_material, elapsed_widening_hr, dt_hr
+      real*4  :: widening_deceleration, widening_rate
+      !
+      if (nr_src_structures <= 0) return
+      !
+      !$acc parallel loop present( z_volume, zs, zb, qsrc, src_struc_q_now, &
+      !$acc                        src_struc_nm_s1, src_struc_nm_s2, &
+      !$acc                        src_struc_nm_o1, src_struc_nm_o2, &
+      !$acc                        src_struc_type, src_struc_direction, &
+      !$acc                        src_struc_q, src_struc_flow_coef, &
+      !$acc                        src_struc_width, src_struc_sill_elevation, &
+      !$acc                        src_struc_mannings_n, &
+      !$acc                        src_struc_opening_duration, src_struc_closing_duration, &
+      !$acc                        src_struc_height, &
+      !$acc                        src_struc_invert_1, src_struc_invert_2, &
+      !$acc                        src_struc_submergence_ratio, &
+      !$acc                        src_struc_z_crest, src_struc_t_breach, src_struc_z_min, &
+      !$acc                        src_struc_B0, src_struc_t0, src_struc_dike_core, &
+      !$acc                        src_struc_breach_width, src_struc_breach_level, &
+      !$acc                        src_struc_distance, src_struc_fraction_open, &
+      !$acc                        src_struc_rule_start, src_struc_rule_count, &
+      !$acc                        rule_list_op, rule_list_id, &
+      !$acc                        rule_opcode, rule_atom, rule_cmp, rule_threshold, &
+      !$acc                        rule_start, rule_length ) &
+      !$acc              private( nm_s1, nm_s2, nm_o1, nm_o2, qq, k, iop, target_frac, &
+      !$acc                       zs_o1, zs_o2, frac, wdt, mng, zsill, dist, dzds, hgate, qq0, alpha, &
+      !$acc                       dh, a_eff, &
+      !$acc                       h_up, h_dn, qq_sign, &
+      !$acc                       crest_breach, width_breach, z_crest_breach, z_min_breach, &
+      !$acc                       tstart_breach, tstart_widening, t_phase1_deepening, &
+      !$acc                       vk_f1, vk_f2, uc_material, elapsed_widening_hr, dt_hr, &
+      !$acc                       widening_deceleration, widening_rate )
+      !$omp parallel do &
+      !$omp   private( nm_s1, nm_s2, nm_o1, nm_o2, qq, k, iop, target_frac, &
+      !$omp            zs_o1, zs_o2, frac, wdt, mng, zsill, dist, dzds, hgate, qq0, alpha, &
+      !$omp            dh, a_eff, &
+      !$omp            h_up, h_dn, qq_sign, &
+      !$omp            crest_breach, width_breach, z_crest_breach, z_min_breach, &
+      !$omp            tstart_breach, tstart_widening, t_phase1_deepening, &
+      !$omp            vk_f1, vk_f2, uc_material, elapsed_widening_hr, dt_hr, &
+      !$omp            widening_deceleration, widening_rate ) &
+      !$omp   schedule ( static )
+      do istruc = 1, nr_src_structures
+         !
+         nm_s1 = src_struc_nm_s1(istruc)
+         nm_s2 = src_struc_nm_s2(istruc)
+         !
+         if (nm_s1 > 0 .and. nm_s2 > 0) then
+            !
+            ! Ordered gate-rule list (any structure type).
+            !
+            ! Only runs if the structure has rules. Structures without rules
+            ! stay at the init-time default fraction_open = 1.0 ("always open"),
+            ! which turns the common-tail scaling below into a no-op.
+            !
+            ! Each step the rules are evaluated in order; the first whose "when"
+            ! expression fires sets the target gate position (open -> 1.0,
+            ! close -> 0.0, hold -> freeze at the current fraction). If no rule
+            ! fires the gate holds. The gate then ramps toward the target at
+            ! 1/opening_duration (opening) or 1/closing_duration (closing); a
+            ! target that flips mid-ramp simply reverses direction from the
+            ! current fraction, so the scheme is interruptible by construction.
+            ! Obs points feed the rule inputs and default to the src pair.
+            !
+            if (src_struc_rule_count(istruc) > 0) then
+               !
+               nm_o1 = src_struc_nm_o1(istruc)
+               nm_o2 = src_struc_nm_o2(istruc)
+               !
+               if (nm_o1 > 0) then
+                  zs_o1 = real(zs(nm_o1), 4)
+               else
+                  zs_o1 = 0.0
+               endif
+               !
+               if (nm_o2 > 0) then
+                  zs_o2 = real(zs(nm_o2), 4)
+               else
+                  zs_o2 = 0.0
+               endif
+               !
+               ! First matching rule wins; default to hold when none fires.
+               !
+               iop = gate_op_hold
+               !
+               do k = 1, src_struc_rule_count(istruc)
+                  !
+                  if (evaluate_rule(rule_list_id(src_struc_rule_start(istruc) + k - 1), zs_o1, zs_o2)) then
+                     !
+                     iop = rule_list_op(src_struc_rule_start(istruc) + k - 1)
+                     exit
+                     !
+                  endif
+                  !
+               enddo
+               !
+               frac = src_struc_fraction_open(istruc)
+               !
+               if (iop == gate_op_open) then
+                  target_frac = 1.0
+               elseif (iop == gate_op_close) then
+                  target_frac = 0.0
+               else
+                  target_frac = frac   ! hold: freeze at current fraction
+               endif
+               !
+               ! Ramp toward the target. A zero/negative duration snaps instantly.
+               !
+               if (target_frac > frac) then
+                  !
+                  if (src_struc_opening_duration(istruc) <= 0.0) then
+                     frac = target_frac
+                  else
+                     frac = min(frac + dt / src_struc_opening_duration(istruc), target_frac)
+                  endif
+                  !
+               elseif (target_frac < frac) then
+                  !
+                  if (src_struc_closing_duration(istruc) <= 0.0) then
+                     frac = target_frac
+                  else
+                     frac = max(frac - dt / src_struc_closing_duration(istruc), target_frac)
+                  endif
+                  !
+               endif
+               !
+               src_struc_fraction_open(istruc) = frac
+               !
+            endif
+            !
+            ! Per-type flux formula. Produces a raw signed discharge qq in
+            ! m^3/s, before the common-tail scaling by fraction_open and
+            ! direction filter.
+            !
+            select case(src_struc_type(istruc))
+               !
+               case(structure_pump)
+                  !
+                  ! Pump endpoint mapping: endpoint 1 (nm_s1) is the intake,
+                  ! endpoint 2 (nm_s2) is the discharge. The pump enforces
+                  ! qq >= 0 (no reverse flow); the sign convention in the
+                  ! common tail below then sends water from nm_s1 to nm_s2.
+                  !
+                  qq = src_struc_q(istruc)
+                  !
+                  ! Reduction curve: scale by upstream depth so the pump cannot
+                  ! pump the intake cell dry. pump_reduction_depth is a module-level
+                  ! constant (see top of module); not user-tunable.
+                  !
+                  ! Turn this off for now. Does not work with subgrid.
+                  !
+                  !h_up = max(real(zs(nm_s1), 4) - zb(nm_s1), 0.0)
+                  !qq   = qq * min(1.0, h_up / pump_reduction_depth)
+                  !
+               case(structure_culvert_simple)
+                  !
+                  ! Bidirectional: Q = flow_coef * sign(dh) * sqrt(|dh|).
+                  ! The legacy "check_valve" alias maps to direction_positive
+                  ! in the parser; the direction filter in the common tail
+                  ! below restricts the allowed sign when requested.
+                  !
+                  if (zs(nm_s1) > zs(nm_s2)) then
+                     !
+                     qq =  src_struc_flow_coef(istruc) * sqrt(zs(nm_s1) - zs(nm_s2))
+                     !
+                  else
+                     !
+                     qq = -src_struc_flow_coef(istruc) * sqrt(zs(nm_s2) - zs(nm_s1))
+                     !
+                  endif
+                  !
+               case(structure_culvert)
+                  !
+                  ! Regime-aware culvert. The controlling sill is the higher
+                  ! of the two inverts (flow cannot pass until the upstream
+                  ! water level reaches it). Upstream / downstream are picked
+                  ! by the water-level difference, so the structure is
+                  ! bidirectional and the direction filter in the common tail
+                  ! below restricts the sign when requested.
+                  !
+                  ! Two regimes, selected by h_dn/h_up against the user-set
+                  ! submergence_ratio threshold (default 2/3 = 0.667, the
+                  ! standard broad-crested-weir / Villemonte value):
+                  !
+                  !    submerged (h_dn/h_up >= threshold):
+                  !       qq = flow_coef * a_eff * sqrt(2 g |dh|)
+                  !    free / inlet-controlled (h_dn/h_up < threshold):
+                  !       qq = flow_coef * a_eff * sqrt(2 g  h_up)
+                  !
+                  ! The flow area a_eff = width * min(h_up, height) caps at
+                  ! the barrel height, so a deeply-submerged inlet can't
+                  ! give unbounded discharge.
+                  !
+                  zsill = max(src_struc_invert_1(istruc), src_struc_invert_2(istruc))
+                  !
+                  dh = real(zs(nm_s1), 4) - real(zs(nm_s2), 4)
+                  !
+                  if (dh >= 0.0) then
+                     !
+                     h_up    = max(real(zs(nm_s1), 4) - zsill, 0.0)
+                     h_dn    = max(real(zs(nm_s2), 4) - zsill, 0.0)
+                     qq_sign =  1.0
+                     !
+                  else
+                     !
+                     h_up    = max(real(zs(nm_s2), 4) - zsill, 0.0)
+                     h_dn    = max(real(zs(nm_s1), 4) - zsill, 0.0)
+                     qq_sign = -1.0
+                     !
+                  endif
+                  !
+                  if (h_up <= 0.0) then
+                     !
+                     qq = 0.0
+                     !
+                  else
+                     !
+                     a_eff = src_struc_width(istruc) * min(h_up, src_struc_height(istruc))
+                     !
+                     if (h_dn / h_up >= src_struc_submergence_ratio(istruc)) then
+                        !
+                        qq = qq_sign * src_struc_flow_coef(istruc) * a_eff * sqrt(2.0 * g * abs(dh))
+                        !
+                     else
+                        !
+                        qq = qq_sign * src_struc_flow_coef(istruc) * a_eff * sqrt(2.0 * g * h_up)
+                        !
+                     endif
+                     !
+                  endif
+                  !
+               case(structure_gate)
+                  !
+                  ! Bidirectional culvert-style flow. Flow uses the src pair
+                  ! (nm_s1/nm_s2), not the obs pair. Bates et al. (2010)
+                  ! inertial formulation, per unit width:
+                  !    q^{n+1} = (q^n - g*h*(dzs/ds)*dt) /
+                  !              (1 + g*n^2*dt*|q^n| / h^{7/3})
+                  ! with h = max(max(zs_s1, zs_s2) - zsill, 0).
+                  ! Multiply by width to get the full structure discharge;
+                  ! scaling by fraction_open happens in the common tail.
+                  ! src_struc_q_now(istruc) holds the previous step's discharge
+                  ! after the full common-tail scaling (width*fraction_open),
+                  ! so unscale by (width*fraction_open) to recover qq0 in
+                  ! per-unit-width form. Sign convention: qq > 0 means flow
+                  ! nm_s1 -> nm_s2, matching dzds = (zs_s2 - zs_s1)/dist.
+                  !
+                  frac  = src_struc_fraction_open(istruc)
+                  wdt   = src_struc_width(istruc)
+                  mng   = src_struc_mannings_n(istruc)
+                  zsill = src_struc_sill_elevation(istruc)
+                  dist  = src_struc_distance(istruc)
+                  !
+                  dzds  = (real(zs(nm_s2), 4) - real(zs(nm_s1), 4)) / dist
+                  hgate = max(max(real(zs(nm_s1), 4), real(zs(nm_s2), 4)) - zsill, 0.0)
+                  !
+                  if (hgate > 0.0 .and. frac > 0.0) then
+                     !
+                     qq0 = src_struc_q_now(istruc) / (wdt * max(frac, 0.001))
+                     qq  = (qq0 - g * hgate * dzds * dt) / &
+                           (1.0 + g * mng * mng * dt * abs(qq0) / hgate**(7.0/3.0))
+                     qq  = qq * wdt
+                     qq  = src_struc_flow_coef(istruc) * qq
+                     !
+                  else
+                     !
+                     qq = 0.0
+                     !
+                  endif
+                  !
+               case(structure_dike_breach)
+                  !
+                  ! Verheij-Knaap (2003): two-phase dike breach.
+                  ! Water levels are read from the obs pair (obs_1 = inside /
+                  ! high-head side; obs_2 = outside / low-head side), which
+                  ! default to the src pair when not user-specified.
+                  ! Flow direction and submergence follow the same pattern
+                  ! as structure_culvert (h_up / h_dn / src_struc_submergence_ratio).
+                  !
+                  nm_o1 = src_struc_nm_o1(istruc)
+                  nm_o2 = src_struc_nm_o2(istruc)
+                  !
+                  z_crest_breach      = src_struc_z_crest(istruc)
+                  z_min_breach        = src_struc_z_min(istruc)
+                  tstart_breach       = src_struc_t_breach(istruc)
+                  tstart_widening     = src_struc_t0(istruc)
+                  t_phase1_deepening  = tstart_breach + tstart_widening
+                  !
+                  width_breach = src_struc_breach_width(istruc)
+                  crest_breach = src_struc_breach_level(istruc)
+                  !
+                  if (src_struc_dike_core(istruc) == 1) then
+                     vk_f1 = 1.3; vk_f2 = 0.04; uc_material = 0.2  ! sand
+                  else
+                     vk_f1 = 1.3; vk_f2 = 0.04; uc_material = 0.5  ! clay
+                  endif
+                  !
+                  ! --- Breach geometry update ---
+                  !
+                  if (real(t, 4) >= tstart_breach) then
+                     !
+                     if (real(t, 4) < t_phase1_deepening) then
+                        !
+                        ! Phase 1: crest lowers linearly to z_min over t0; width = B0
+                        !
+                        crest_breach = z_crest_breach - (z_crest_breach - z_min_breach) * &
+                                       (real(t, 4) - tstart_breach) / tstart_widening
+                        width_breach = src_struc_B0(istruc)
+                        !
+                     else
+                        !
+                        ! Phase 2: crest at z_min, breach widens via Verheij formula.
+                        ! Driving head H = upstream head above z_min minus downstream.
+                        !
+                        crest_breach        = z_min_breach
+                        elapsed_widening_hr = (real(t, 4) - t_phase1_deepening) / 3600.0
+                        dt_hr               = dt / 3600.0
+                        ! Only widen when obs_1 (inside) is higher than obs_2 (outside).
+                        ! Reversed flow (ebb/return) is allowed but does not erode further.
+                        if (real(zs(nm_o1), 4) > real(zs(nm_o2), 4)) then
+                           h_up                 = max(real(zs(nm_o1), 4) - z_min_breach, 0.0)
+                           h_dn                 = max(real(zs(nm_o2), 4) - z_min_breach, 0.0)
+                           dh                   = max(h_up - h_dn, 0.0)
+                           widening_deceleration = max(1.0 + (vk_f2 * g / uc_material) * elapsed_widening_hr, 1.0e-12)
+                           widening_rate         = (vk_f1 * vk_f2 / log(10.0)) * (g * dh)**1.5 / &
+                                                   (uc_material * uc_material * widening_deceleration)
+                           width_breach = width_breach + max(widening_rate, 0.0) * dt_hr
+                        endif
+                        !
+                     endif
+                     !
+                  else
+                     crest_breach = z_crest_breach
+                     width_breach = 0.0
+                  endif
+                  !
+                  src_struc_breach_level(istruc) = crest_breach
+                  src_struc_breach_width(istruc) = width_breach
+                  !
+                  ! --- Discharge through breach (culvert-style, obs-point WLs) ---
+                  !
+                  dh = real(zs(nm_o1), 4) - real(zs(nm_o2), 4)
+                  if (dh >= 0.0) then
+                     h_up    = max(real(zs(nm_o1), 4) - crest_breach, 0.0)
+                     h_dn    = max(real(zs(nm_o2), 4) - crest_breach, 0.0)
+                     qq_sign = 1.0
+                  else
+                     h_up    = max(real(zs(nm_o2), 4) - crest_breach, 0.0)
+                     h_dn    = max(real(zs(nm_o1), 4) - crest_breach, 0.0)
+                     qq_sign = -1.0
+                  endif
+                  !
+                  if (h_up <= 0.0 .or. width_breach <= 0.0) then
+                     qq = 0.0
+                  elseif (h_dn / h_up >= src_struc_submergence_ratio(istruc)) then
+                     qq = qq_sign * width_breach * h_up * sqrt(2.0 * g * abs(dh))
+                  else
+                     qq = qq_sign * 1.71 * width_breach * sqrt(g) * h_up**1.5
+                  endif
+                  !
+            end select
+            !
+            ! Common tail: scale by fraction_open (state-machine output) and
+            ! apply the direction filter. Structures without rules sit at
+            ! fraction_open=1.0 so the scaling is a no-op; structures with
+            ! direction_both (the default) see the filter as a no-op too.
+            !
+            qq = qq * src_struc_fraction_open(istruc)
+            !
+            if (src_struc_direction(istruc) == direction_positive .and. qq < 0.0) qq = 0.0
+            if (src_struc_direction(istruc) == direction_negative .and. qq > 0.0) qq = 0.0
+            !
+            ! Relaxation: blend new and previous discharge to damp oscillations.
+            ! structure_relax is a dimensionless step count: alpha = 1/N damps
+            ! the discharge response over roughly N time steps. Typical 1-10.
+            !
+            alpha = 1.0 / structure_relax
+            qq = alpha * qq + (1.0 - alpha) * src_struc_q_now(istruc)
+            !
+            ! Limit discharge by available volume in the donor cell (endpoint 1
+            ! for qq > 0, endpoint 2 for qq < 0).
+            !
+            if (subgrid) then
+               !
+               if (qq > 0.0) then
+                  !
+                  qq = min(qq,  max(z_volume(nm_s1), 0.0) / dt)
+                  !
+               else
+                  !
+                  qq = max(qq, -max(z_volume(nm_s2), 0.0) / dt)
+                  !
+               endif
+               !
+            else
+               !
+               if (qq > 0.0) then
+                  !
+                  qq = min(qq,  max((zs(nm_s1) - zb(nm_s1)) * cell_area(z_flags_iref(nm_s1)), 0.0) / dt)
+                  !
+               else
+                  !
+                  qq = max(qq, -max((zs(nm_s2) - zb(nm_s2)) * cell_area(z_flags_iref(nm_s2)), 0.0) / dt)
+                  !
+               endif
+               !
+            endif
+            !
+            src_struc_q_now(istruc) = qq
+            !
+            ! Accumulate into cell-wise qsrc. Atomic guards against multiple
+            ! structures (or a river and a structure) in the same cell. Sign
+            ! convention qq > 0 means flow nm_s1 -> nm_s2, so qq is subtracted
+            ! at endpoint 1 and added at endpoint 2.
+            !
+            !$acc atomic update
+            !$omp atomic
+            qsrc(nm_s1) = qsrc(nm_s1) - qq
+            !$acc atomic update
+            !$omp atomic
+            qsrc(nm_s2) = qsrc(nm_s2) + qq
+            !
+         endif
+         !
+      enddo
+      !$omp end parallel do
+      !$acc end parallel loop
+      !
+   end subroutine
+   !
+   !-----------------------------------------------------------------------------------------------------!
+   !
+   subroutine read_toml_src_structures(filename, structures, ierr)
+      !
+      ! Parse a TOML input file describing point source structures into an
+      ! allocatable array of t_src_structure.
+      !
+      ! The TOML schema is an array of tables under the key "src_structure":
+      !
+      !    [[src_structure]]
+      !    name = "south_tide_gate"     ! required, string (sole identifier)
+      !    type = "gate"                ! required, one of pump/culvert_simple/gate/culvert
+      !                                 ! legacy alias: "check_valve" -> culvert_simple + direction="positive"
+      !                                 ! note: "culvert" now resolves to the detailed-culvert physics type;
+      !                                 !       users wanting the lumped one-coefficient form must say
+      !                                 !       "culvert_simple" explicitly. Orifice behaviour is recoverable
+      !                                 !       as "culvert" with submergence_ratio = 0.0.
+      !    direction = "both"           ! optional, culvert_simple/culvert only
+      !                                 ! one of "both" (default), "positive", "negative"
+      !                                 ! positive: allow flow src_1 -> src_2 only
+      !                                 ! negative: allow flow src_2 -> src_1 only
+      !    src_1 = [x, y] ; src_2 = [x, y]
+      !    obs_1 = [x, y] ; obs_2 = [x, y]
+      !    q = ...                      ! pump discharge
+      !    width = ... ; sill_elevation = ... ; mannings_n = ...
+      !    opening_duration = ... ; closing_duration = ...
+      !    flow_coef = ...              ! culvert_simple / culvert flow coefficient
+      !    height = ...                                 ! culvert pipe height (m)
+      !    invert_1 = ... ; invert_2 = ...              ! culvert invert elevations at src_1/src_2 ends
+      !    submergence_ratio = ...                      ! culvert submergence threshold h_dn/h_up (-)
+      !    [[src_structure.rule]]      ! optional, ordered list of gate control rules
+      !    operation = "close"         !   one of "open" / "close" / "hold"
+      !    when      = "z1-z2 < -0.03" !   trigger expression (rule mini-language)
+      !    [[src_structure.rule]]
+      !    operation = "open"
+      !    when      = "z1 > -0.15 & z1-z2 > 0.09"
+      !                                 ! Rules are evaluated in order; the first whose
+      !                                 ! "when" fires sets the target (open=1, close=0,
+      !                                 ! hold=freeze). If none fires the gate holds.
+      !                                 ! The gate ramps toward the target over
+      !                                 ! opening_duration / closing_duration; a target
+      !                                 ! flip mid-ramp reverses smoothly (interruptible).
+      !
+      ! Per-type required keys (enforced on parse):
+      !    pump           : name, src_1, src_2, q
+      !    culvert_simple : name, src_1, src_2, flow_coef
+      !    gate           : name, src_1, src_2, width, sill_elevation
+      !    culvert        : name, src_1, src_2,
+      !                     width, height, invert_1, invert_2
+      !                     (optional: flow_coef=0.6, submergence_ratio=0.667)
+      !
+      ! On success, structures is allocated to the exact number of entries
+      ! (can be 0). On any I/O or parse failure, structures is left
+      ! unallocated and ierr is non-zero.
+      !
+      ! This routine does not modify module state; it is the caller's job to
+      ! decide what to do with the parsed array.
+      !
+      ! Called from: initialize_src_structures (this module).
+      !
+      use tomlf
+      !
+      implicit none
+      !
+      character(len=*), intent(in)                    :: filename
+      type(t_src_structure), allocatable, intent(out) :: structures(:)
+      integer, intent(out)                            :: ierr
+      !
+      type(toml_table), allocatable    :: top
+      type(toml_error), allocatable    :: err
+      type(toml_array), pointer        :: arr_structs
+      type(toml_table), pointer        :: tbl_struct
+      type(toml_array), pointer        :: arr_rules
+      type(toml_table), pointer        :: tbl_rule
+      character(len=:), allocatable    :: name_str, type_str, rule_str, dir_str, type_str_lc, op_str
+      integer                          :: n_struct, n_rule, i, j, stat, ierr_parse
+      !
+      ierr = 0
+      !
+      ! Parse the file. toml_load returns an allocatable table; on failure the
+      ! table is not allocated and err carries the diagnostic.
+      !
+      call toml_load(top, filename, error=err)
+      !
+      if (allocated(err)) then
+         !
+         write(logstr,'(a,a,a,a)')' Error ! Failed to parse TOML file ', trim(filename), ': ', trim(err%message)
+         call write_log(logstr, 1)
+         ierr = 1
+         return
+         !
+      endif
+      !
+      if (.not. allocated(top)) then
+         !
+         write(logstr,'(a,a)')' Error ! Could not load TOML file ', trim(filename)
+         call write_log(logstr, 1)
+         ierr = 1
+         return
+         !
+      endif
+      !
+      ! Look for the top-level array of tables "src_structure". If it is not
+      ! present at all, treat that as "zero entries" (empty but valid).
+      !
+      nullify(arr_structs)
+      call get_value(top, 'src_structure', arr_structs, requested=.false., stat=stat)
+      !
+      if (.not. associated(arr_structs)) then
+         !
+         allocate(structures(0))
+         return
+         !
+      endif
+      !
+      if (.not. is_array_of_tables(arr_structs)) then
+         !
+         write(logstr,'(a,a)')' Error ! Key "src_structure" must be an array of tables in ', trim(filename)
+         call write_log(logstr, 1)
+         ierr = 1
+         return
+         !
+      endif
+      !
+      n_struct = len(arr_structs)
+      allocate(structures(n_struct))
+      !
+      do i = 1, n_struct
+         !
+         nullify(tbl_struct)
+         call get_value(arr_structs, i, tbl_struct, stat=stat)
+         !
+         if (.not. associated(tbl_struct)) then
+            !
+            write(logstr,'(a,i0,a)')' Error ! src_structure entry ', i, ' is not a table'
+            call write_log(logstr, 1)
+            call cleanup_on_error()
+            return
+            !
+         endif
+         !
+         ! Required name string (presence enforced by check_required below,
+         ! so that the missing-key error path flows through a single place).
+         !
+         if (allocated(name_str)) deallocate(name_str)
+         call get_value(tbl_struct, 'name', name_str, stat=stat)
+         if (allocated(name_str)) structures(i)%name = name_str
+         !
+         ! Required type string, mapped to structure_* code
+         !
+         if (allocated(type_str)) deallocate(type_str)
+         call get_value(tbl_struct, 'type', type_str, stat=stat)
+         !
+         if (.not. allocated(type_str)) then
+            !
+            write(logstr,'(a,i0,a,a)')' Error ! Missing required "type" in src_structure entry ', i, &
+                 ' of ', trim(filename)
+            call write_log(logstr, 1)
+            ierr = 1
+            call cleanup_on_error()
+            return
+            !
+         endif
+         !
+         call parse_structure_type(type_str, structures(i)%structure_type, ierr_parse)
+         !
+         if (ierr_parse /= 0) then
+            !
+            ierr = ierr_parse
+            write(logstr,'(a,a,a,i0)')' Error ! Unknown structure type "', trim(type_str), &
+                 '" in src_structure entry ', i
+            call write_log(logstr, 1)
+            call cleanup_on_error()
+            return
+            !
+         endif
+         !
+         ! Per-type required-field validation. Checked by key presence
+         ! (has_key) so that 0.0 remains a legal input value.
+         !
+         select case (structures(i)%structure_type)
+            !
+            case (structure_pump)
+               !
+               call check_required(tbl_struct, [ character(len=16) :: &
+                    'name', 'q' ], i, ierr)
+               call check_required_coord_pair(tbl_struct, 'src_1', i, ierr)
+               call check_required_coord_pair(tbl_struct, 'src_2', i, ierr)
+               !
+            case (structure_culvert_simple)
+               !
+               call check_required(tbl_struct, [ character(len=16) :: &
+                    'name', 'flow_coef' ], i, ierr)
+               call check_required_coord_pair(tbl_struct, 'src_1', i, ierr)
+               call check_required_coord_pair(tbl_struct, 'src_2', i, ierr)
+               !
+            case (structure_culvert)
+               !
+               call check_required(tbl_struct, [ character(len=16) :: &
+                    'name', 'width', 'height', 'invert_1', 'invert_2' ], i, ierr)
+               call check_required_coord_pair(tbl_struct, 'src_1', i, ierr)
+               call check_required_coord_pair(tbl_struct, 'src_2', i, ierr)
+               !
+            case (structure_gate)
+               !
+               call check_required(tbl_struct, [ character(len=16) :: &
+                    'name', 'width', 'sill_elevation' ], i, ierr)
+               call check_required_coord_pair(tbl_struct, 'src_1', i, ierr)
+               call check_required_coord_pair(tbl_struct, 'src_2', i, ierr)
+               !
+            case (structure_dike_breach)
+               !
+               call check_required(tbl_struct, [ character(len=16) :: &
+                    'name', 'z_crest', 't_breach', 'z_min', 'B0', 't0' ], i, ierr)
+               call check_required_coord_pair(tbl_struct, 'src_1', i, ierr)
+               call check_required_coord_pair(tbl_struct, 'src_2', i, ierr)
+               !
+         end select
+         !
+         if (ierr /= 0) then
+            !
+            call cleanup_on_error()
+            return
+            !
+         endif
+         !
+         ! Coordinates - src pair is required (enforced above). obs pair
+         ! defaults to src in the marshal when the key is absent; track
+         ! presence here so the marshal can distinguish "user gave (0,0)"
+         ! from "user gave nothing".
+         !
+         call read_coord_pair(tbl_struct, 'src_1', structures(i)%x_s1, structures(i)%y_s1, i, ierr)
+         call read_coord_pair(tbl_struct, 'src_2', structures(i)%x_s2, structures(i)%y_s2, i, ierr)
+         !
+         structures(i)%has_o1 = tbl_struct%has_key('obs_1')
+         structures(i)%has_o2 = tbl_struct%has_key('obs_2')
+         !
+         call read_coord_pair(tbl_struct, 'obs_1', structures(i)%x_o1, structures(i)%y_o1, i, ierr)
+         call read_coord_pair(tbl_struct, 'obs_2', structures(i)%x_o2, structures(i)%y_o2, i, ierr)
+         !
+         ! Named physical parameters. Defaults are picked to avoid NaN in
+         ! arithmetic and to match the legacy-reader fallbacks.
+         !
+         call get_value(tbl_struct, 'q',                structures(i)%q,                0.0,    stat=stat)
+         call get_value(tbl_struct, 'width',            structures(i)%width,            0.0,    stat=stat)
+         call get_value(tbl_struct, 'sill_elevation',   structures(i)%sill_elevation,   0.0,    stat=stat)
+         !
+         ! opening_duration / closing_duration default depends on type: gate keeps
+         ! its historical 600 s (legacy "dtype 4" gates always had finite ramp
+         ! durations), pump / culvert_simple / culvert default to 0 s (instant
+         ! open/close when a rule fires; skips the transient states 2 and 3).
+         !
+         if (structures(i)%structure_type == structure_gate) then
+            !
+            call get_value(tbl_struct, 'opening_duration', structures(i)%opening_duration, 600.0, stat=stat)
+            call get_value(tbl_struct, 'closing_duration', structures(i)%closing_duration, 600.0, stat=stat)
+            !
+         else
+            !
+            call get_value(tbl_struct, 'opening_duration', structures(i)%opening_duration, 0.0, stat=stat)
+            call get_value(tbl_struct, 'closing_duration', structures(i)%closing_duration, 0.0, stat=stat)
+            !
+         endif
+         !
+         ! flow_coef default differs by type: 1.0 for culvert_simple (legacy
+         ! lumped one-coefficient form), 0.6 for the detailed culvert
+         ! (standard orifice discharge coefficient).
+         !
+         if (structures(i)%structure_type == structure_culvert) then
+            !
+            call get_value(tbl_struct, 'flow_coef', structures(i)%flow_coef, 0.6, stat=stat)
+            !
+         else
+            !
+            call get_value(tbl_struct, 'flow_coef', structures(i)%flow_coef, 1.0, stat=stat)
+            !
+         endif
+         !
+         ! mannings_n (gate only). Default 0.024 for concrete-lined gate sill.
+         !
+         call get_value(tbl_struct, 'mannings_n', structures(i)%mannings_n, 0.024, stat=stat)
+         !
+         ! Detailed-culvert geometry + submergence threshold. Geometry keys
+         ! are required (enforced above); submergence_ratio defaults to 2/3
+         ! (0.667), the standard broad-crested-weir / Villemonte value.
+         !
+         call get_value(tbl_struct, 'height',            structures(i)%height,            0.0,   stat=stat)
+         call get_value(tbl_struct, 'invert_1',          structures(i)%invert_1,          0.0,   stat=stat)
+         call get_value(tbl_struct, 'invert_2',          structures(i)%invert_2,          0.0,   stat=stat)
+         call get_value(tbl_struct, 'submergence_ratio', structures(i)%submergence_ratio, 0.667, stat=stat)
+         !
+         ! Dike breach parameters (ignored for other types)
+         !
+         call get_value(tbl_struct, 'z_crest',   structures(i)%z_crest,   0.0, stat=stat)
+         call get_value(tbl_struct, 't_breach',  structures(i)%t_breach,  0.0, stat=stat)
+         call get_value(tbl_struct, 'z_min',     structures(i)%z_min,     0.0, stat=stat)
+         call get_value(tbl_struct, 'B0',        structures(i)%B0,        0.0, stat=stat)
+         call get_value(tbl_struct, 't0',        structures(i)%t0,        0.0, stat=stat)
+         call get_value(tbl_struct, 'dike_core', structures(i)%dike_core, 1,   stat=stat)
+         !
+         ! Optional direction filter (culvert_simple / culvert). Default is
+         ! direction_both. Unknown strings are a hard error.
+         !
+         structures(i)%direction = direction_both
+         !
+         if (allocated(dir_str)) deallocate(dir_str)
+         call get_value(tbl_struct, 'direction', dir_str, stat=stat)
+         !
+         if (allocated(dir_str)) then
+            !
+            call parse_direction(dir_str, structures(i)%direction, ierr_parse)
+            !
+            if (ierr_parse /= 0) then
+               !
+               ierr = ierr_parse
+               write(logstr,'(a,a,a,i0)')' Error ! Unknown direction "', trim(dir_str), &
+                    '" in src_structure entry ', i
+               call write_log(logstr, 1)
+               call cleanup_on_error()
+               return
+               !
+            endif
+            !
+         endif
+         !
+         ! Legacy alias side-effect: "check_valve" always pins direction_positive
+         ! regardless of any explicit direction key. Detect on the lowered type
+         ! string so "Check_Valve" etc. are handled identically.
+         !
+         type_str_lc = to_lower(type_str)
+         !
+         if (type_str_lc == 'check_valve') then
+            !
+            structures(i)%direction = direction_positive
+            !
+         endif
+         !
+         ! Optional ordered list of gate control rules under the sub-key
+         ! "rule" (an array of tables). Absent / empty leaves rules(:)
+         ! unallocated, which the marshal treats as "no rules".
+         !
+         nullify(arr_rules)
+         call get_value(tbl_struct, 'rule', arr_rules, requested=.false., stat=stat)
+         !
+         if (associated(arr_rules)) then
+            !
+            if (.not. is_array_of_tables(arr_rules)) then
+               !
+               write(logstr,'(a,i0,a)')' Error ! Key "rule" must be an array of tables in src_structure entry ', i, &
+                    ' (use [[src_structure.rule]])'
+               call write_log(logstr, 1)
+               ierr = 1
+               call cleanup_on_error()
+               return
+               !
+            endif
+            !
+            n_rule = len(arr_rules)
+            !
+            if (n_rule > 0) then
+               !
+               allocate(structures(i)%rules(n_rule))
+               !
+               do j = 1, n_rule
+                  !
+                  nullify(tbl_rule)
+                  call get_value(arr_rules, j, tbl_rule, stat=stat)
+                  !
+                  if (.not. associated(tbl_rule)) then
+                     write(logstr,'(a,i0,a,i0,a)')' Error ! rule ', j, ' in src_structure entry ', i, ' is not a table'
+                     call write_log(logstr, 1)
+                     ierr = 1
+                     call cleanup_on_error()
+                     return
+                  endif
+                  !
+                  ! operation (required): open / close / hold
+                  !
+                  if (allocated(op_str)) deallocate(op_str)
+                  call get_value(tbl_rule, 'operation', op_str, stat=stat)
+                  !
+                  if (.not. allocated(op_str)) then
+                     write(logstr,'(a,i0,a,i0)')' Error ! Missing "operation" in rule ', j, &
+                          ' of src_structure entry ', i
+                     call write_log(logstr, 1)
+                     ierr = 1
+                     call cleanup_on_error()
+                     return
+                  endif
+                  !
+                  call parse_operation(op_str, structures(i)%rules(j)%op, ierr_parse)
+                  !
+                  if (ierr_parse /= 0) then
+                     write(logstr,'(a,a,a,i0,a,i0)')' Error ! Unknown operation "', trim(op_str), &
+                          '" in rule ', j, ' of src_structure entry ', i
+                     call write_log(logstr, 1)
+                     ierr = 1
+                     call cleanup_on_error()
+                     return
+                  endif
+                  !
+                  ! when (required): the trigger expression
+                  !
+                  if (allocated(rule_str)) deallocate(rule_str)
+                  call get_value(tbl_rule, 'when', rule_str, stat=stat)
+                  !
+                  if (.not. allocated(rule_str)) then
+                     write(logstr,'(a,i0,a,i0)')' Error ! Missing "when" in rule ', j, &
+                          ' of src_structure entry ', i
+                     call write_log(logstr, 1)
+                     ierr = 1
+                     call cleanup_on_error()
+                     return
+                  endif
+                  !
+                  structures(i)%rules(j)%when = rule_str
+                  !
+               enddo
+               !
+            endif
+            !
+         endif
+         !
+      enddo
+      !
+      contains
+         !
+         subroutine cleanup_on_error()
+            !
+            ! Internal helper for the parse loop: drop the partially-filled
+            ! structures(:) array so the caller always sees it unallocated on
+            ! error exit. Trivial deallocator.
+            !
+            ! Called from: read_toml_src_structures (host routine) on every
+            ! error bail-out path.
+            !
+            if (allocated(structures)) deallocate(structures)
+            !
+         end subroutine
+         !
+   end subroutine
+   !
+   !-----------------------------------------------------------------------------------------------------!
+   !
+   subroutine check_required(table, keys, seq_index, ierr)
+      !
+      ! Verify that every key in "keys" is present in the TOML table. Missing
+      ! keys are reported to the log (naming the structure by its 1-based
+      ! sequence index, since "name" itself may be the missing key) and ierr
+      ! is set non-zero. Presence is checked via has_key so that a legal
+      ! value of 0.0 is not mistaken for "missing".
+      !
+      ! Called from: read_toml_src_structures (this module), once per
+      ! structure entry in the per-type required-field validation block.
+      !
+      use tomlf
+      !
+      implicit none
+      !
+      type(toml_table), pointer,    intent(in)    :: table
+      character(len=*),             intent(in)    :: keys(:)
+      integer,                      intent(in)    :: seq_index
+      integer,                      intent(inout) :: ierr
+      !
+      integer :: k
+      !
+      do k = 1, size(keys)
+         !
+         if (.not. table%has_key(trim(keys(k)))) then
+            !
+            write(logstr,'(a,i0,a,a,a)')' Error ! Structure #', seq_index, &
+                 ' is missing required key "', trim(keys(k)), '"'
+            call write_log(logstr, 1)
+            ierr = 1
+            !
+         endif
+         !
+      enddo
+      !
+   end subroutine
+   !
+   !-----------------------------------------------------------------------------------------------------!
+   !
+   subroutine check_required_coord_pair(table, key_base, seq_index, ierr)
+      !
+      ! Verify that a coordinate pair "<key_base> = [x, y]" is present in the
+      ! TOML table. Emits a single missing-key error when absent.
+      !
+      ! Called from: read_toml_src_structures (this module), once per required
+      ! coordinate pair (src_1, src_2) in the per-type validation block.
+      !
+      use tomlf
+      !
+      implicit none
+      !
+      type(toml_table), pointer, intent(in)    :: table
+      character(len=*),          intent(in)    :: key_base
+      integer,                   intent(in)    :: seq_index
+      integer,                   intent(inout) :: ierr
+      !
+      if (.not. table%has_key(trim(key_base))) then
+         !
+         write(logstr,'(a,i0,a,a,a)')' Error ! Structure #', seq_index, &
+              ' is missing required coordinate pair "', trim(key_base), ' = [x, y]"'
+         call write_log(logstr, 1)
+         ierr = 1
+         !
+      endif
+      !
+   end subroutine
+   !
+   !-----------------------------------------------------------------------------------------------------!
+   !
+   subroutine read_coord_pair(table, key_base, x, y, seq_index, ierr)
+      !
+      ! Read a coordinate pair "<key_base> = [x, y]" from a TOML table.
+      !
+      ! If the key is absent, x and y are left at 0.0 and no error is raised
+      ! here — presence of required pairs is enforced separately by
+      ! check_required_coord_pair.
+      !
+      ! Called from: read_toml_src_structures (this module), once per
+      ! coordinate pair (src_1, src_2, obs_1, obs_2) per structure entry.
+      !
+      use tomlf
+      !
+      implicit none
+      !
+      type(toml_table), pointer, intent(in)    :: table
+      character(len=*),          intent(in)    :: key_base
+      real,                      intent(out)   :: x, y
+      integer,                   intent(in)    :: seq_index
+      integer,                   intent(inout) :: ierr
+      !
+      type(toml_array), pointer :: arr
+      integer                   :: n, stat
+      !
+      x = 0.0
+      y = 0.0
+      !
+      if (.not. table%has_key(trim(key_base))) return
+      !
+      nullify(arr)
+      call get_value(table, trim(key_base), arr, requested=.false., stat=stat)
+      !
+      if (.not. associated(arr)) then
+         !
+         write(logstr,'(a,a,a,i0,a)')' Error ! Key "', trim(key_base), &
+              '" in src_structure #', seq_index, ' must be a 2-element array [x, y]'
+         call write_log(logstr, 1)
+         ierr = 1
+         return
+         !
+      endif
+      !
+      n = len(arr)
+      !
+      if (n /= 2) then
+         !
+         write(logstr,'(a,a,a,i0,a,i0,a)')' Error ! Key "', trim(key_base), &
+              '" in src_structure #', seq_index, ' must have exactly 2 elements (got ', n, ')'
+         call write_log(logstr, 1)
+         ierr = 1
+         return
+         !
+      endif
+      !
+      call get_value(arr, 1, x, stat=stat)
+      call get_value(arr, 2, y, stat=stat)
+      !
+   end subroutine
+   !
+   !-----------------------------------------------------------------------------------------------------!
+   !
+   subroutine parse_structure_type(str, code, ierr)
+      !
+      ! Translate a TOML "type" string to one of the structure_* codes.
+      !
+      ! Legacy alias accepted (quietly, no warning):
+      !    "check_valve" -> structure_culvert_simple
+      !                     (caller is responsible for pinning direction_positive)
+      !
+      ! Note: "culvert" now resolves to structure_culvert (the detailed
+      ! physics-based pipe-flow type). Users wanting the lumped one-coefficient
+      ! form must say "culvert_simple" explicitly.
+      !
+      ! Called from: read_toml_src_structures (this module), once per entry
+      ! to resolve the required "type" key.
+      !
+      implicit none
+      !
+      character(len=*), intent(in) :: str
+      integer, intent(out)         :: code
+      integer, intent(out)         :: ierr
+      !
+      character(len=:), allocatable :: s
+      !
+      ierr = 0
+      code = 0
+      s    = to_lower(str)
+      !
+      select case (s)
+         !
+         case ('pump')
+            !
+            code = structure_pump
+            !
+         case ('culvert_simple', 'check_valve')
+            !
+            code = structure_culvert_simple
+            !
+         case ('gate')
+            !
+            code = structure_gate
+            !
+         case ('culvert')
+            !
+            code = structure_culvert
+            !
+         case ('dike_breach')
+            !
+            code = structure_dike_breach
+            !
+         case default
+            !
+            ierr = 1
+            !
+      end select
+      !
+   end subroutine
+   !
+   !-----------------------------------------------------------------------------------------------------!
+   !
+   subroutine parse_direction(str, code, ierr)
+      !
+      ! Translate a TOML "direction" string to one of the direction_* codes.
+      ! Accepts "both" / "positive" / "negative" case-insensitively.
+      !
+      ! Called from: read_toml_src_structures (this module) when an optional
+      ! "direction" key is present on a structure entry.
+      !
+      implicit none
+      !
+      character(len=*), intent(in) :: str
+      integer, intent(out)         :: code
+      integer, intent(out)         :: ierr
+      !
+      character(len=:), allocatable :: s
+      !
+      ierr = 0
+      code = 0
+      s    = to_lower(str)
+      !
+      select case (s)
+         !
+         case ('both')
+            !
+            code = direction_both
+            !
+         case ('positive')
+            !
+            code = direction_positive
+            !
+         case ('negative')
+            !
+            code = direction_negative
+            !
+         case default
+            !
+            ierr = 1
+            !
+      end select
+      !
+   end subroutine
+   !
+   !-----------------------------------------------------------------------------------------------------!
+   !
+   subroutine parse_operation(str, code, ierr)
+      !
+      ! Translate a gate-rule "operation" string to one of the gate_op_* codes.
+      ! Accepts "open" / "close" / "hold" case-insensitively.
+      !
+      ! Called from: read_toml_src_structures (this module), once per rule in
+      ! a structure's [[src_structure.rule]] list.
+      !
+      implicit none
+      !
+      character(len=*), intent(in) :: str
+      integer, intent(out)         :: code
+      integer, intent(out)         :: ierr
+      !
+      character(len=:), allocatable :: s
+      !
+      ierr = 0
+      code = gate_op_hold
+      s    = to_lower(str)
+      !
+      select case (s)
+         !
+         case ('open')
+            !
+            code = gate_op_open
+            !
+         case ('close')
+            !
+            code = gate_op_close
+            !
+         case ('hold')
+            !
+            code = gate_op_hold
+            !
+         case default
+            !
+            ierr = 1
+            !
+      end select
+      !
+   end subroutine
+   !
+   !-----------------------------------------------------------------------------------------------------!
+   !
+   function to_lower(str) result(lower)
+      !
+      ! Return a lowercase copy of str (ASCII only).
+      !
+      ! Called from: parse_structure_type, parse_direction, and
+      ! convert_legacy_to_toml (all in this module).
+      !
+      implicit none
+      !
+      character(len=*), intent(in)  :: str
+      character(len=:), allocatable :: lower
+      !
+      integer :: k, ic
+      !
+      lower = str
+      !
+      do k = 1, len(lower)
+         !
+         ic = iachar(lower(k:k))
+         !
+         if (ic >= iachar('A') .and. ic <= iachar('Z')) then
+            !
+            lower(k:k) = achar(ic + 32)
+            !
+         endif
+         !
+      enddo
+      !
+   end function
+   !
+   !-----------------------------------------------------------------------------------------------------!
+   !
+   subroutine write_src_structures_log_summary()
+      !
+      ! Emit a one-block-per-structure description of every parsed src
+      ! structure to the log file. Intended for operator review at init
+      ! time; not printed to stdout.
+      !
+      ! Called from: initialize_src_structures (this module), once after
+      ! the marshal runs and cell indices have been resolved.
+      !
+      implicit none
+      !
+      integer :: i, k
+      character(len=32) :: type_str, dir_str, op_str
+      !
+      if (nr_src_structures <= 0) return
+      !
+      call write_log('------------------------------------------', 0)
+      call write_log('Flow control structures', 0)
+      call write_log('------------------------------------------', 0)
+      !
+      write(logstr,'(a,i0,a)')'Added ', nr_src_structures, ' flow control structures'
+      call write_log(logstr, 0)
+      call write_log('', 0)
+      !
+      do i = 1, nr_src_structures
+         !
+         select case (int(src_struc_type(i)))
+            !
+            case (structure_pump)
+               !
+               type_str = 'pump'
+               !
+            case (structure_culvert_simple)
+               !
+               type_str = 'culvert_simple'
+               !
+            case (structure_culvert)
+               !
+               type_str = 'culvert'
+               !
+            case (structure_gate)
+               !
+               type_str = 'gate'
+               !
+            case (structure_dike_breach)
+               !
+               type_str = 'dike_breach'
+               !
+            case default
+               !
+               type_str = 'unknown'
+               !
+         end select
+         !
+         write(logstr,'(a,i0,a)')'Structure ', i, ':'
+         call write_log(logstr, 0)
+         !
+         write(logstr,'(a22,1x,a)')              '  name               :',              trim(src_struc_name(i))
+         call write_log(logstr, 0)
+         !
+         write(logstr,'(a22,1x,a)')              '  type               :',              trim(type_str)
+         call write_log(logstr, 0)
+         !
+         write(logstr,'(a22,1x,a,a,a,a,a)')      '  src_1              :',             '(', trim(fmt_real(src_struc_x_s1(i), 3)), ', ', trim(fmt_real(src_struc_y_s1(i), 3)), ')'
+         call write_log(logstr, 0)
+         !
+         write(logstr,'(a22,1x,a,a,a,a,a)')      '  src_2              :',             '(', trim(fmt_real(src_struc_x_s2(i), 3)), ', ', trim(fmt_real(src_struc_y_s2(i), 3)), ')'
+         call write_log(logstr, 0)
+         !
+         ! obs coords are meaningful for culvert_simple / gate / dike_breach.
+         !
+         if (src_struc_type(i) == structure_culvert_simple .or. &
+             src_struc_type(i) == structure_gate           .or. &
+             src_struc_type(i) == structure_dike_breach) then
+            !
+            write(logstr,'(a22,1x,a,a,a,a,a)')   '  obs_1              :',              '(', trim(fmt_real(src_struc_x_o1(i), 3)), ', ', trim(fmt_real(src_struc_y_o1(i), 3)), ')'
+            call write_log(logstr, 0)
+            !
+            write(logstr,'(a22,1x,a,a,a,a,a)')   '  obs_2              :',              '(', trim(fmt_real(src_struc_x_o2(i), 3)), ', ', trim(fmt_real(src_struc_y_o2(i), 3)), ')'
+            call write_log(logstr, 0)
+            !
+         endif
+         !
+         if (src_struc_type(i) == structure_pump) then
+            !
+            write(logstr,'(a22,1x,a,a)')            '  discharge          :',       trim(fmt_real(src_struc_q(i), 4)), ' (m3/s)'
+            call write_log(logstr, 0)
+            !
+         endif
+         !
+         if (src_struc_type(i) == structure_culvert_simple) then
+            !
+            write(logstr,'(a22,1x,a)')              '  flow_coef          :',       trim(fmt_real(src_struc_flow_coef(i), 4))
+            call write_log(logstr, 0)
+            !
+         endif
+         !
+         ! Direction filter (culvert_simple / culvert)
+         !
+         if (src_struc_type(i) == structure_culvert_simple .or. &
+             src_struc_type(i) == structure_culvert) then
+            !
+            select case (src_struc_direction(i))
+               !
+               case (direction_both)
+                  !
+                  dir_str = 'both'
+                  !
+               case (direction_positive)
+                  !
+                  dir_str = 'positive'
+                  !
+               case (direction_negative)
+                  !
+                  dir_str = 'negative'
+                  !
+               case default
+                  !
+                  dir_str = 'unknown'
+                  !
+            end select
+            !
+            write(logstr,'(a22,1x,a)')              '  direction          :',      trim(dir_str)
+            call write_log(logstr, 0)
+            !
+         endif
+         !
+         if (src_struc_type(i) == structure_culvert) then
+            !
+            write(logstr,'(a22,1x,a,a)')            '  width              :',              trim(fmt_real(src_struc_width(i), 4)),             ' (m)'
+            call write_log(logstr, 0)
+            !
+            write(logstr,'(a22,1x,a,a)')            '  height             :',             trim(fmt_real(src_struc_height(i), 4)),            ' (m)'
+            call write_log(logstr, 0)
+            !
+            write(logstr,'(a22,1x,a,a)')            '  invert_1           :',           trim(fmt_real(src_struc_invert_1(i), 4)),          ' (m)'
+            call write_log(logstr, 0)
+            !
+            write(logstr,'(a22,1x,a,a)')            '  invert_2           :',           trim(fmt_real(src_struc_invert_2(i), 4)),          ' (m)'
+            call write_log(logstr, 0)
+            !
+            write(logstr,'(a22,1x,a)')              '  flow_coef          :',          trim(fmt_real(src_struc_flow_coef(i), 4))
+            call write_log(logstr, 0)
+            !
+            write(logstr,'(a22,1x,a)')              '  submergence_ratio  :',  trim(fmt_real(src_struc_submergence_ratio(i), 4))
+            call write_log(logstr, 0)
+            !
+         endif
+         !
+         if (src_struc_type(i) == structure_gate) then
+            !
+            write(logstr,'(a22,1x,a,a)')            '  width              :',              trim(fmt_real(src_struc_width(i), 4)),             ' (m)'
+            call write_log(logstr, 0)
+            !
+            write(logstr,'(a22,1x,a,a)')            '  sill_elevation     :',     trim(fmt_real(src_struc_sill_elevation(i), 4)),    ' (m)'
+            call write_log(logstr, 0)
+            !
+            write(logstr,'(a22,1x,a)')              '  mannings_n         :',         trim(fmt_real(src_struc_mannings_n(i), 4))
+            call write_log(logstr, 0)
+            !
+            write(logstr,'(a22,1x,a,a)')            '  opening_duration   :',   trim(fmt_real(src_struc_opening_duration(i), 2)),  ' (s)'
+            call write_log(logstr, 0)
+            !
+            write(logstr,'(a22,1x,a,a)')            '  closing_duration   :',   trim(fmt_real(src_struc_closing_duration(i), 2)),  ' (s)'
+            call write_log(logstr, 0)
+            !
+         endif
+         !
+         if (src_struc_type(i) == structure_dike_breach) then
+            !
+            write(logstr,'(a22,a,a)')            '  z_crest:',            trim(fmt_real(src_struc_z_crest(i), 4)),           ' (m)'
+            call write_log(logstr, 0)
+            !
+            write(logstr,'(a22,a,a)')            '  z_min:',              trim(fmt_real(src_struc_z_min(i), 4)),             ' (m)'
+            call write_log(logstr, 0)
+            !
+            write(logstr,'(a22,a,a)')            '  t_breach:',           trim(fmt_real(src_struc_t_breach(i), 2)),          ' (s)'
+            call write_log(logstr, 0)
+            !
+            write(logstr,'(a22,a,a)')            '  t0:',                 trim(fmt_real(src_struc_t0(i), 2)),                ' (s)'
+            call write_log(logstr, 0)
+            !
+            write(logstr,'(a22,a,a)')            '  B0:',                 trim(fmt_real(src_struc_B0(i), 4)),                ' (m)'
+            call write_log(logstr, 0)
+            !
+            if (src_struc_dike_core(i) == 1) then
+               write(logstr,'(a22,a)')           '  dike_core:',          'sand (1)'
+            else
+               write(logstr,'(a22,a)')           '  dike_core:',          'clay (2)'
+            endif
+            call write_log(logstr, 0)
+            !
+         endif
+         !
+         if (src_struc_rule_count(i) > 0) then
+            !
+            write(logstr,'(a22,1x,i0)')             '  rules              :',      src_struc_rule_count(i)
+            call write_log(logstr, 0)
+            !
+            do k = 1, src_struc_rule_count(i)
+               !
+               select case (rule_list_op(src_struc_rule_start(i) + k - 1))
+                  case (gate_op_open);  op_str = 'open'
+                  case (gate_op_close); op_str = 'close'
+                  case default;         op_str = 'hold'
+               end select
+               !
+               write(logstr,'(a,i0,1x,a8,1x,a,a,a)') '    ', k, adjustl(op_str), &
+                    '"', trim(rule_list_src(src_struc_rule_start(i) + k - 1)), '"'
+               call write_log(logstr, 0)
+               !
+            enddo
+            !
+         endif
+         !
+         ! Opening/closing durations. For gate structures these are always
+         ! printed (above); for other types only print if rules are set and
+         ! the duration is non-zero (non-default).
+         !
+         if (src_struc_type(i) /= structure_gate) then
+            !
+            if (src_struc_rule_count(i) > 0 .and. &
+                (src_struc_opening_duration(i) > 0.0 .or. src_struc_closing_duration(i) > 0.0)) then
+               !
+               write(logstr,'(a22,1x,a,a)')         '  opening_duration   :',  trim(fmt_real(src_struc_opening_duration(i), 2)),  ' (s)'
+               call write_log(logstr, 0)
+               !
+               write(logstr,'(a22,1x,a,a)')         '  closing_duration   :',  trim(fmt_real(src_struc_closing_duration(i), 2)),  ' (s)'
+               call write_log(logstr, 0)
+               !
+            endif
+            !
+         endif
+         !
+         call write_log('', 0)
+         !
+      enddo
+      !
+   end subroutine
+   !
+   !-----------------------------------------------------------------------------------------------------!
+   !
+   subroutine convert_legacy_to_toml(legacy_path, toml_path, ierr)
+      !
+      ! Transcribe a legacy fixed-column drn file into a TOML sibling file,
+      ! so that downstream code only has to consume the TOML schema. One
+      ! [[src_structure]] block is emitted per non-blank, non-comment line
+      ! of the legacy file. Water-level-triggered gates (legacy dtype 4) are
+      ! converted to TOML gate blocks with synthesised rule expressions.
+      ! Schedule-triggered gates (legacy dtype 5) are refused; the new rule
+      ! grammar is water-level-only and has no time atom.
+      !
+      ! The output path is derived from legacy_path: if it ends in ".drn"
+      ! (case-insensitive) the suffix ".toml" is inserted before the ".drn",
+      ! otherwise ".toml" is appended. The resolved path is returned in
+      ! toml_path for the caller to feed into the TOML reader.
+      !
+      ! The converter is deliberately minimal: no coord sanity checks, no
+      ! duplicate-name detection, no preservation of comments. It exists only
+      ! to remove the parallel legacy parsing machinery that used to live
+      ! in this module.
+      !
+      ! Called from: initialize_src_structures (this module) when toml-f
+      ! rejects the drn file on the initial probe.
+      !
+      implicit none
+      !
+      character(len=*), intent(in)  :: legacy_path
+      character(len=*), intent(out) :: toml_path
+      integer,          intent(out) :: ierr
+      !
+      integer            :: u_in, u_out, stat, n_struct, dtype
+      integer            :: len_in, ext_pos
+      real*4             :: x2, y2, x1, y1, par
+      real*4             :: g_width, g_sill, g_mann, g_zmin, g_zmax, g_tcls
+      character(len=512) :: line, trimmed
+      character(len=32)  :: name_str
+      character(len=16)  :: type_name, par_name, dir_name
+      character(len=13)  :: zmin_str, zmax_str
+      character(len=128) :: rule_open_str, rule_close_str
+      !
+      ierr     = 0
+      n_struct = 0
+      u_in     = 501
+      u_out    = 502
+      !
+      ! Derive the TOML sibling path from legacy_path. If legacy_path ends
+      ! in ".drn" (case-insensitive), insert ".toml" before the extension;
+      ! else append ".toml".
+      !
+      len_in  = len_trim(legacy_path)
+      ext_pos = 0
+      !
+      if (len_in >= 4) then
+         !
+         if (to_lower(legacy_path(len_in-3:len_in)) == '.drn') then
+            !
+            ext_pos = len_in - 3
+            !
+         endif
+         !
+      endif
+      !
+      if (ext_pos > 0) then
+         !
+         toml_path = legacy_path(1:ext_pos-1) // '.toml' // legacy_path(ext_pos:len_in)
+         !
+      else
+         !
+         toml_path = legacy_path(1:len_in) // '.toml'
+         !
+      endif
+      !
+      open(u_in,  file=trim(legacy_path), status='old',     action='read',  iostat=stat)
+      !
+      if (stat /= 0) then
+         !
+         write(logstr,'(a,a,a)')' Error ! Could not open legacy drn file "', trim(legacy_path), '" for reading'
+         call write_log(logstr, 1)
+         ierr = 1
+         return
+         !
+      endif
+      !
+      open(u_out, file=trim(toml_path),   status='replace', action='write', iostat=stat)
+      !
+      if (stat /= 0) then
+         !
+         write(logstr,'(a,a,a)')' Error ! Could not open TOML output file "', trim(toml_path), '" for writing'
+         close(u_in)
+         call write_log(logstr, 1)
+         ierr = 1
+         return
+         !
+      endif
+      !
+      write(u_out,'(a)') '# Auto-generated from legacy drn file by SFINCS.'
+      write(u_out,'(a)') '# Do not edit; edit the legacy source or rewrite as TOML directly.'
+      write(u_out,'(a)') ''
+      !
+      do while (.true.)
+         !
+         read(u_in,'(a)', iostat=stat) line
+         !
+         if (stat /= 0) exit
+         !
+         ! Skip blank / comment lines.
+         !
+         trimmed = adjustl(line)
+         !
+         if (len_trim(trimmed) == 0) cycle
+         if (trimmed(1:1) == '#' .or. trimmed(1:1) == '!') cycle
+         !
+         ! Columns: x1, y1, x2, y2, dtype, par.
+         ! (legacy xsnk=intake -> src_1; legacy xsrc=outfall -> src_2).
+         !
+         read(line, *, iostat=stat) x1, y1, x2, y2, dtype, par
+         !
+         if (stat /= 0) then
+            !
+            write(logstr,'(a,a,a)')' Error ! Could not parse legacy drn line in "', trim(legacy_path), '"'
+            call write_log(logstr, 1)
+            write(logstr,'(a,a)')'        line: ', trim(line)
+            call write_log(logstr, 1)
+            close(u_in)
+            close(u_out)
+            ierr = 1
+            return
+            !
+         endif
+         !
+         ! Branch on dtype. Gates (4, 5) and unknown codes set ierr and bail.
+         !
+         ! dir_name is left blank unless dtype pins a direction filter; a blank
+         ! dir_name causes the emitter below to skip the direction key entirely,
+         ! which reads back as direction_both (the default).
+         !
+         dir_name = ''
+         !
+         select case (dtype)
+            !
+            case (1)
+               !
+               type_name = 'pump'
+               par_name  = 'q'
+               !
+            case (2)
+               !
+               ! legacy culvert -> bidirectional culvert_simple
+               !
+               type_name = 'culvert_simple'
+               par_name  = 'flow_coef'
+               !
+            case (3)
+               !
+               ! legacy check_valve -> culvert_simple with direction = "positive"
+               !
+               type_name = 'culvert_simple'
+               par_name  = 'flow_coef'
+               dir_name  = 'positive'
+               !
+            case (4)
+               !
+               ! Water-level-triggered gate. Legacy columns past dtype:
+               !   width, sill_elevation, mannings_n, zmin, zmax, t_close.
+               ! Re-read the whole line to pull those extra columns.
+               !
+               read(line, *, iostat=stat) x1, y1, x2, y2, dtype, &
+                    g_width, g_sill, g_mann, g_zmin, g_zmax, g_tcls
+               !
+               if (stat /= 0) then
+                  !
+                  write(logstr,'(a,a,a)')' Error ! Could not parse legacy dtype-4 gate line in "', trim(legacy_path), '"'
+                  call write_log(logstr, 1)
+                  write(logstr,'(a,a)')'        line: ', trim(line)
+                  call write_log(logstr, 1)
+                  close(u_in)
+                  close(u_out)
+                  ierr = 1
+                  return
+                  !
+               endif
+               !
+               ! Synthesise rule strings with the legacy numeric values baked in.
+               ! Grammar accepts '<', '>', '&', '|' only (no '<=' / '>=').
+               !
+               write(zmin_str,'(es13.6)') g_zmin
+               write(zmax_str,'(es13.6)') g_zmax
+               write(rule_open_str, '(a,a,a,a)') 'z1>', trim(adjustl(zmin_str)), ' & z1<', trim(adjustl(zmax_str))
+               write(rule_close_str,'(a,a,a,a)') 'z1<', trim(adjustl(zmin_str)), ' | z1>', trim(adjustl(zmax_str))
+               !
+               n_struct = n_struct + 1
+               !
+               if (g_zmin >= g_zmax) then
+                  !
+                  write(logstr,'(a,i0,a)')' Warning ! legacy gate entry ', n_struct, ': zmin >= zmax, open rule will never fire'
+                  call write_log(logstr, 0)
+                  !
+               endif
+               !
+               write(name_str,'(a,i0)') 'legacy_', n_struct
+               !
+               write(u_out,'(a)')         '[[src_structure]]'
+               write(u_out,'(a,a,a)')     'name             = "', trim(name_str), '"'
+               write(u_out,'(a)')         'type             = "gate"'
+               write(u_out,'(a,es14.6,a,es14.6,a)') 'src_1            = [', x1, ', ', y1, ']'
+               write(u_out,'(a,es14.6,a,es14.6,a)') 'src_2            = [', x2, ', ', y2, ']'
+               write(u_out,'(a,es14.6)')  'width            = ', g_width
+               write(u_out,'(a,es14.6)')  'sill_elevation   = ', g_sill
+               write(u_out,'(a,es14.6)')  'mannings_n       = ', g_mann
+               write(u_out,'(a,es14.6)')  'opening_duration = ', g_tcls
+               write(u_out,'(a,es14.6)')  'closing_duration = ', g_tcls
+               write(u_out,'(a)')         '[[src_structure.rule]]'
+               write(u_out,'(a)')         'operation = "open"'
+               write(u_out,'(a,a,a)')     'when      = "', trim(rule_open_str),  '"'
+               write(u_out,'(a)')         '[[src_structure.rule]]'
+               write(u_out,'(a)')         'operation = "close"'
+               write(u_out,'(a,a,a)')     'when      = "', trim(rule_close_str), '"'
+               write(u_out,'(a)')         ''
+               !
+               cycle
+               !
+            case (5)
+               !
+               write(logstr,'(a)')' Error ! legacy schedule-triggered gate (dtype 5) not supported - rewrite as TOML with rule-based triggers or file an issue to add a time atom to the rule grammar'
+               call write_log(logstr, 1)
+               close(u_in)
+               close(u_out)
+               ierr = 1
+               return
+               !
+            case default
+               !
+               write(logstr,'(a,i0,a)')' Error ! unknown drainage_type ', dtype, ' in legacy drn file'
+               call write_log(logstr, 1)
+               close(u_in)
+               close(u_out)
+               ierr = 1
+               return
+               !
+         end select
+         !
+         n_struct = n_struct + 1
+         write(name_str,'(a,i0)') 'legacy_', n_struct
+         !
+         write(u_out,'(a)')         '[[src_structure]]'
+         write(u_out,'(a,a,a)')     'name    = "', trim(name_str), '"'
+         write(u_out,'(a,a,a)')     'type    = "', trim(type_name),'"'
+         !
+         if (len_trim(dir_name) > 0) then
+            !
+            write(u_out,'(a,a,a)')  'direction = "', trim(dir_name), '"'
+            !
+         endif
+         !
+         write(u_out,'(a,es14.6,a,es14.6,a)') 'src_1   = [', x1, ', ', y1, ']'
+         write(u_out,'(a,es14.6,a,es14.6,a)') 'src_2   = [', x2, ', ', y2, ']'
+         write(u_out,'(a,a,a,es14.6)') trim(par_name), repeat(' ', max(1, 7 - len_trim(par_name))), '= ', par
+         write(u_out,'(a)')         ''
+         !
+      enddo
+      !
+      close(u_in)
+      close(u_out)
+      !
+      write(logstr,'(a,a,a,a,a)')' Converted legacy drn file "', trim(legacy_path), &
+           '" to TOML "', trim(toml_path), '"'
+      call write_log(logstr, 0)
+      !
+   end subroutine
+   !
+end module

--- a/source/src/sfincs_src_structures.f90
+++ b/source/src/sfincs_src_structures.f90
@@ -85,7 +85,13 @@ module sfincs_src_structures
    !
    use sfincs_log
    use sfincs_error
-   use sfincs_rule_expression, only: add_rule, evaluate_rule, finalize_rule_storage
+   ! The rule bytecode arrays are named in the !$acc present() clause of
+   ! update_src_structures: evaluate_rule is an acc routine seq and reads
+   ! them on the device, so they must be in scope in this module too.
+   !
+   use sfincs_rule_expression, only: add_rule, evaluate_rule, finalize_rule_storage, &
+                                     rule_opcode, rule_atom, rule_cmp, rule_threshold, &
+                                     rule_start, rule_length
    !
    private :: parse_structure_type, parse_direction, parse_operation, to_lower, check_required
    private :: convert_legacy_to_toml

--- a/source/src/sfincs_src_structures.f90
+++ b/source/src/sfincs_src_structures.f90
@@ -1248,9 +1248,9 @@ contains
                   if (h_up <= 0.0 .or. width_breach <= 0.0) then
                      qq = 0.0
                   elseif (h_dn / h_up >= src_struc_submergence_ratio(istruc)) then
-                     qq = qq_sign * width_breach * h_up * sqrt(2.0 * g * abs(dh))
+                     qq = qq_sign * width_breach * h_dn * sqrt(2.0 * g * abs(dh))
                   else
-                     qq = qq_sign * 1.71 * width_breach * sqrt(g) * h_up**1.5
+                     qq = qq_sign * 1.71 * width_breach * h_up**1.5
                   endif
                   !
             end select

--- a/source/src/sfincs_urban_drainage.f90
+++ b/source/src/sfincs_urban_drainage.f90
@@ -1,0 +1,993 @@
+module sfincs_urban_drainage
+   !
+   ! Simple urban-drainage sink/source model for SFINCS.
+   !
+   ! Each zone is a polygon in the horizontal plane and has one of two
+   ! types:
+   !
+   !   piped_drainage  — cells inside the polygon drain to a single
+   !                     outfall cell through a conceptual buried pipe
+   !                     network. Flow is bidirectional: during high
+   !                     water at the outfall (tide / surge), water can
+   !                     push back into the zone cells unless a check
+   !                     valve is configured. The per-zone net flux is
+   !                     added as a point source/sink at the outfall.
+   !
+   !   injection_well  — water is pumped out of the zone cells (evenly
+   !                     split across the cells in the polygon) and
+   !                     disappears from the model underground. There is
+   !                     no outfall and no backflow. Pumping stops when
+   !                     the cumulative injected volume reaches the
+   !                     well's maximum capacity.
+   !
+   ! Common mechanics (both types):
+   !
+   !    dt-capped per-cell drain: q = min(ramp * qmax(nm), h_cell * A(nm) / dt)
+   !    ramp = min(h_cell / h_threshold, 1) if h_threshold > 0, else 1
+   !    h_cell = zs(nm) - (subgrid ? subgrid_z_zmin(nm) : zb(nm))
+   !
+   ! Piped drainage specifics:
+   !
+   !    dzs = zs(nm) - zs(outfall)
+   !    if dzs > 0: drain as above (positive q, water leaves cell)
+   !    if dzs < 0: backflow q = -backflow_coef(nm)*sqrt(-dzs), capped at
+   !                -qmax(nm); suppressed entirely by check_valve
+   !    Per-cell qmax from the design precipitation rate:
+   !       qmax(nm) = design_precip_mm_hr * 1e-3 / 3600 * cell_area(nm)
+   !    Alternatively the user may supply max_outfall_rate [m3/s] for the
+   !    whole zone (exclusive with design_precip per zone); design_precip
+   !    is then derived as
+   !       design_precip_mm_hr = max_outfall_rate / zone_area * 1000 * 3600
+   !    which distributes the capacity proportionally to cell area.
+   !    Per-cell design-head (bed_elev is subgrid_z_zmin in subgrid mode,
+   !    zb otherwise):
+   !       dh_design(nm) = max(bed_elev(nm) - bed_elev(outfall), dh_design_min)
+   !       backflow_coef(nm) = qmax(nm) / sqrt(dh_design(nm))
+   !
+   ! Injection well specifics:
+   !
+   !    Per-cell qmax is area-weighted, so the sum across zone cells is
+   !    exactly injection_rate and refinement-level changes inside a
+   !    zone don't shift the per-cell flux relative to cell area:
+   !       qmax(nm) = injection_rate * cell_area(nm) / zone_area
+   !    The zone holds a running cumulative_injection(iz) = sum(qd*dt)
+   !    across cells and time steps. Once cumulative_injection(iz)
+   !    reaches urb_zone_maximum_capacity(iz), pumping is skipped for
+   !    that zone (flow drops to zero).
+   !
+   ! Subroutines:
+   !
+   !   initialize_urban_drainage()
+   !     Top-level driver. Calls read_urban_drainage, loads polygons,
+   !     marks cells per zone (last zone wins on overlap), snaps outfall
+   !     coords to the nearest active cell (piped_drainage only),
+   !     precomputes per-cell qmax and backflow_coef. Called from
+   !     sfincs_lib (once at init time).
+   !
+   !   read_urban_drainage(filename, ierr)
+   !     Parses the *.urb TOML file into the per-zone arrays. Called
+   !     from initialize_urban_drainage (this module).
+   !
+   !   update_urban_drainage(t, dt)
+   !     Per-time-step entry: accumulates signed discharges into qsrc
+   !     and adds the zone contribution at the outfall cell (for
+   !     piped_drainage zones). Called from update_continuity
+   !     (sfincs_continuity).
+   !
+   !   write_urban_drainage_log_summary()
+   !     Prints a one-block-per-zone summary to the log. Called from
+   !     initialize_urban_drainage (this module).
+   !
+   use sfincs_log
+   use sfincs_error
+   use sfincs_polygons
+   !
+   implicit none
+   !
+   private
+   !
+   public :: initialize_urban_drainage
+   public :: update_urban_drainage
+   !
+   ! Zone type identifiers. Kept public so ncoutput can branch on type
+   ! when writing per-zone output variables.
+   !
+   integer, parameter, public :: urb_type_piped_drainage = 1
+   integer, parameter, public :: urb_type_injection_well = 2
+   !
+   ! Per-zone runtime state. Sized nr_urban_drainage_zones.
+   !
+   integer, public :: nr_urban_drainage_zones = 0
+   !
+   character(len=64),  dimension(:), allocatable, public :: urb_zone_name
+   character(len=64),  dimension(:), allocatable, public :: urb_zone_type      ! original TOML type string (for logging)
+   character(len=256), dimension(:), allocatable         :: urb_zone_polygon_file
+   integer,            dimension(:), allocatable, public :: urb_zone_type_id   ! one of urb_type_*
+   !
+   real*4,  dimension(:), allocatable, public :: urb_zone_outfall_x          ! m (piped_drainage)
+   real*4,  dimension(:), allocatable, public :: urb_zone_outfall_y          ! m (piped_drainage)
+   real*4,  dimension(:), allocatable, public :: urb_zone_design_precip      ! mm/hr (piped_drainage; either direct or derived from max_outfall_rate)
+   real*4,  dimension(:), allocatable, public :: urb_zone_max_outfall_rate   ! m3/s (piped_drainage; 0.0 if input was design_precip)
+   real*4,  dimension(:), allocatable, public :: urb_zone_injection_rate     ! m3/s (injection_well)
+   real*4,  dimension(:), allocatable, public :: urb_zone_maximum_capacity   ! m3 (injection_well)
+   real*4,  dimension(:), allocatable, public :: urb_zone_h_threshold        ! m ponding threshold (both types)
+   real*4,  dimension(:), allocatable, public :: urb_zone_dh_design_min      ! m floor on design head (piped_drainage)
+   logical, dimension(:), allocatable, public :: urb_zone_include_outfall    ! (piped_drainage)
+   logical, dimension(:), allocatable, public :: urb_zone_check_valve        ! (piped_drainage)
+   !
+   integer, dimension(:), allocatable, public :: urban_drainage_outfall_index   ! cell index, 0 if none
+   real*4,  dimension(:), allocatable, public :: urban_drainage_q_total         ! m3/s per zone, per step (total discharge leaving zone cells)
+   real*4,  dimension(:), allocatable, public :: urb_zone_cumulative_injection  ! m3 accumulated per zone (injection_well)
+   real*4,  dimension(:), allocatable, public :: urb_zone_area                  ! m2, sum of cell areas in zone
+   integer, dimension(:), allocatable, public :: urb_zone_n_cells               ! number of cells in zone
+   real*4,  dimension(:), allocatable, public :: urb_zone_qmax_total            ! m3/s, sum of per-cell qmax
+   !
+   ! Per-cell runtime state. Sized np.
+   !
+   integer, dimension(:), allocatable, public :: urban_drainage_zone_indices       ! 0 if not in any zone
+   real*4,  dimension(:), allocatable, public :: urban_drainage_qmax               ! m3/s cap per cell
+   real*4,  dimension(:), allocatable, public :: urban_drainage_backflow_coef      ! qmax / sqrt(dh_design), piped_drainage only
+   real*4,  dimension(:), allocatable, public :: urban_drainage_cumulative_volume  ! m3 accumulated per cell
+   !
+contains
+   !
+   !-----------------------------------------------------------------------------------------------------!
+   !
+   subroutine initialize_urban_drainage()
+      !
+      ! Top-level initializer for urban drainage. Parses *.urb TOML file,
+      ! loads polygons, stamps cells per zone (last-wins on overlap), snaps
+      ! outfall coords (piped_drainage zones only) to the nearest active
+      ! cell, and precomputes per-cell qmax and backflow coefficients.
+      !
+      ! Sets sfincs_data::urban_drainage = .true. when at least one zone is
+      ! loaded and has at least one participating cell. Otherwise leaves it
+      ! .false. and returns early.
+      !
+      ! Called from: sfincs_lib (once, at init time, after
+      ! initialize_src_structures).
+      !
+      use sfincs_data
+      use quadtree
+      !
+      implicit none
+      !
+      integer                       :: ierr, ipoly, iz, nm, io
+      integer                       :: n_cells_in_zones, n_outfalls, nmq
+      real*4                        :: area_nm, dzb, dh_min
+      type(t_polygon), allocatable  :: polygons(:)
+      logical, allocatable          :: inside(:)
+      character(len=256)            :: last_file
+      integer                       :: ip
+      !
+      urban_drainage = .false.
+      !
+      if (urbfile(1:4) == 'none') return
+      !
+      call write_log('Info    : reading urban drainage file ...', 0)
+      !
+      call read_urban_drainage(trim(urbfile), ierr)
+      !
+      if (ierr /= 0) then
+         call stop_sfincs('Error ! Failed to read urban drainage TOML file.', -1)
+         return
+      endif
+      !
+      if (nr_urban_drainage_zones <= 0) then
+         call write_log('Info    : urban drainage file contains no zones; feature disabled', 0)
+         return
+      endif
+      !
+      ! Allocate per-zone snapped outfall index and per-step accumulators.
+      !
+      allocate(urban_drainage_outfall_index(nr_urban_drainage_zones))
+      allocate(urban_drainage_q_total(nr_urban_drainage_zones))
+      allocate(urb_zone_cumulative_injection(nr_urban_drainage_zones))
+      allocate(urb_zone_area(nr_urban_drainage_zones))
+      allocate(urb_zone_n_cells(nr_urban_drainage_zones))
+      allocate(urb_zone_qmax_total(nr_urban_drainage_zones))
+      urban_drainage_outfall_index  = 0
+      urban_drainage_q_total        = 0.0
+      urb_zone_cumulative_injection = 0.0
+      urb_zone_area                 = 0.0
+      urb_zone_n_cells              = 0
+      urb_zone_qmax_total           = 0.0
+      !
+      ! Allocate per-cell state.
+      !
+      allocate(urban_drainage_zone_indices(np))
+      allocate(urban_drainage_qmax(np))
+      allocate(urban_drainage_backflow_coef(np))
+      allocate(urban_drainage_cumulative_volume(np))
+      urban_drainage_zone_indices      = 0
+      urban_drainage_qmax              = 0.0
+      urban_drainage_backflow_coef     = 0.0
+      urban_drainage_cumulative_volume = 0.0
+      !
+      ! Stamp cells per zone. Polygons are cached per unique file so that
+      ! multiple zones sharing a polygon file only trigger one file read.
+      ! Within a file each polygon name is matched against urb_zone_name.
+      !
+      allocate(inside(np))
+      last_file = ''
+      !
+      do iz = 1, nr_urban_drainage_zones
+         !
+         if (trim(urb_zone_polygon_file(iz)) == '') then
+            write(logstr,'(a,a,a)')' Error ! Urban drainage zone "', trim(urb_zone_name(iz)), &
+                 '" has no polygon_file'
+            call stop_sfincs(trim(logstr), -1)
+         endif
+         !
+         if (trim(urb_zone_polygon_file(iz)) /= trim(last_file)) then
+            if (allocated(polygons)) then
+               do ip = 1, size(polygons)
+                  if (allocated(polygons(ip)%x)) deallocate(polygons(ip)%x)
+                  if (allocated(polygons(ip)%y)) deallocate(polygons(ip)%y)
+               enddo
+               deallocate(polygons)
+            endif
+            call read_tek_polygons(trim(urb_zone_polygon_file(iz)), polygons, ierr)
+            if (ierr /= 0) then
+               write(logstr,'(a,a)')' Error ! Failed to read urban drainage polygon file ', &
+                    trim(urb_zone_polygon_file(iz))
+               call stop_sfincs(trim(logstr), -1)
+            endif
+            last_file = urb_zone_polygon_file(iz)
+         endif
+         !
+         ! Find a polygon in this file whose name matches this zone's name.
+         !
+         ipoly = 0
+         do ip = 1, size(polygons)
+            if (trim(polygons(ip)%name) == trim(urb_zone_name(iz))) then
+               ipoly = ip
+               exit
+            endif
+         enddo
+         !
+         if (ipoly == 0) then
+            write(logstr,'(a,a,a,a)')' Error ! No polygon named "', trim(urb_zone_name(iz)), &
+                 '" found in file ', trim(urb_zone_polygon_file(iz))
+            call stop_sfincs(trim(logstr), -1)
+         endif
+         !
+         ! Test all active cell centers against this polygon.
+         !
+         inside = .false.
+         call points_in_polygon_omp(z_xz, z_yz, np, polygons(ipoly), inside)
+         !
+         ! Last-zone-wins: overwrite zone_indices wherever inside is true.
+         !
+         do nm = 1, np
+            if (inside(nm)) urban_drainage_zone_indices(nm) = iz
+         enddo
+         !
+      enddo
+      !
+      if (allocated(polygons)) then
+         do ip = 1, size(polygons)
+            if (allocated(polygons(ip)%x)) deallocate(polygons(ip)%x)
+            if (allocated(polygons(ip)%y)) deallocate(polygons(ip)%y)
+         enddo
+         deallocate(polygons)
+      endif
+      deallocate(inside)
+      !
+      ! Snap outfall coordinates to nearest active cell (piped_drainage only).
+      !
+      n_outfalls = 0
+      !
+      do iz = 1, nr_urban_drainage_zones
+         !
+         if (urb_zone_type_id(iz) /= urb_type_piped_drainage) cycle
+         if (.not. urb_zone_include_outfall(iz)) cycle
+         !
+         nmq = find_quadtree_cell(urb_zone_outfall_x(iz), urb_zone_outfall_y(iz))
+         if (nmq > 0) urban_drainage_outfall_index(iz) = index_sfincs_in_quadtree(nmq)
+         !
+         if (urban_drainage_outfall_index(iz) <= 0) then
+            write(logstr,'(a,a,a)')' Warning : outfall for zone "', trim(urb_zone_name(iz)), &
+                 '" could not be snapped to an active cell; zone contributions will be discarded'
+            call write_log(logstr, 0)
+         else
+            n_outfalls = n_outfalls + 1
+         endif
+         !
+      enddo
+      !
+      ! Precompute per-cell qmax and backflow coef. Two passes: first
+      ! accumulate per-zone area and cell count, then derive design_precip
+      ! where needed and compute per-cell qmax.
+      !
+      ! Pass 1: accumulate area and cell count per zone.
+      !
+      n_cells_in_zones = 0
+      !
+      do nm = 1, np
+         !
+         iz = urban_drainage_zone_indices(nm)
+         if (iz == 0) cycle
+         !
+         if (crsgeo) then
+            area_nm = cell_area_m2(nm)
+         else
+            area_nm = cell_area(z_flags_iref(nm))
+         endif
+         !
+         urb_zone_area(iz)    = urb_zone_area(iz) + area_nm
+         urb_zone_n_cells(iz) = urb_zone_n_cells(iz) + 1
+         n_cells_in_zones     = n_cells_in_zones + 1
+         !
+      enddo
+      !
+      ! Derive design_precip for piped_drainage zones that were given
+      ! max_outfall_rate. Error out on injection_well zones with zero cells.
+      !
+      do iz = 1, nr_urban_drainage_zones
+         !
+         if (urb_zone_type_id(iz) == urb_type_piped_drainage) then
+            !
+            if (urb_zone_max_outfall_rate(iz) > 0.0) then
+               !
+               if (urb_zone_area(iz) <= 0.0) then
+                  write(logstr,'(a,a,a)')' Error ! urban_drainage_zone "', trim(urb_zone_name(iz)), &
+                       '" has max_outfall_rate set but zero participating cells; cannot derive design_precip'
+                  call stop_sfincs(trim(logstr), -1)
+               endif
+               !
+               urb_zone_design_precip(iz) = urb_zone_max_outfall_rate(iz) / urb_zone_area(iz) * 1000.0 * 3600.0
+               !
+            endif
+            !
+         elseif (urb_zone_type_id(iz) == urb_type_injection_well) then
+            !
+            if (urb_zone_n_cells(iz) <= 0) then
+               write(logstr,'(a,a,a)')' Error ! urban_drainage_zone "', trim(urb_zone_name(iz)), &
+                    '" is an injection_well with zero participating cells'
+               call stop_sfincs(trim(logstr), -1)
+            endif
+            !
+         endif
+         !
+      enddo
+      !
+      ! Pass 2: compute per-cell qmax and (piped only) backflow coefficient.
+      !
+      do nm = 1, np
+         !
+         iz = urban_drainage_zone_indices(nm)
+         if (iz == 0) cycle
+         !
+         if (crsgeo) then
+            area_nm = cell_area_m2(nm)
+         else
+            area_nm = cell_area(z_flags_iref(nm))
+         endif
+         !
+         if (urb_zone_type_id(iz) == urb_type_piped_drainage) then
+            !
+            ! mm/hr -> m/s then m3/s
+            !
+            urban_drainage_qmax(nm) = urb_zone_design_precip(iz) * 1.0e-3 / 3600.0 * area_nm
+            !
+            io = urban_drainage_outfall_index(iz)
+            !
+            if (io > 0) then
+               dh_min = urb_zone_dh_design_min(iz)
+               if (subgrid) then
+                  dzb = max(subgrid_z_zmin(nm) - subgrid_z_zmin(io), dh_min)
+               else
+                  dzb = max(zb(nm) - zb(io), dh_min)
+               endif
+               urban_drainage_backflow_coef(nm) = urban_drainage_qmax(nm) / sqrt(dzb)
+            endif
+            !
+         elseif (urb_zone_type_id(iz) == urb_type_injection_well) then
+            !
+            ! Split pump capacity across the zone by cell area so the sum
+            ! over zone cells equals injection_rate exactly.
+            !
+            urban_drainage_qmax(nm) = urb_zone_injection_rate(iz) * area_nm / urb_zone_area(iz)
+            !
+         endif
+         !
+         urb_zone_qmax_total(iz) = urb_zone_qmax_total(iz) + urban_drainage_qmax(nm)
+         !
+      enddo
+      !
+      write(logstr,'(a,i0,a,i0,a,i0,a)')' Info    : urban drainage: ', nr_urban_drainage_zones, &
+           ' zone(s), ', n_cells_in_zones, ' cell(s) assigned, ', n_outfalls, ' outfall(s)'
+      call write_log(logstr, 0)
+      !
+      if (n_cells_in_zones > 0) urban_drainage = .true.
+      !
+      call write_urban_drainage_log_summary()
+      !
+   end subroutine
+   !
+   !-----------------------------------------------------------------------------------------------------!
+   !
+   subroutine update_urban_drainage(t, dt)
+      !
+      ! Per-time-step entry: accumulate signed discharges into qsrc for
+      ! cells inside drainage zones, add the zone contribution at each
+      ! piped_drainage outfall cell, and accumulate the per-zone
+      ! cumulative injection volume for injection_well zones.
+      !
+      ! Sign convention: qd > 0 means water leaves the cell (drains to
+      ! outfall or underground). qsrc(nm) -= qd subtracts that flux from
+      ! the cell; for piped_drainage zones the same amount is added back
+      ! at the outfall cell. injection_well zones don't return water to
+      ! the model.
+      !
+      ! Called from: update_continuity (sfincs_continuity), once per time
+      ! step, after update_src_structures.
+      !
+      use sfincs_data
+      !
+      implicit none
+      !
+      real*8, intent(in) :: t
+      real*4, intent(in) :: dt
+      !
+      integer :: nm, iz, io, type_id
+      real*4  :: dzs, qd, area_nm, h_cell, ramp
+      !
+      if (nr_urban_drainage_zones <= 0) return
+      !
+      !$acc kernels present(urban_drainage_q_total)
+      urban_drainage_q_total = 0.0
+      !$acc end kernels
+      !
+      !$acc parallel loop present( qsrc, zs, zb, subgrid_z_zmin,z_volume, cell_area, cell_area_m2, z_flags_iref, &
+      !$acc                        urban_drainage_zone_indices, urban_drainage_outfall_index, &
+      !$acc                        urban_drainage_qmax, urban_drainage_backflow_coef, &
+      !$acc                        urban_drainage_q_total, urban_drainage_cumulative_volume, &
+      !$acc                        urb_zone_type_id, urb_zone_maximum_capacity, urb_zone_cumulative_injection, &
+      !$acc                        urb_zone_h_threshold, urb_zone_check_valve ) &
+      !$acc                reduction(+:urban_drainage_q_total)
+      !$omp parallel do default(shared) &
+      !$omp private(nm, iz, io, type_id, dzs, qd, area_nm, h_cell, ramp) &
+      !$omp reduction(+:urban_drainage_q_total) schedule(static)
+      do nm = 1, np
+         !
+         iz = urban_drainage_zone_indices(nm)
+         if (iz == 0) cycle
+         !
+         type_id = urb_zone_type_id(iz)
+         !
+         if (type_id == urb_type_injection_well) then
+            !
+            ! Skip entirely once the well has reached maximum capacity.
+            ! Small overshoot of one dt is acceptable; we do not scale
+            ! per-cell flux to hit the cap exactly.
+            !
+            if (urb_zone_cumulative_injection(iz) >= urb_zone_maximum_capacity(iz)) cycle
+            !
+            if (subgrid) then
+               h_cell = zs(nm) - subgrid_z_zmin(nm)
+            else
+               h_cell = zs(nm) - zb(nm)
+            endif
+            !
+            if (h_cell <= 0.0) cycle
+            !
+            if (urb_zone_h_threshold(iz) > 0.0) then
+               ramp = min(h_cell / urb_zone_h_threshold(iz), 1.0)
+            else
+               ramp = 1.0
+            endif
+            !
+            if (crsgeo) then
+               area_nm = cell_area_m2(nm)
+            else
+               area_nm = cell_area(z_flags_iref(nm))
+            endif
+            !
+            if (subgrid) then
+               qd = min(ramp * urban_drainage_qmax(nm), z_volume(nm) / dt)
+            else
+               qd = min(ramp * urban_drainage_qmax(nm), h_cell * area_nm / dt)
+            endif
+            !
+         else
+            !
+            ! piped_drainage
+            !
+            io = urban_drainage_outfall_index(iz)
+            if (io <= 0) cycle
+            !
+            dzs = zs(nm) - zs(io)
+            !
+            if (dzs > 0.0) then
+               !
+               if (subgrid) then
+                  h_cell = zs(nm) - subgrid_z_zmin(nm)
+               else
+                  h_cell = zs(nm) - zb(nm)
+               endif
+               if (h_cell <= 0.0) cycle
+               !
+               if (urb_zone_h_threshold(iz) > 0.0) then
+                  ramp = min(h_cell / urb_zone_h_threshold(iz), 1.0)
+               else
+                  ramp = 1.0
+               endif
+               !
+               if (crsgeo) then
+                  area_nm = cell_area_m2(nm)
+               else
+                  area_nm = cell_area(z_flags_iref(nm))
+               endif
+               !
+               if (subgrid) then
+                  qd = min(ramp * urban_drainage_qmax(nm), z_volume(nm) / dt)
+               else
+                  qd = min(ramp * urban_drainage_qmax(nm), h_cell * area_nm / dt)
+               endif
+               !
+            else
+               !
+               if (urb_zone_check_valve(iz)) cycle
+               !
+               qd = -urban_drainage_backflow_coef(nm) * sqrt(-dzs)
+               if (qd < -urban_drainage_qmax(nm)) qd = -urban_drainage_qmax(nm)
+               !
+            endif
+            !
+         endif
+         !
+         ! qsrc(nm) is unique per iteration (loop is over nm), no race.
+         ! The zone accumulator urban_drainage_q_total(iz) is summed via
+         ! the reduction(+) clause on the parent directive, so each
+         ! thread / gang gets a private copy that is combined at loop end.
+         !
+         qsrc(nm) = qsrc(nm) - qd
+         !
+         urban_drainage_q_total(iz) = urban_drainage_q_total(iz) + qd
+         !
+         urban_drainage_cumulative_volume(nm) = urban_drainage_cumulative_volume(nm) + qd * dt
+         !
+      enddo
+      !$omp end parallel do
+      !
+      ! Second pass: for piped_drainage zones, deposit the per-zone flux
+      ! at the outfall cell; for injection_well zones, accumulate the
+      ! cumulative injected volume.
+      !
+      !$acc parallel loop present( qsrc, urban_drainage_outfall_index, urban_drainage_q_total, &
+      !$acc                        urb_zone_type_id, urb_zone_cumulative_injection )
+      do iz = 1, nr_urban_drainage_zones
+         !
+         if (urb_zone_type_id(iz) == urb_type_piped_drainage) then
+            !
+            io = urban_drainage_outfall_index(iz)
+            if (io <= 0) cycle
+            !
+            !$acc atomic update
+            qsrc(io) = qsrc(io) + urban_drainage_q_total(iz)
+            !
+         else
+            !
+            ! injection_well
+            !
+            urb_zone_cumulative_injection(iz) = urb_zone_cumulative_injection(iz) + urban_drainage_q_total(iz) * dt
+            !
+         endif
+         !
+      enddo
+      !
+   end subroutine
+   !
+   !-----------------------------------------------------------------------------------------------------!
+   !
+   subroutine write_urban_drainage_log_summary()
+      !
+      ! Emit a one-block-per-zone description of every parsed urban
+      ! drainage zone to the log file. Intended for operator review at
+      ! init time.
+      !
+      ! Called from: initialize_urban_drainage (this module), once after
+      ! cells have been stamped and per-zone totals have been
+      ! accumulated.
+      !
+      implicit none
+      !
+      integer :: iz
+      !
+      if (nr_urban_drainage_zones <= 0) return
+      !
+      call write_log('------------------------------------------', 0)
+      call write_log('Urban drainage zones', 0)
+      call write_log('------------------------------------------', 0)
+      !
+      write(logstr,'(a,i0,a)')'Added ', nr_urban_drainage_zones, ' urban drainage zone(s)'
+      call write_log(logstr, 0)
+      call write_log('', 0)
+      !
+      do iz = 1, nr_urban_drainage_zones
+         !
+         write(logstr,'(a,i0,a)')'Zone ', iz, ':'
+         call write_log(logstr, 0)
+         !
+         write(logstr,'(a,a)')         '  name:             ', trim(urb_zone_name(iz))
+         call write_log(logstr, 0)
+         !
+         write(logstr,'(a,a)')         '  type:             ', trim(urb_zone_type(iz))
+         call write_log(logstr, 0)
+         !
+         write(logstr,'(a,a)')         '  polygon_file:     ', trim(urb_zone_polygon_file(iz))
+         call write_log(logstr, 0)
+         !
+         write(logstr,'(a,i0)')        '  cells_assigned:   ', urb_zone_n_cells(iz)
+         call write_log(logstr, 0)
+         !
+         write(logstr,'(a,a,a)')       '  area:             ', trim(fmt_real(urb_zone_area(iz), 1)), ' (m2)'
+         call write_log(logstr, 0)
+         !
+         if (urb_zone_type_id(iz) == urb_type_piped_drainage) then
+            !
+            if (urb_zone_max_outfall_rate(iz) > 0.0) then
+               write(logstr,'(a,a,a)')    '  max_outfall_rate: ', trim(fmt_real(urb_zone_max_outfall_rate(iz), 4)), ' (m3/s)'
+               call write_log(logstr, 0)
+               write(logstr,'(a,a,a)')    '  design_precip:    ', trim(fmt_real(urb_zone_design_precip(iz), 2)), &
+                    ' (mm/hr, derived from max_outfall_rate)'
+               call write_log(logstr, 0)
+            else
+               write(logstr,'(a,a,a)')    '  design_precip:    ', trim(fmt_real(urb_zone_design_precip(iz), 2)), ' (mm/hr)'
+               call write_log(logstr, 0)
+            endif
+            !
+            write(logstr,'(a,a,a)')       '  qmax_total:       ', trim(fmt_real(urb_zone_qmax_total(iz), 4)), ' (m3/s)'
+            call write_log(logstr, 0)
+            !
+            write(logstr,'(a,a,a)')       '  h_threshold:      ', trim(fmt_real(urb_zone_h_threshold(iz), 3)), ' (m)'
+            call write_log(logstr, 0)
+            !
+            write(logstr,'(a,a,a)')       '  dh_design_min:    ', trim(fmt_real(urb_zone_dh_design_min(iz), 3)), ' (m)'
+            call write_log(logstr, 0)
+            !
+            if (urb_zone_include_outfall(iz)) then
+               write(logstr,'(a,a,a,a,a)') '  outfall:          [', trim(fmt_real(urb_zone_outfall_x(iz), 3)), ', ', &
+                    trim(fmt_real(urb_zone_outfall_y(iz), 3)), ']'
+               call write_log(logstr, 0)
+               !
+               if (urban_drainage_outfall_index(iz) > 0) then
+                  write(logstr,'(a,i0)')  '  outfall_index:    ', urban_drainage_outfall_index(iz)
+                  call write_log(logstr, 0)
+               else
+                  call write_log('  outfall_index:    (no active cell snapped)', 0)
+               endif
+            else
+               call write_log('  outfall:          (disabled)', 0)
+            endif
+            !
+            if (urb_zone_check_valve(iz)) then
+               call write_log('  check_valve:      true', 0)
+            else
+               call write_log('  check_valve:      false', 0)
+            endif
+            !
+         elseif (urb_zone_type_id(iz) == urb_type_injection_well) then
+            !
+            write(logstr,'(a,a,a)')       '  injection_rate:   ', trim(fmt_real(urb_zone_injection_rate(iz), 4)), ' (m3/s)'
+            call write_log(logstr, 0)
+            !
+            write(logstr,'(a,a,a)')       '  maximum_capacity: ', trim(fmt_real(urb_zone_maximum_capacity(iz), 1)), ' (m3)'
+            call write_log(logstr, 0)
+            !
+            write(logstr,'(a,a,a)')       '  qmax_total:       ', trim(fmt_real(urb_zone_qmax_total(iz), 4)), ' (m3/s)'
+            call write_log(logstr, 0)
+            !
+            write(logstr,'(a,a,a)')       '  h_threshold:      ', trim(fmt_real(urb_zone_h_threshold(iz), 3)), ' (m)'
+            call write_log(logstr, 0)
+            !
+         endif
+         !
+         call write_log('', 0)
+         !
+      enddo
+      !
+   end subroutine
+   !
+   !-----------------------------------------------------------------------------------------------------!
+   !
+   subroutine read_urban_drainage(filename, ierr)
+      !
+      ! Parse the *.urb TOML file into the per-zone arrays.
+      !
+      ! Schema:
+      !
+      !    [[urban_drainage_zone]]
+      !    name              = "area 1"            ! required, string (matches polygon name)
+      !    type              = "piped_drainage"    ! required, one of: "piped_drainage", "injection_well"
+      !    polygon_file      = "zones.tek"         ! required
+      !
+      !    # piped_drainage keys:
+      !    outfall           = [950.0, 150.0]      ! required if include_outfall = true, [x, y] pair
+      !    design_precip     = 20.0                ! required if max_outfall_rate absent, mm/hr
+      !    max_outfall_rate  = 6.0                 ! alternative to design_precip, m3/s total zone capacity
+      !                                            ! exactly one of {design_precip, max_outfall_rate} must be given
+      !    dh_design_min     = 0.1                 ! optional, m (default 0.1)
+      !    include_outfall   = true                ! optional (default true)
+      !    check_valve       = true                ! optional (default false)
+      !
+      !    # injection_well keys:
+      !    injection_rate    = 0.5                 ! required, m3/s total zone pump rate
+      !    maximum_capacity  = 1000.0              ! required, m3 well total storage capacity
+      !
+      !    # common:
+      !    h_threshold       = 0.0                 ! optional, m (default 0.0)
+      !
+      ! Called from: initialize_urban_drainage (this module).
+      !
+      use tomlf
+      !
+      implicit none
+      !
+      character(len=*), intent(in)  :: filename
+      integer,          intent(out) :: ierr
+      !
+      type(toml_table), allocatable :: top
+      type(toml_error), allocatable :: err
+      type(toml_array), pointer     :: arr_zones
+      type(toml_table), pointer     :: tbl_zone
+      character(len=:), allocatable :: name_str, type_str, poly_str
+      integer                       :: nz, i, stat
+      real(kind=8)                  :: r8_tmp
+      logical                       :: l_tmp, found
+      !
+      ierr = 0
+      !
+      call toml_load(top, filename, error=err)
+      if (allocated(err)) then
+         write(logstr,'(a,a,a,a)')' Error ! Failed to parse TOML file ', trim(filename), ': ', &
+              trim(err%message)
+         call write_log(logstr, 1)
+         ierr = 1
+         return
+      endif
+      !
+      if (.not. allocated(top)) then
+         write(logstr,'(a,a)')' Error ! Could not load TOML file ', trim(filename)
+         call write_log(logstr, 1)
+         ierr = 1
+         return
+      endif
+      !
+      nullify(arr_zones)
+      call get_value(top, 'urban_drainage_zone', arr_zones, requested=.false., stat=stat)
+      !
+      if (.not. associated(arr_zones)) then
+         nr_urban_drainage_zones = 0
+         return
+      endif
+      !
+      if (.not. is_array_of_tables(arr_zones)) then
+         write(logstr,'(a,a)')' Error ! Key "urban_drainage_zone" must be an array of tables in ', &
+              trim(filename)
+         call write_log(logstr, 1)
+         ierr = 1
+         return
+      endif
+      !
+      nz = len(arr_zones)
+      nr_urban_drainage_zones = nz
+      !
+      if (nz == 0) return
+      !
+      allocate(urb_zone_name(nz))
+      allocate(urb_zone_type(nz))
+      allocate(urb_zone_type_id(nz))
+      allocate(urb_zone_polygon_file(nz))
+      allocate(urb_zone_outfall_x(nz))
+      allocate(urb_zone_outfall_y(nz))
+      allocate(urb_zone_design_precip(nz))
+      allocate(urb_zone_max_outfall_rate(nz))
+      allocate(urb_zone_injection_rate(nz))
+      allocate(urb_zone_maximum_capacity(nz))
+      allocate(urb_zone_h_threshold(nz))
+      allocate(urb_zone_dh_design_min(nz))
+      allocate(urb_zone_include_outfall(nz))
+      allocate(urb_zone_check_valve(nz))
+      !
+      urb_zone_name             = ''
+      urb_zone_type             = ''
+      urb_zone_type_id          = 0
+      urb_zone_polygon_file     = ''
+      urb_zone_outfall_x        = 0.0
+      urb_zone_outfall_y        = 0.0
+      urb_zone_design_precip    = 0.0
+      urb_zone_max_outfall_rate = 0.0
+      urb_zone_injection_rate   = 0.0
+      urb_zone_maximum_capacity = 0.0
+      urb_zone_h_threshold      = 0.0
+      urb_zone_dh_design_min    = 0.1
+      urb_zone_include_outfall  = .true.
+      urb_zone_check_valve      = .false.
+      !
+      do i = 1, nz
+         !
+         nullify(tbl_zone)
+         call get_value(arr_zones, i, tbl_zone, stat=stat)
+         if (.not. associated(tbl_zone)) then
+            write(logstr,'(a,i0,a)')' Error ! urban_drainage_zone entry ', i, ' is not a table'
+            call write_log(logstr, 1)
+            ierr = 1
+            return
+         endif
+         !
+         if (allocated(name_str)) deallocate(name_str)
+         call get_value(tbl_zone, 'name', name_str, stat=stat)
+         if (.not. allocated(name_str)) then
+            write(logstr,'(a,i0)')' Error ! Missing required "name" in urban_drainage_zone entry ', i
+            call write_log(logstr, 1)
+            ierr = 1
+            return
+         endif
+         urb_zone_name(i) = name_str
+         !
+         ! type is now required and must resolve to a known type id.
+         !
+         if (allocated(type_str)) deallocate(type_str)
+         call get_value(tbl_zone, 'type', type_str, stat=stat)
+         if (.not. allocated(type_str)) then
+            write(logstr,'(a,a,a)')' Error ! Missing required "type" in urban_drainage_zone "', &
+                 trim(urb_zone_name(i)), '" (expected "piped_drainage" or "injection_well")'
+            call write_log(logstr, 1)
+            ierr = 1
+            return
+         endif
+         urb_zone_type(i) = type_str
+         !
+         select case (trim(type_str))
+         case ('piped_drainage')
+            urb_zone_type_id(i) = urb_type_piped_drainage
+         case ('injection_well')
+            urb_zone_type_id(i) = urb_type_injection_well
+         case default
+            write(logstr,'(a,a,a,a,a)')' Error ! Unknown type "', trim(type_str), &
+                 '" in urban_drainage_zone "', trim(urb_zone_name(i)), &
+                 '" (expected "piped_drainage" or "injection_well")'
+            call write_log(logstr, 1)
+            ierr = 1
+            return
+         end select
+         !
+         if (allocated(poly_str)) deallocate(poly_str)
+         call get_value(tbl_zone, 'polygon_file', poly_str, stat=stat)
+         if (.not. allocated(poly_str)) then
+            write(logstr,'(a,a,a)')' Error ! Missing required "polygon_file" in urban_drainage_zone "', &
+                 trim(urb_zone_name(i)), '"'
+            call write_log(logstr, 1)
+            ierr = 1
+            return
+         endif
+         urb_zone_polygon_file(i) = poly_str
+         !
+         ! h_threshold is common to both types.
+         !
+         call get_value(tbl_zone, 'h_threshold', r8_tmp, stat=stat)
+         if (stat == 0) urb_zone_h_threshold(i) = real(r8_tmp, 4)
+         !
+         ! Type-specific fields.
+         !
+         if (urb_zone_type_id(i) == urb_type_piped_drainage) then
+            !
+            block
+               type(toml_array), pointer :: arr_outfall
+               integer                   :: n_out, stat_arr
+               !
+               nullify(arr_outfall)
+               call get_value(tbl_zone, 'outfall', arr_outfall, requested=.false., stat=stat_arr)
+               !
+               if (associated(arr_outfall)) then
+                  !
+                  n_out = len(arr_outfall)
+                  !
+                  if (n_out /= 2) then
+                     write(logstr,'(a,a,a,i0,a)')' Error ! urban_drainage_zone "', trim(urb_zone_name(i)), &
+                          '" key "outfall" must have exactly 2 elements (got ', n_out, ')'
+                     call write_log(logstr, 1)
+                     ierr = 1
+                     return
+                  endif
+                  !
+                  call get_value(arr_outfall, 1, r8_tmp, stat=stat_arr)
+                  urb_zone_outfall_x(i) = real(r8_tmp, 4)
+                  !
+                  call get_value(arr_outfall, 2, r8_tmp, stat=stat_arr)
+                  urb_zone_outfall_y(i) = real(r8_tmp, 4)
+                  !
+               endif
+               !
+            end block
+            !
+            ! Exactly one of design_precip / max_outfall_rate must be given.
+            ! has_key distinguishes "absent" from "present but 0.0".
+            !
+            block
+               logical :: has_precip, has_rate
+               has_precip = tbl_zone%has_key('design_precip')
+               has_rate   = tbl_zone%has_key('max_outfall_rate')
+               if (has_precip .and. has_rate) then
+                  write(logstr,'(a,a,a)')' Error ! urban_drainage_zone "', trim(urb_zone_name(i)), &
+                       '" has both "design_precip" and "max_outfall_rate"; specify only one'
+                  call write_log(logstr, 1)
+                  ierr = 1
+                  return
+               endif
+               if (.not. has_precip .and. .not. has_rate) then
+                  write(logstr,'(a,a,a)')' Error ! piped_drainage zone "', trim(urb_zone_name(i)), &
+                       '" needs "design_precip" (mm/hr) or "max_outfall_rate" (m3/s)'
+                  call write_log(logstr, 1)
+                  ierr = 1
+                  return
+               endif
+               if (has_precip) then
+                  call get_value(tbl_zone, 'design_precip', r8_tmp, stat=stat)
+                  urb_zone_design_precip(i) = real(r8_tmp, 4)
+               else
+                  call get_value(tbl_zone, 'max_outfall_rate', r8_tmp, stat=stat)
+                  urb_zone_max_outfall_rate(i) = real(r8_tmp, 4)
+               endif
+            end block
+            !
+            call get_value(tbl_zone, 'dh_design_min', r8_tmp, stat=stat)
+            if (stat == 0) urb_zone_dh_design_min(i) = real(r8_tmp, 4)
+            if (urb_zone_dh_design_min(i) <= 0.0) urb_zone_dh_design_min(i) = 0.1
+            !
+            call get_value(tbl_zone, 'include_outfall', l_tmp, stat=stat)
+            if (stat == 0) urb_zone_include_outfall(i) = l_tmp
+            !
+            call get_value(tbl_zone, 'check_valve', l_tmp, stat=stat)
+            if (stat == 0) urb_zone_check_valve(i) = l_tmp
+            !
+            ! Minimal sanity check on outfall: if include_outfall is true,
+            ! outfall coords should be specified (warn only; snap will
+            ! catch bad values).
+            !
+            if (urb_zone_include_outfall(i)) then
+               found = (urb_zone_outfall_x(i) /= 0.0 .or. urb_zone_outfall_y(i) /= 0.0)
+               if (.not. found) then
+                  write(logstr,'(a,a,a)')' Warning : piped_drainage zone "', trim(urb_zone_name(i)), &
+                       '" has include_outfall = true but outfall = [0.0, 0.0]'
+                  call write_log(logstr, 0)
+               endif
+            endif
+            !
+         elseif (urb_zone_type_id(i) == urb_type_injection_well) then
+            !
+            if (.not. tbl_zone%has_key('injection_rate')) then
+               write(logstr,'(a,a,a)')' Error ! injection_well zone "', trim(urb_zone_name(i)), &
+                    '" needs "injection_rate" (m3/s)'
+               call write_log(logstr, 1)
+               ierr = 1
+               return
+            endif
+            call get_value(tbl_zone, 'injection_rate', r8_tmp, stat=stat)
+            urb_zone_injection_rate(i) = real(r8_tmp, 4)
+            !
+            if (.not. tbl_zone%has_key('maximum_capacity')) then
+               write(logstr,'(a,a,a)')' Error ! injection_well zone "', trim(urb_zone_name(i)), &
+                    '" needs "maximum_capacity" (m3)'
+               call write_log(logstr, 1)
+               ierr = 1
+               return
+            endif
+            call get_value(tbl_zone, 'maximum_capacity', r8_tmp, stat=stat)
+            urb_zone_maximum_capacity(i) = real(r8_tmp, 4)
+            !
+            ! injection_well has no outfall or check valve.
+            !
+            urb_zone_include_outfall(i) = .false.
+            urb_zone_check_valve(i)     = .false.
+            !
+         endif
+         !
+      enddo
+      !
+   end subroutine
+   !
+end module sfincs_urban_drainage

--- a/source/src/sfincs_wavemaker.f90
+++ b/source/src/sfincs_wavemaker.f90
@@ -1618,7 +1618,7 @@
       !
    endif
    !
-   ! UV fluxes at wave makers
+   ! UV fluxes at wave makers - No OMP acceleration here?
    !
    ! Push time-interpolated forcing values to GPU before parallel region
    !

--- a/source/src/snapwave/snapwave_solver.f90
+++ b/source/src/snapwave/snapwave_solver.f90
@@ -788,13 +788,28 @@ contains
             !
          enddo
          !
-         A(1) = - ctheta(ntheta, k) * oneover2dtheta
-         B(1) = oneoverdt + cg(k) / ds(1, k) + DoverE(k)
-         C(1) = ctheta(2, k) * oneover2dtheta
+         ! Directional edge BCs: first-order upwind, open at the grid ends, 
+         ! same upwind scheme as the IG (ee_ig) and action (aa) balances
          !
-         A(ntheta) = -ctheta(ntheta - 1, k) * oneover2dtheta
-         B(ntheta) =  oneoverdt + cg(k) / ds(ntheta, k) + DoverE(k)
-         C(ntheta) =  ctheta(1, k) * oneover2dtheta
+         if (ctheta(1, k) < 0.0) then
+            A(1) = 0.0
+            B(1) = oneoverdt - ctheta(1, k) / dtheta + cg(k) / ds(1, k) + DoverE(k)
+            C(1) = ctheta(2, k) / dtheta
+         else
+            A(1) = 0.0
+            B(1) = oneoverdt + cg(k) / ds(1, k) + DoverE(k)
+            C(1) = 0.0
+         endif
+         !
+         if (ctheta(ntheta, k) > 0.0) then
+            A(ntheta) = -ctheta(ntheta - 1, k) / dtheta
+            B(ntheta) =  oneoverdt + ctheta(ntheta, k) / dtheta + cg(k) / ds(ntheta, k) + DoverE(k)
+            C(ntheta) =  0.0
+         else
+            A(ntheta) = 0.0
+            B(ntheta) = oneoverdt + cg(k) / ds(ntheta, k) + DoverE(k)
+            C(ntheta) = 0.0
+         endif
          !
          if (wind) R(:) = R(:) + WsorE(:, k)
          !

--- a/source/src/utils/sfincs_polygons.f90
+++ b/source/src/utils/sfincs_polygons.f90
@@ -1,0 +1,233 @@
+module sfincs_polygons
+   !
+   ! Minimal polygon helper module for SFINCS.
+   !
+   ! Provides:
+   !   t_polygon               Derived type: one named polygon with vertex arrays.
+   !   read_tek_polygons       Read a Delft3D "tek" polyline/polygon file
+   !                           (name line + "nrows ncols" + rows of x y) and
+   !                           return an array of t_polygon, each closed so
+   !                           that the last vertex equals the first. Called
+   !                           from initialize_urban_drainage (sfincs_urban_drainage).
+   !   point_in_polygon        Scalar ray-casting test for a single point.
+   !                           Called from points_in_polygon_omp.
+   !   points_in_polygon_omp   OMP-parallel sweep of a point array against one
+   !                           polygon, writing a logical mask. Called from
+   !                           initialize_urban_drainage (sfincs_urban_drainage).
+   !
+   use sfincs_log
+   use sfincs_error
+   !
+   implicit none
+   !
+   private
+   public :: t_polygon, read_tek_polygons, point_in_polygon, points_in_polygon_omp
+   !
+   type :: t_polygon
+      character(len=64)                  :: name = ''
+      integer                            :: n = 0
+      real*4, dimension(:), allocatable  :: x
+      real*4, dimension(:), allocatable  :: y
+   end type t_polygon
+   !
+contains
+   !
+   subroutine read_tek_polygons(filename, polygons, ierr)
+      !
+      ! Read a Delft3D "tek" polyline file into an array of t_polygon.
+      !
+      ! File format (one or more blocks):
+      !    <name line>
+      !    <nrows> <ncols>
+      !    <x_1> <y_1>
+      !    ...
+      !    <x_nrows> <y_nrows>
+      !
+      ! The file is swept twice: first to count blocks, then to read them.
+      ! Each polygon is auto-closed: if the last vertex is not equal to the
+      ! first, a copy of the first vertex is appended so downstream
+      ! point-in-polygon tests can treat the last-to-first edge uniformly.
+      !
+      ! Called from: initialize_urban_drainage (sfincs_urban_drainage).
+      !
+      implicit none
+      !
+      character(len=*),               intent(in)  :: filename
+      type(t_polygon), allocatable,   intent(out) :: polygons(:)
+      integer,                        intent(out) :: ierr
+      !
+      integer            :: unit, stat, npoly, nrows, ncols, irow, ipoly
+      character(len=256) :: name_line
+      real*4             :: dummy
+      logical            :: ok
+      !
+      ierr = 0
+      !
+      ok = check_file_exists(filename, 'Urban drainage polygon file', .true.)
+      !
+      ! First pass: count polygons.
+      !
+      unit = 501
+      open(unit, file=trim(filename), status='old', action='read', iostat=stat)
+      if (stat /= 0) then
+         write(logstr,'(a,a)')' Error ! Could not open polygon file ', trim(filename)
+         call write_log(logstr, 1)
+         ierr = 1
+         return
+      endif
+      !
+      npoly = 0
+      do
+         read(unit, '(a)', iostat=stat) name_line
+         if (stat /= 0) exit
+         if (len_trim(name_line) == 0) cycle
+         read(unit, *, iostat=stat) nrows, ncols
+         if (stat /= 0) exit
+         npoly = npoly + 1
+         do irow = 1, nrows
+            read(unit, *, iostat=stat) dummy
+            if (stat /= 0) exit
+         enddo
+      enddo
+      rewind(unit)
+      !
+      if (npoly == 0) then
+         close(unit)
+         allocate(polygons(0))
+         return
+      endif
+      !
+      allocate(polygons(npoly))
+      !
+      ! Second pass: read each polygon.
+      !
+      do ipoly = 1, npoly
+         !
+         read(unit, '(a)', iostat=stat) name_line
+         if (stat /= 0) exit
+         do while (len_trim(name_line) == 0)
+            read(unit, '(a)', iostat=stat) name_line
+            if (stat /= 0) exit
+         enddo
+         !
+         read(unit, *, iostat=stat) nrows, ncols
+         if (stat /= 0) then
+            write(logstr,'(a,i0,a,a)')' Error ! Missing shape line for polygon ', ipoly, &
+                 ' in ', trim(filename)
+            call write_log(logstr, 1)
+            ierr = 1
+            close(unit)
+            return
+         endif
+         !
+         ! Reserve one extra slot so we can auto-close the ring if needed.
+         !
+         allocate(polygons(ipoly)%x(nrows + 1))
+         allocate(polygons(ipoly)%y(nrows + 1))
+         polygons(ipoly)%name = trim(adjustl(name_line))
+         !
+         do irow = 1, nrows
+            read(unit, *, iostat=stat) polygons(ipoly)%x(irow), polygons(ipoly)%y(irow)
+            if (stat /= 0) then
+               write(logstr,'(a,i0,a,i0,a,a)')' Error ! Failed reading vertex ', irow, &
+                    ' of polygon ', ipoly, ' in ', trim(filename)
+               call write_log(logstr, 1)
+               ierr = 1
+               close(unit)
+               return
+            endif
+         enddo
+         !
+         ! Close the ring if the user omitted it.
+         !
+         if (polygons(ipoly)%x(nrows) /= polygons(ipoly)%x(1) .or. &
+             polygons(ipoly)%y(nrows) /= polygons(ipoly)%y(1)) then
+            polygons(ipoly)%x(nrows + 1) = polygons(ipoly)%x(1)
+            polygons(ipoly)%y(nrows + 1) = polygons(ipoly)%y(1)
+            polygons(ipoly)%n = nrows + 1
+         else
+            polygons(ipoly)%n = nrows
+         endif
+         !
+      enddo
+      !
+      close(unit)
+      !
+   end subroutine
+   !
+   !-----------------------------------------------------------------------------------------------------!
+   !
+   pure function point_in_polygon(xp, yp, xv, yv, nv) result(inside)
+      !
+      ! Classic even-odd ray-casting point-in-polygon test.
+      !
+      ! Returns .true. if (xp, yp) lies inside the closed polygon defined by
+      ! the first nv vertices of (xv, yv). The polygon is assumed closed by
+      ! the caller (last vertex == first vertex).
+      !
+      ! Called from: points_in_polygon_omp (this module).
+      !
+      implicit none
+      !
+      real*4, intent(in)              :: xp, yp
+      integer, intent(in)             :: nv
+      real*4, intent(in)              :: xv(nv), yv(nv)
+      logical                         :: inside
+      !
+      integer :: i, j
+      !
+      inside = .false.
+      j = nv - 1
+      if (j < 1) j = nv
+      do i = 1, nv
+         if (((yv(i) > yp) .neqv. (yv(j) > yp)) .and. &
+             (xp < (xv(j) - xv(i)) * (yp - yv(i)) / (yv(j) - yv(i) + tiny(1.0)) + xv(i))) then
+            inside = .not. inside
+         endif
+         j = i
+      enddo
+      !
+   end function
+   !
+   !-----------------------------------------------------------------------------------------------------!
+   !
+   subroutine points_in_polygon_omp(xp, yp, np_pts, poly, inside)
+      !
+      ! OMP-parallel sweep of an (xp, yp) point array against a single polygon.
+      ! inside(:) must be allocated by the caller with size np_pts. Points
+      ! already flagged .true. on entry are preserved (so the caller can
+      ! accumulate hits across multiple polygons if desired); this routine
+      ! only flips .false. to .true..
+      !
+      ! Called from: initialize_urban_drainage (sfincs_urban_drainage).
+      !
+      implicit none
+      !
+      integer,        intent(in)    :: np_pts
+      real*4,         intent(in)    :: xp(np_pts), yp(np_pts)
+      type(t_polygon), intent(in)   :: poly
+      logical,        intent(inout) :: inside(np_pts)
+      !
+      integer :: i
+      real*4  :: xmin, xmax, ymin, ymax
+      !
+      if (poly%n < 3) return
+      !
+      xmin = minval(poly%x(1:poly%n))
+      xmax = maxval(poly%x(1:poly%n))
+      ymin = minval(poly%y(1:poly%n))
+      ymax = maxval(poly%y(1:poly%n))
+      !
+      !$omp parallel do default(shared) private(i) schedule(static)
+      do i = 1, np_pts
+         if (inside(i)) cycle
+         if (xp(i) < xmin .or. xp(i) > xmax .or. yp(i) < ymin .or. yp(i) > ymax) cycle
+         if (point_in_polygon(xp(i), yp(i), poly%x, poly%y, poly%n)) then
+            inside(i) = .true.
+         endif
+      enddo
+      !$omp end parallel do
+      !
+   end subroutine
+   !
+end module sfincs_polygons

--- a/source/third_party_open/netcdf/netcdf-fortran-4.6.1/netcdff_c.vcxproj
+++ b/source/third_party_open/netcdf/netcdf-fortran-4.6.1/netcdff_c.vcxproj
@@ -25,12 +25,12 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">


### PR DESCRIPTION
This pull request significantly updates the SFINCS documentation to introduce and explain the new urban drainage feature, modernizes infiltration and drainage input methods, and clarifies recommended practices for input files. The changes add a comprehensive user guide for urban drainage, update infiltration method documentation to prefer NetCDF-based inputs, deprecate legacy binary input keywords, and introduce new parameters for urban drainage output.

**Urban drainage feature:**

* Added a new documentation page `docs/input_urban_drainage.rst` detailing the urban drainage model, including configuration, input file formats, parameter descriptions, and output variables. This includes both piped drainage and injection well abstractions, with TOML-based configuration and polygon zone assignment.
* Updated the main documentation index (`docs/index.rst`) to include the new `input_urban_drainage` documentation section.

**Infiltration and drainage input modernization:**

* Updated `docs/input.rst` to recommend NetCDF-based `infiltrationfile` and `infiltrationtype` for all modern infiltration and bucket model inputs, with detailed variable requirements for each method. Legacy binary keywords (e.g., `qinffile`, `scsfile`, `bucketfile`, etc.) are now marked as deprecated and for backward compatibility only. [[1]](diffhunk://#diff-f950d732d5f0d433c5c2f984319c3cd932a27478545412d2515162e880d7b779R362-R392) [[2]](diffhunk://#diff-f950d732d5f0d433c5c2f984319c3cd932a27478545412d2515162e880d7b779L386-R409) [[3]](diffhunk://#diff-f950d732d5f0d433c5c2f984319c3cd932a27478545412d2515162e880d7b779L429-R452) [[4]](diffhunk://#diff-f950d732d5f0d433c5c2f984319c3cd932a27478545412d2515162e880d7b779L461-R484) [[5]](diffhunk://#diff-f950d732d5f0d433c5c2f984319c3cd932a27478545412d2515162e880d7b779L501-R524) [[6]](diffhunk://#diff-f950d732d5f0d433c5c2f984319c3cd932a27478545412d2515162e880d7b779L525-R548) [[7]](diffhunk://#diff-f950d732d5f0d433c5c2f984319c3cd932a27478545412d2515162e880d7b779R559-R589)
* Added dedicated sections for the bucket model and drainage mimic, clarifying their configuration and input requirements. The bucket model now requires all variables to be present in `infiltrationfile`, and the legacy `bucketfile` and `bucket_loss_frac` inputs are no longer supported; for drainage, only the `drainagefile` input is now supported.

**Parameter documentation:**

* Added two new parameters, `store_urban_drainage_discharge` and `store_cumulative_urban_drainage`, to `docs/parameters.rst`, describing their purpose and usage for urban drainage output.

**General documentation improvements:**

* Updated section headings and improved clarity in `docs/input.rst` to reflect the new recommended practices and to organize information more clearly.