### PR TITLE
Feat/netcdf status warning

### DIFF
--- a/source/src/sfincs_boundaries.f90
+++ b/source/src/sfincs_boundaries.f90
@@ -190,13 +190,15 @@ contains
    endif
    !
    ! Check for 'weird' values (very low, very high, or NaN).
+   ! Negating the in-range test catches NaN too, which fails every ordered compare.
+   ! (The form  x < -99.0 .or. x > 990.0  is both-false for a NaN and misses it.)
    !
    iok = 1
    !
    do ib = 1, nbnd
       do itb = 1, ntbnd
          !
-         if (zs_bnd(ib, itb) < -99.0 .or. zs_bnd(ib, itb) > 990.0) then
+         if (.not. (zs_bnd(ib, itb) >= -99.0 .and. zs_bnd(ib, itb) <= 990.0)) then
             !
             iok = 0
             !

--- a/source/src/sfincs_boundaries.f90
+++ b/source/src/sfincs_boundaries.f90
@@ -190,25 +190,19 @@ contains
    endif
    !
    ! Check for 'weird' values (very low, very high, or NaN).
-   ! A NaN fails EVERY ordered comparison, so testing the negation of the
-   ! in-range condition catches low, high AND NaN in a single test:
-   !    .not. (x >= -99.0 .and. x <= 990.0)  is .true. for x < -99, x > 990, or NaN.
-   ! (The old form  x < -99.0 .or. x > 990.0  is both-false for a NaN and misses it.)
-   ! This deliberately avoids ieee_arithmetic: its ieee_is_nan pulls a UCRT frexp
-   ! that clashes with Intel's libmmd at link time (LNK2005) in this toolchain.
    !
    iok = 1
    !
    do ib = 1, nbnd
       do itb = 1, ntbnd
          !
-         if (.not. (zs_bnd(ib, itb) >= -99.0 .and. zs_bnd(ib, itb) <= 990.0)) then
+         if (zs_bnd(ib, itb) < -99.0 .or. zs_bnd(ib, itb) > 990.0) then
             !
             iok = 0
             !
          endif
          !
-      enddo
+      enddo 
    enddo
    !
    if (iok == 0) then
@@ -216,9 +210,7 @@ contains
       write(logstr,'(a)')'Warning! Very low, very high or NaN values found in boundary conditions file ! Please check !'
       call write_log(logstr, 1)
       !
-      ! Flag a non-fatal warning. The run continues, but the NetCDF 'status'
-      ! variable will report 2 (completed with warning) instead of 0.
-      !
+      ! Flag a non-fatal warning.
       warning = 1
       !
    endif

--- a/source/src/sfincs_boundaries.f90
+++ b/source/src/sfincs_boundaries.f90
@@ -189,27 +189,38 @@ contains
       !
    endif
    !
-   ! Check for 'weird' values
+   ! Check for 'weird' values (very low, very high, or NaN).
+   ! A NaN fails EVERY ordered comparison, so testing the negation of the
+   ! in-range condition catches low, high AND NaN in a single test:
+   !    .not. (x >= -99.0 .and. x <= 990.0)  is .true. for x < -99, x > 990, or NaN.
+   ! (The old form  x < -99.0 .or. x > 990.0  is both-false for a NaN and misses it.)
+   ! This deliberately avoids ieee_arithmetic: its ieee_is_nan pulls a UCRT frexp
+   ! that clashes with Intel's libmmd at link time (LNK2005) in this toolchain.
    !
    iok = 1
-   ! 
+   !
    do ib = 1, nbnd
       do itb = 1, ntbnd
          !
-         if (zs_bnd(ib, itb) < -99.0 .or. zs_bnd(ib, itb) > 990.0) then
+         if (.not. (zs_bnd(ib, itb) >= -99.0 .and. zs_bnd(ib, itb) <= 990.0)) then
             !
             iok = 0
             !
          endif
          !
-      enddo 
-   enddo    
+      enddo
+   enddo
    !
    if (iok == 0) then
-      ! 
+      !
       write(logstr,'(a)')'Warning! Very low, very high or NaN values found in boundary conditions file ! Please check !'
       call write_log(logstr, 1)
-      ! 
+      !
+      ! Flag a non-fatal warning. The run continues, but the NetCDF 'status'
+      ! variable will report 2 (completed with warning) instead of 0.
+      !
+      warning = 1
+      !
    endif
    !
    ! Now the downstream river boundaries. No time series, just points, slope and direction

--- a/source/src/sfincs_data.f90
+++ b/source/src/sfincs_data.f90
@@ -11,6 +11,9 @@ module sfincs_data
       !!! Error code
       integer :: error
       character*256 :: error_message
+      !!! Non-fatal warning flag (0 = none, 1 = warning). Written to the NetCDF
+      !!! 'status' variable as 2. Does NOT affect the process exit code (ierr).
+      integer :: warning
       !!!
       !!! BMI
       !!!

--- a/source/src/sfincs_lib.f90
+++ b/source/src/sfincs_lib.f90
@@ -89,6 +89,7 @@ module sfincs_lib
    call open_log()   
    !
    error = 0 ! Error code. This is now only set to 1 in case of instabilities. Could also use other error codes, e.g. for missing files.
