### PR TITLE
Fix culvert discharge chatter, make drain volume transfer mass-exact, limit withdrawal per step

### DIFF
--- a/source/src/sfincs_continuity.f90
+++ b/source/src/sfincs_continuity.f90
@@ -315,9 +315,8 @@ contains
          !
          nm = nmindsrc(isrc)
          !
-         if ((z_volume(nm) >= 0) .or. ((qtsrc(isrc)<0.0) .and. (z_volume(nm) >= 0))) then
-            z_volume(nm) = z_volume(nm) + qtsrc(isrc) * dt
-         endif
+         ! Apply the source/drain volume change and floor at zero
+         z_volume(nm) = max(z_volume(nm) + qtsrc(isrc) * dt, 0.0)
          !
       enddo
       !$acc end serial

--- a/source/src/sfincs_continuity.f90
+++ b/source/src/sfincs_continuity.f90
@@ -54,6 +54,8 @@ contains
    !
    integer          :: nm
    integer          :: isrc
+   integer          :: idrn, jin, jout, nmin, nmout
+   real*4           :: dv, dva, zold, a, ain, aout
    !
    integer          :: iwm
    !
@@ -67,7 +69,7 @@ contains
    real*4           :: qnum
    real*4           :: qndm
    real*4           :: factime
-   real*4           :: dvol    
+   real*4           :: dvol
    !
    if (snapwave) then ! need to compute filtered water levels for snapwave
       !
@@ -85,24 +87,72 @@ contains
    ! First discharges (don't do this parallel, as it's probably not worth it)
    !
    if (nsrcdrn > 0) then
-      ! 
-      !$acc loop
-      do isrc = 1, nsrcdrn
-         ! 
+      !
+      ! Plain point sources: apply the volume change and floor at the bed
+      !
+      !$acc loop seq
+      do isrc = 1, nsrc
+         !
          nm = nmindsrc(isrc)
-         ! 
+         !
          if (crsgeo) then
-            ! 
-            zs(nmindsrc(isrc)) = max(zs(nm) + qtsrc(isrc) * dt / cell_area_m2(nm), zb(nm))
-            ! 
+            a = cell_area_m2(nm)
          else
-            ! 
-            zs(nmindsrc(isrc)) = max(zs(nm) + qtsrc(isrc) * dt / cell_area(z_flags_iref(nm)), zb(nm))
-            ! 
+            a = cell_area(z_flags_iref(nm))
          endif
-         ! 
+         !
+         dv = qtsrc(isrc) * dt
+         if (dv < 0.0) then
+            srcdrn_vol_withdrawn = srcdrn_vol_withdrawn - dv
+            srcdrn_vol_shortfall = srcdrn_vol_shortfall + max(-((zs(nm) - zb(nm)) * a + dv), 0.0)
+         endif
+         !
+         zs(nm) = max(zs(nm) + dv / a, zb(nm))
+         !
       enddo
-      ! 
+      !
+      ! Drainage structures: the donor cell is floored at the bed and the receiving cell
+      ! gets exactly the volume that was actually removed, so the pair conserves mass.
+      !
+      !$acc loop seq
+      do idrn = 1, ndrn
+         !
+         jin   = nsrc + idrn * 2 - 1
+         jout  = nsrc + idrn * 2
+         nmin  = nmindsrc(jin)
+         nmout = nmindsrc(jout)
+         !
+         if (nmin > 0 .and. nmout > 0) then
+            !
+            if (crsgeo) then
+               ain  = cell_area_m2(nmin)
+               aout = cell_area_m2(nmout)
+            else
+               ain  = cell_area(z_flags_iref(nmin))
+               aout = cell_area(z_flags_iref(nmout))
+            endif
+            !
+            dv = qtsrc(jout) * dt          ! volume moved from intake to outfall this step (negative = reverse flow)
+            !
+            if (dv >= 0.0) then
+               zold      = zs(nmin)
+               zs(nmin)  = max(zold - dv / ain, zb(nmin))
+               dva       = max((zold - zs(nmin)) * ain, 0.0)
+               zs(nmout) = zs(nmout) + dva / aout
+            else
+               zold      = zs(nmout)
+               zs(nmout) = max(zold + dv / aout, zb(nmout))
+               dva       = max((zold - zs(nmout)) * aout, 0.0)
+               zs(nmin)  = zs(nmin) + dva / ain
+            endif
+            !
+            srcdrn_vol_withdrawn = srcdrn_vol_withdrawn + abs(dv)
+            srcdrn_vol_shortfall = srcdrn_vol_shortfall + (abs(dv) - dva)
+            !
+         endif
+         !
+      enddo
+      !
    endif
    !
    !$omp parallel &