+   warning = 0 ! Non-fatal warning flag. Written to the NetCDF 'status' variable as 2 (e.g. NaN/out-of-range boundary conditions). Does not affect the exit code.
    !
    ierr = 0 ! Always 0 or 1  ! Always 0 or 1 
    !

--- a/source/src/sfincs_lib.f90
+++ b/source/src/sfincs_lib.f90
@@ -89,8 +89,7 @@ module sfincs_lib
    call open_log()   
    !
    error = 0 ! Error code. This is now only set to 1 in case of instabilities. Could also use other error codes, e.g. for missing files.
-   warning = 0 ! Non-fatal warning flag. Written to the NetCDF 'status' variable as 2 (e.g. NaN/out-of-range boundary conditions). Does not affect the exit code.
-   !
+   warning = 0 ! Non-fatal warning flag. Written to the NetCDF 'status' variable as 2 (e.g. NaN/out-of-range boundary conditions)
    ierr = 0 ! Always 0 or 1  ! Always 0 or 1 
    !
    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

--- a/source/src/sfincs_ncoutput.F90
+++ b/source/src/sfincs_ncoutput.F90
@@ -649,7 +649,7 @@ contains
         's', 'Average model time step (s)')
    !
    call ncdef_float_var(map_file%ncid, 'status', (/map_file%runtime_dimid/), map_file%status_varid, &
-        '-', 'status of SFINCS simulation - 0 is no error')
+        '-', 'status of SFINCS simulation - 0 = no error, 1 = error (simulation stopped, e.g. instability), 2 = completed with warning (e.g. NaN or out-of-range boundary conditions)')
    !
    ! -------------------------------------------------------
    ! Finish definitions
@@ -1052,7 +1052,7 @@ contains
         's', 'Average model time step (s)')
    !
    call ncdef_float_var(his_file%ncid, 'status', (/his_file%runtime_dimid/), his_file%status_varid, &
-        '-', 'status of SFINCS simulation - 0 is no error')
+        '-', 'status of SFINCS simulation - 0 = no error, 1 = error (simulation stopped, e.g. instability), 2 = completed with warning (e.g. NaN or out-of-range boundary conditions)')
    !    
    ! Finish definitions
    NF90(nf90_enddef(his_file%ncid))
@@ -1526,13 +1526,39 @@ contains
    !
    end subroutine ncoutput_update_max
 
-   subroutine ncoutput_map_finalize() 
+   integer function run_status()
+   !
+   ! Combined status code written to the NetCDF 'status' variable:
+   !   0 = no error
+   !   1 = error, simulation stopped (e.g. instability)
+   !   2 = completed with a warning (e.g. NaN / out-of-range boundary conditions)
+   ! A fatal error takes precedence over a warning.
+   !
+   use sfincs_data
+   !
+   implicit none
+   !
+   if (error > 0) then
+      run_status = error
+   elseif (warning > 0) then
+      run_status = 2
+   else
+      run_status = 0
+   endif
+   !
+   end function run_status
+   !
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+   !
+   subroutine ncoutput_map_finalize()
    !
    ! Add total runtime, dtavg to file and close
    !
    use sfincs_data
-   !   
-   implicit none   
+   !
+   implicit none
+   !
+   integer :: status_code
    !
    if (store_tsunami_arrival_time) then
       !
@@ -1546,9 +1572,11 @@ contains
        !
    endif   
    !
+   status_code = run_status()
+   !
    NF90(nf90_put_var(map_file%ncid, map_file%total_runtime_varid, tfinish_all - tstart_all))
    NF90(nf90_put_var(map_file%ncid, map_file%average_dt_varid,  dtavg))
-   NF90(nf90_put_var(map_file%ncid, map_file%status_varid,  error))
+   NF90(nf90_put_var(map_file%ncid, map_file%status_varid,  status_code))
    !
    NF90(nf90_close(map_file%ncid))
    !
@@ -1561,9 +1589,11 @@ contains
    ! Add total runtime, dtavg to file and close
    !
    use sfincs_data
-   !   
-   implicit none   
-   !   
+   !
+   implicit none
+   !
+   integer :: status_code
+   !
    ! Mirror the early-return condition from ncoutput_his_init exactly: if
    ! none of these are present, no his file was created. (Note: thindams
    ! alone do NOT trigger his-file creation in init, so they're not in
@@ -1572,9 +1602,11 @@ contains
       return
    endif
    !
-   NF90(nf90_put_var(his_file%ncid, his_file%total_runtime_varid, tfinish_all - tstart_all)) 
-   NF90(nf90_put_var(his_file%ncid, his_file%average_dt_varid,  dtavg)) 
-   NF90(nf90_put_var(his_file%ncid, his_file%status_varid,  error))       
+   status_code = run_status()
+   !
+   NF90(nf90_put_var(his_file%ncid, his_file%total_runtime_varid, tfinish_all - tstart_all))
+   NF90(nf90_put_var(his_file%ncid, his_file%average_dt_varid,  dtavg))
+   NF90(nf90_put_var(his_file%ncid, his_file%status_varid,  status_code))
    !   
    NF90(nf90_close(his_file%ncid))
    !


### PR DESCRIPTION
Minor new implementations to allow for proper warning and status =2 which means the simulation didnt run as expected