@@ -273,6 +323,8 @@ contains
    !
    integer          :: nm
    integer          :: isrc
+   integer          :: idrn, jin, jout, nmin, nmout
+   real*4           :: dva, zold
    !
    integer          :: iwm
    integer          :: ind
@@ -311,12 +363,52 @@ contains
    if (nsrcdrn > 0) then
       !
       !$acc serial present( z_volume, nmindsrc, qtsrc )
-      do isrc = 1, nsrcdrn
+      !
+      ! Plain point sources: apply the volume change and floor at zero
+      !
+      do isrc = 1, nsrc
          !
          nm = nmindsrc(isrc)
          !
-         ! Apply the source/drain volume change and floor at zero
-         z_volume(nm) = max(z_volume(nm) + qtsrc(isrc) * dt, 0.0)
+         dv = qtsrc(isrc) * dt
+         if (dv < 0.0) then
+            srcdrn_vol_withdrawn = srcdrn_vol_withdrawn - dv
+            srcdrn_vol_shortfall = srcdrn_vol_shortfall + (max(z_volume(nm) + dv, 0.0) - (z_volume(nm) + dv))
+         endif
+         z_volume(nm) = max(z_volume(nm) + dv, 0.0)
+         !
+      enddo
+      !
+      ! Drainage structures: the donor cell is floored at zero and the receiving cell
+      ! gets exactly the volume that was actually removed, so the pair conserves mass.
+      !
+      do idrn = 1, ndrn
+         !
+         jin   = nsrc + idrn * 2 - 1
+         jout  = nsrc + idrn * 2
+         nmin  = nmindsrc(jin)
+         nmout = nmindsrc(jout)
+         !
+         if (nmin > 0 .and. nmout > 0) then
+            !
+            dv = qtsrc(jout) * dt          ! volume moved from intake to outfall this step (negative = reverse flow)
+            !
+            if (dv >= 0.0) then
+               zold           = z_volume(nmin)
+               z_volume(nmin) = max(zold - dv, 0.0)
+               dva            = max(zold - z_volume(nmin), 0.0)
+               z_volume(nmout) = max(z_volume(nmout) + dva, 0.0)
+            else
+               zold            = z_volume(nmout)
+               z_volume(nmout) = max(zold + dv, 0.0)
+               dva             = max(zold - z_volume(nmout), 0.0)
+               z_volume(nmin)  = max(z_volume(nmin) + dva, 0.0)
+            endif
+            !
+            srcdrn_vol_withdrawn = srcdrn_vol_withdrawn + abs(dv)
+            srcdrn_vol_shortfall = srcdrn_vol_shortfall + (abs(dv) - dva)
+            !
+         endif
          !
       enddo
       !$acc end serial

--- a/source/src/sfincs_data.f90
+++ b/source/src/sfincs_data.f90
@@ -802,6 +802,8 @@ module sfincs_data
       real*4, dimension(:),     allocatable :: drainage_distance
       integer*1, dimension(:),  allocatable :: drainage_status
       real*4, dimension(:),     allocatable :: drainage_fraction_open
+      real*8                                :: srcdrn_vol_withdrawn   ! volume nominally withdrawn by drains/negative sources (m3)
+      real*8                                :: srcdrn_vol_shortfall   ! part of that not actually moved because the donor cell ran dry (m3)
       real*4, dimension(:),     allocatable :: xsrc
       real*4, dimension(:),     allocatable :: ysrc
       !!!

--- a/source/src/sfincs_data.f90
+++ b/source/src/sfincs_data.f90
@@ -89,6 +89,7 @@ module sfincs_data
       real*4 horton_kr_kd
       real*4 btrelax
       real*4 structure_relax
+      real*4 drainage_volfrac   ! max fraction of the donor cell volume a drain may remove per time step (0-1)
       real*4 wiggle_factor
       real*4 wiggle_threshold
       real*4 uvlim

--- a/source/src/sfincs_discharges.f90
+++ b/source/src/sfincs_discharges.f90
@@ -619,13 +619,7 @@ contains
                   !                  
             end select
             !
-            ! Add some relaxation
-            ! structure_relax in seconds => gives ratio between new and old discharge (default 10s)
-            !   
-            qq = 1.0 / (structure_relax / dt) * qq + (1.0 - (1.0 / (structure_relax / dt))) * -qtsrc(jin)
-            !   
-            ! Limit discharge based on available volume in cell (regular or subgrid)
-            !    
+            ! Limit discharge based on available volume in cell (regular or subgrid).
             if (subgrid) then
                !
                if (qq > 0.0) then
@@ -643,8 +637,11 @@ contains
                endif
                !
             endif
-            !      
-            qtsrc(jin)  = -qq 
+            !
+            ! Add some relaxation (applied LAST, so the applied discharge is a smooth low-pass).
+            qq = 1.0 / (structure_relax / dt) * qq + (1.0 - (1.0 / (structure_relax / dt))) * -qtsrc(jin)
+            !
+            qtsrc(jin)  = -qq
             qtsrc(jout) = qq
             !
          endif

--- a/source/src/sfincs_discharges.f90
+++ b/source/src/sfincs_discharges.f90
@@ -370,7 +370,7 @@ contains
    !
    if (ndrn > 0) then
       !
-      !$acc serial, present( z_volume, zs, zb, nmindsrc, qtsrc, drainage_type, drainage_params )
+      !$acc serial, present( z_volume, zs, zb, nmindsrc, qtsrc, drainage_type, drainage_params ) copyin( drainage_volfrac )
       do idrn = 1, ndrn
          !
          jin  = nsrc + idrn * 2 - 1
@@ -619,21 +619,23 @@ contains
                   !                  
             end select
             !
-            ! Limit discharge based on available volume in cell (regular or subgrid).
+            ! Limit discharge to a fraction of the available volume in the donor cell (regular or subgrid).
+            ! With drainage_volfrac < 1 the cell volume decays geometrically instead of hitting zero,
+            ! so the limited discharge converges smoothly to the inflow instead of switching on and off.
             if (subgrid) then
                !
                if (qq > 0.0) then
-                  qq = min(qq, max(z_volume(nmin), 0.0) / dt)
+                  qq = min(qq, drainage_volfrac * max(z_volume(nmin), 0.0) / dt)
                else
-                  qq = max(qq, -max(z_volume(nmout), 0.0) / dt)
+                  qq = max(qq, -drainage_volfrac * max(z_volume(nmout), 0.0) / dt)
                endif
                !
             else
                !
                if (qq > 0.0) then
-                  qq = min(qq, max((zs(nmin) - zb(nmin)) * cell_area(z_flags_iref(nmin)), 0.0) / dt)
+                  qq = min(qq, drainage_volfrac * max((zs(nmin) - zb(nmin)) * cell_area(z_flags_iref(nmin)), 0.0) / dt)
                else
-                  qq = max(qq, -max((zs(nmout) - zb(nmout)) * cell_area(z_flags_iref(nmout)), 0.0) / dt)
+                  qq = max(qq, -drainage_volfrac * max((zs(nmout) - zb(nmout)) * cell_area(z_flags_iref(nmout)), 0.0) / dt)
                endif
                !
             endif

--- a/source/src/sfincs_input.f90
+++ b/source/src/sfincs_input.f90
@@ -189,6 +189,8 @@ contains
    call read_real_input(500,'btrelax',btrelax,3600.0)
    call read_logical_input(500,'wiggle_suppression', wiggle_suppression, .true.)
    call read_real_input(500,'structure_relax',structure_relax,10.0)
+   call read_real_input(500,'drainage_volfrac',drainage_volfrac,0.5)
+   drainage_volfrac = min(max(drainage_volfrac, 0.05), 1.0)
    call read_real_input(500,'wiggle_factor',wiggle_factor,0.1)
    call read_real_input(500,'wiggle_threshold',wiggle_threshold,0.1)
    call read_real_input(500, 'uvlim', uvlim, 10.0)

--- a/source/src/sfincs_lib.f90
+++ b/source/src/sfincs_lib.f90
@@ -281,6 +281,8 @@ module sfincs_lib
    dt          = 1.0e-6 ! First time step very small
    min_dt      = 1.0e-6 ! First time step very small
    dtavg       = 0.0    ! average time step
+   srcdrn_vol_withdrawn = 0.0d0
+   srcdrn_vol_shortfall = 0.0d0
    maxdepth    = 999.0  ! maximum depth over time step
    maxmaxdepth = 0.0    ! maximum depth over entire simulation
    nt          = 0      ! number of time steps
@@ -773,6 +775,12 @@ module sfincs_lib
    !
    write(logstr,'(a,20f10.3)')           ' Average time step (s)  : ', dtavg
    call write_log(logstr, 1)
+   !
+   if (nsrcdrn > 0 .and. srcdrn_vol_withdrawn > 0.0d0) then
+      write(logstr,'(a,f14.1,a,f12.1,a,f7.3,a)') ' Drain/source withdrawal: ', srcdrn_vol_withdrawn, ' m3, not removed (dry cell): ', &
+                                                  srcdrn_vol_shortfall, ' m3 (', 100.0d0 * srcdrn_vol_shortfall / srcdrn_vol_withdrawn, '%)'
+      call write_log(logstr, 1)
+   endif
    !
    call write_log('', 1)
    !


### PR DESCRIPTION
Fix culvert discharge chatter, make drain volume transfer mass-exact, limit withdrawal per step

Tim reported wiggles in the culvert discharges when running the refreshed testbed after the Galibier release. In the Newark drainage model, the discharge on volume-limited culverts (drains 108 and 15) oscillates full-amplitude (0 to -16 m3/s) across the whole event, while drains that are not volume-limited (e.g. 10, 100) stay smooth. Bisected across the release archive: v2.2.0 is smooth, v2.3.0 (#211, moving gates) swapped the order of the volume clamp and the relaxation in the shared drainage tail, so the on/off clamp output is applied directly and fed back as the relaxation memory.

**Changes**

1. `sfincs_discharges.f90`: clamp first, relax last, so the applied discharge is a smooth low-pass again (restores the v2.0-v2.2 order).
2. `sfincs_continuity.f90`: drainage structures are applied as pairs. The donor cell is floored at zero volume (subgrid) or at the bed (regular), and the receiving cell gets exactly the volume that was actually removed. v2.2 delivered the full discharge to the outfall even when the intake had run dry.
3. `sfincs_discharges.f90`: the volume limit is now a fraction of the donor cell volume per step, new keyword `drainage_volfrac` (default 0.5, range 0.05-1, `1` recovers the old hard limit). With the hard limit `q <= V/dt` a volume-limited culvert emptied its cell in one step and the limited discharge switched between zero and full demand; with a fraction the cell volume decays geometrically and the discharge converges smoothly to the inflow.
4. `sfincs_continuity.f90`: plain point sources are applied and floored (previously silently dropped when the cell volume was negative).
5. New end-of-run log line: `Drain/source withdrawal: X m3, not removed (dry cell): Y m3 (Z%)`, the volume drains nominally withdrew and the part the dry donor never gave up.

**Newark testbed, 8 h event** (nTV = total variation / 2 range, about 1 for smooth, about 40 for chatter; reversals = direction changes > 5 % of range; jump = largest step change / range)

| variant | drain 108 nTV / rev. / jump | drain 15 | drain 100 | water created | not delivered |
|---|---|---|---|---|---|
| main v2.4.1 | 41.3 / 187 / - | 39.2 / 130 / - | 4.2 / 0 / - | 4,570 m3 (0.16 %) | - |
| clamp-then-relax only (first push of this PR) | 0.87 / 0 / 0.01 | 0.70 / 0 / 0.01 | 3.9 / 0 / 0.02 | 66,392 m3 (2.20 %) | - |
| relax unclamped, clamp last (review suggestion) | 1.09 / 0, spikes | 1.18 / 0, spikes | 6.98 / 11 | 75,541 m3 (2.50 %) | - |
| pair delivery, `drainage_volfrac = 1` | 0.87 / 0 / 0.01 | 1.20 / 0 / 0.02 | 4.2 / 0 / 0.03 | 0 | 3.56 % |
| **this PR: pair delivery, `drainage_volfrac = 0.5`** | 0.89 / 0 / 0.01 | 0.87 / 0 / 0.01 | 4.2 / 0 / 0.02 | 0 | 0.31 % |
| pair delivery, `drainage_volfrac = 0.25` | 0.90 / 0 / 0.01 | 0.90 / 0 / 0.01 | 4.0 / 0 / 0.02 | 0 | 0.002 % |

`drainage_volfrac = 0.5` also removes the sharp dip and the deep late peak that `= 1` still shows on drain 15. Flood map: zsmax at 0.5 is within 8 mm of the value at 1 in every cell; at 0.25 the limiter starts to throttle (11 cells change by more than 5 cm, up to 0.31 m), which is why 0.5 is the default.

At the SFINCS default `structure_relax = 10` (Newark sets 600) the volume-limited drains stay fixed (drain 108 nTV 33 on main, 1.8 here; drain 15 15 on main, 1.3 here; undelivered 3.7 % at `drainage_volfrac = 1`, 0.07 % at 0.5). The small control drains 100 and 10 chatter at relax 10 on main and on this branch alike (drain 100 nTV 66 vs 64, about 570 reversals in both), so that is a separate, pre-existing weakness of the 10 s default against a 1.8 s time step and is not addressed here.

**Behaviour change to be aware of.** Because the outfall no longer receives phantom water, zsmax drops by up to 1.1 m in 173 cells around outfalls relative to the first push of this PR, and relative to v2.2 which had the same phantom water. Regular-grid gate case `01_Implementation/controlled_gates_group/controlled_gates`: water levels at the observation points agree to 1 mm with the first push, and the gate intake never dries; the only discharge difference is a phase shift of the +-0.5 m3/s flicker both versions show while the gate sits at near-zero head.
